### PR TITLE
fix: bound attacker-controlled BodyLength and CheckSum arithmetic (closes #4)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 license = "MIT"
@@ -26,16 +26,16 @@ categories = ["finance", "data-structures"]
 
 [workspace.dependencies]
 # Internal crates
-ironfix-core = { path = "ironfix-core", version = "0.3.0" }
-ironfix-dictionary = { path = "ironfix-dictionary", version = "0.3.0" }
-ironfix-tagvalue = { path = "ironfix-tagvalue", version = "0.3.0" }
-ironfix-session = { path = "ironfix-session", version = "0.3.0" }
-ironfix-store = { path = "ironfix-store", version = "0.3.0" }
-ironfix-transport = { path = "ironfix-transport", version = "0.3.0" }
-ironfix-fast = { path = "ironfix-fast", version = "0.3.0" }
-ironfix-codegen = { path = "ironfix-codegen", version = "0.3.0" }
-ironfix-derive = { path = "ironfix-derive", version = "0.3.0" }
-ironfix-engine = { path = "ironfix-engine", version = "0.3.0" }
+ironfix-core = { path = "ironfix-core", version = "0.3.1" }
+ironfix-dictionary = { path = "ironfix-dictionary", version = "0.3.1" }
+ironfix-tagvalue = { path = "ironfix-tagvalue", version = "0.3.1" }
+ironfix-session = { path = "ironfix-session", version = "0.3.1" }
+ironfix-store = { path = "ironfix-store", version = "0.3.1" }
+ironfix-transport = { path = "ironfix-transport", version = "0.3.1" }
+ironfix-fast = { path = "ironfix-fast", version = "0.3.1" }
+ironfix-codegen = { path = "ironfix-codegen", version = "0.3.1" }
+ironfix-derive = { path = "ironfix-derive", version = "0.3.1" }
+ironfix-engine = { path = "ironfix-engine", version = "0.3.1" }
 
 # External dependencies
 thiserror = "2.0"

--- a/ironfix-dictionary/src/validator.rs
+++ b/ironfix-dictionary/src/validator.rs
@@ -398,13 +398,34 @@ mod tests {
 
     const SOH: char = '\x01';
 
+    /// Builds a message, recomputing BodyLength (9) from the actual body so the
+    /// decoder's declared-vs-actual length check passes.
     fn build(fields: &[&str]) -> String {
-        let mut msg = String::new();
-        for field in fields {
-            msg.push_str(field);
-            msg.push(SOH);
+        let begin = fields
+            .iter()
+            .find(|f| f.starts_with("8="))
+            .copied()
+            .unwrap_or("8=FIX.4.4");
+        let trailer = fields
+            .iter()
+            .find(|f| f.starts_with("10="))
+            .copied()
+            .unwrap_or("10=000");
+
+        let mut body = String::new();
+        for field in fields
+            .iter()
+            .filter(|f| !f.starts_with("8=") && !f.starts_with("9=") && !f.starts_with("10="))
+        {
+            body.push_str(field);
+            body.push(SOH);
         }
-        msg
+
+        format!(
+            "{begin}{SOH}9={}{SOH}{body}{trailer}{SOH}",
+            body.len(),
+            SOH = SOH
+        )
     }
 
     fn validate(fields: &[&str]) -> Result<(), Vec<ValidationError>> {

--- a/ironfix-tagvalue/src/checksum.rs
+++ b/ironfix-tagvalue/src/checksum.rs
@@ -57,11 +57,14 @@ pub fn format_checksum(checksum: u8) -> [u8; 3] {
 
 /// Parses a 3-digit checksum string to a u8 value.
 ///
+/// The digits are folded in `u16` and the result is range-checked, so a
+/// hostile value such as `999` is rejected instead of overflowing `u8`.
+///
 /// # Arguments
 /// * `bytes` - The 3-byte checksum string
 ///
 /// # Returns
-/// `Some(checksum)` if valid, `None` otherwise.
+/// `Some(checksum)` if valid and in `0..=255`, `None` otherwise.
 #[inline]
 #[must_use]
 pub fn parse_checksum(bytes: &[u8]) -> Option<u8> {
@@ -77,7 +80,10 @@ pub fn parse_checksum(bytes: &[u8]) -> Option<u8> {
         return None;
     }
 
-    Some(d0 * 100 + d1 * 10 + d2)
+    // Fold in u16: 999 does not fit in u8, and `d0 * 100` alone overflows for
+    // any hundreds digit >= 3.
+    let value = u16::from(d0) * 100 + u16::from(d1) * 10 + u16::from(d2);
+    u8::try_from(value).ok()
 }
 
 #[cfg(test)]
@@ -126,6 +132,16 @@ mod tests {
         assert_eq!(parse_checksum(b"0000"), None);
         assert_eq!(parse_checksum(b"abc"), None);
         assert_eq!(parse_checksum(b"12X"), None);
+    }
+
+    #[test]
+    fn test_parse_checksum_out_of_range() {
+        // Hundreds digit >= 3 used to overflow u8 (`d0 * 100`).
+        assert_eq!(parse_checksum(b"999"), None);
+        assert_eq!(parse_checksum(b"624"), None);
+        assert_eq!(parse_checksum(b"300"), None);
+        assert_eq!(parse_checksum(b"256"), None);
+        assert_eq!(parse_checksum(b"255"), Some(255));
     }
 
     #[test]

--- a/ironfix-tagvalue/src/decoder.rs
+++ b/ironfix-tagvalue/src/decoder.rs
@@ -111,9 +111,18 @@ impl<'a> Decoder<'a> {
 
         // Parse remaining fields until checksum
         let mut checksum_field: Option<FieldRef<'a>> = None;
-        while let Some(field) = self.next_field() {
+        // Offset of the first byte of the CheckSum (10) field, i.e. the end of
+        // the body. Tracked explicitly so it stays correct for zero-padded tags
+        // ("010=") that `parse_tag` folds numerically.
+        let mut checksum_field_start = self.offset;
+        loop {
+            let field_start = self.offset;
+            let Some(field) = self.next_field() else {
+                break;
+            };
             if field.tag == 10 {
                 checksum_field = Some(field);
+                checksum_field_start = field_start;
                 break;
             }
             fields.push(field);
@@ -130,9 +139,7 @@ impl<'a> Decoder<'a> {
             })?;
 
             // Calculate checksum of everything before the checksum field
-            let checksum_start =
-                checksum_ref.value.as_ptr() as usize - self.input.as_ptr() as usize - 3; // "10="
-            let calculated = calculate_checksum(&self.input[start_offset..checksum_start]);
+            let calculated = calculate_checksum(&self.input[start_offset..checksum_field_start]);
 
             if calculated != declared {
                 return Err(DecodeError::ChecksumMismatch {
@@ -142,7 +149,20 @@ impl<'a> Decoder<'a> {
             }
         }
 
-        let body_end = body_start + body_length;
+        // BodyLength (tag 9) is fully attacker-controlled: use checked arithmetic
+        // and validate the declared length against the bytes actually consumed.
+        let body_end = body_start
+            .checked_add(body_length)
+            .ok_or(DecodeError::InvalidBodyLength)?;
+        if checksum_field.is_some() {
+            // A well-formed frame declares exactly the bytes between the
+            // BodyLength SOH and the start of the CheckSum field.
+            if body_end != checksum_field_start {
+                return Err(DecodeError::InvalidBodyLength);
+            }
+        } else if body_end > self.offset {
+            return Err(DecodeError::InvalidBodyLength);
+        }
         let body = body_start..body_end;
 
         Ok(RawMessage::new(
@@ -281,5 +301,79 @@ mod tests {
         let input = b"8=FIX.4.4";
         let mut decoder = Decoder::new(input);
         assert!(decoder.next_field().is_none());
+    }
+
+    /// Builds a frame with the given BodyLength text (which may be hostile) and
+    /// a valid trailing checksum over the resulting bytes.
+    fn frame_with_body_length(body_length_text: &str, body_length_tag: &str) -> Vec<u8> {
+        let body = b"35=0\x0149=A\x0156=B\x0134=1\x0152=20240329-12:00:00\x01";
+        let mut msg = Vec::new();
+        msg.extend_from_slice(b"8=FIX.4.4\x01");
+        msg.extend_from_slice(format!("{body_length_tag}={body_length_text}\x01").as_bytes());
+        msg.extend_from_slice(body);
+        let sum: u32 = msg.iter().map(|&b| u32::from(b)).sum();
+        msg.extend_from_slice(format!("10={:03}\x01", (sum % 256) as u8).as_bytes());
+        msg
+    }
+
+    #[test]
+    fn test_decode_body_length_overflow_does_not_panic() {
+        let msg = frame_with_body_length(&usize::MAX.to_string(), "9");
+        assert_eq!(
+            Decoder::new(&msg).decode().unwrap_err(),
+            DecodeError::InvalidBodyLength
+        );
+    }
+
+    #[test]
+    fn test_decode_body_length_overflow_zero_padded_tag() {
+        // `parse_tag` folds digits numerically, so "009" is tag 9 here too.
+        let msg = frame_with_body_length(&usize::MAX.to_string(), "009");
+        assert_eq!(
+            Decoder::new(&msg).decode().unwrap_err(),
+            DecodeError::InvalidBodyLength
+        );
+    }
+
+    #[test]
+    fn test_decode_rejects_body_length_mismatch() {
+        let msg = frame_with_body_length("5", "9");
+        assert_eq!(
+            Decoder::new(&msg).decode().unwrap_err(),
+            DecodeError::InvalidBodyLength
+        );
+    }
+
+    #[test]
+    fn test_decode_accepts_correct_body_length() {
+        let body = b"35=0\x0149=A\x0156=B\x0134=1\x0152=20240329-12:00:00\x01";
+        let msg = frame_with_body_length(&body.len().to_string(), "9");
+        let decoded = Decoder::new(&msg).decode().expect("valid frame decodes");
+        assert_eq!(*decoded.msg_type(), MsgType::Heartbeat);
+    }
+
+    #[test]
+    fn test_decode_checksum_field_start_with_padded_tag() {
+        // Trailing checksum written as "010=" must still checksum the same span.
+        let body = b"35=0\x0149=A\x0156=B\x0134=1\x0152=20240329-12:00:00\x01";
+        let mut msg = Vec::new();
+        msg.extend_from_slice(b"8=FIX.4.4\x01");
+        msg.extend_from_slice(format!("9={}\x01", body.len()).as_bytes());
+        msg.extend_from_slice(body);
+        let sum: u32 = msg.iter().map(|&b| u32::from(b)).sum();
+        msg.extend_from_slice(format!("010={:03}\x01", (sum % 256) as u8).as_bytes());
+        assert!(Decoder::new(&msg).decode().is_ok());
+    }
+
+    #[test]
+    fn test_decode_mid_body_checksum_out_of_range_is_rejected() {
+        // A duplicate/injected `10=624` must not overflow the checksum parser.
+        let body = b"35=0\x0110=624\x0149=A\x01";
+        let mut msg = Vec::new();
+        msg.extend_from_slice(b"8=FIX.4.4\x01");
+        msg.extend_from_slice(format!("9={}\x01", body.len()).as_bytes());
+        msg.extend_from_slice(body);
+        msg.extend_from_slice(b"10=000\x01");
+        assert!(Decoder::new(&msg).decode().is_err());
     }
 }

--- a/ironfix-transport/src/codec.rs
+++ b/ironfix-transport/src/codec.rs
@@ -156,7 +156,13 @@ impl Decoder for FixCodec {
         // Calculate total message length
         // BodyLength counts from after 9=XXX| to before 10=
         // Total = header + body + trailer (10=XXX|)
-        let total_length = body_len_soh + 1 + body_length + 7; // +7 for |10=XXX|
+        // BodyLength is attacker-controlled: fold with checked arithmetic so a
+        // hostile declared length errors instead of overflowing usize.
+        let total_length = body_len_soh
+            .checked_add(1)
+            .and_then(|n| n.checked_add(body_length))
+            .and_then(|n| n.checked_add(7)) // +7 for |10=XXX|
+            .ok_or(CodecError::InvalidBodyLength)?;
 
         // Check maximum size
         if total_length > self.max_message_size {
@@ -248,6 +254,31 @@ mod tests {
 
         let result = codec.decode(&mut buf).unwrap();
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_codec_decode_body_length_overflow() {
+        let mut codec = FixCodec::new();
+        let msg = format!("8=FIX.4.4\x019={}\x0135=0\x0110=000\x01", usize::MAX);
+        let mut buf = BytesMut::from(msg.as_bytes());
+
+        // Must error, not overflow the framing arithmetic.
+        assert!(matches!(
+            codec.decode(&mut buf),
+            Err(CodecError::InvalidBodyLength)
+        ));
+    }
+
+    #[test]
+    fn test_codec_decode_body_length_too_large() {
+        let mut codec = FixCodec::new();
+        let msg = format!("8=FIX.4.4\x019={}\x0135=0\x0110=000\x01", 10 * 1024 * 1024);
+        let mut buf = BytesMut::from(msg.as_bytes());
+
+        assert!(matches!(
+            codec.decode(&mut buf),
+            Err(CodecError::MessageTooLarge { .. })
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Closes #4.

Fixes the three sibling unchecked-arithmetic sites reported in #4, all reachable from raw framing bytes on the default public decode/framing paths. Each panicked under `overflow-checks` (dev/test/CI and hardened release profiles) and wrapped silently under stock `--release`.

## Changes

**`ironfix-tagvalue/src/decoder.rs`** — decode path
- `body_start + body_length` → `checked_add`, mapping overflow to `DecodeError::InvalidBodyLength`.
- Also validates the declared length against reality: `body_end` must land exactly on the start of the `CheckSum (10)` field. A mismatch is a malformed frame per FIX.
- The CheckSum field offset is now tracked during the field scan instead of being derived as `value_ptr - 3`. That derivation mis-located zero-padded tags (`010=`), which `parse_tag` folds numerically — the same blind spot that defeated the downstream literal-prefix guard, and which also mis-computed the checksummed span.

**`ironfix-transport/src/codec.rs`** — framing path
- `body_len_soh + 1 + body_length + 7` folded with `checked_add` → `CodecError::InvalidBodyLength`.

**`ironfix-tagvalue/src/checksum.rs`** — checksum parse
- `parse_checksum` folded `d0 * 100` in `u8`, overflowing for any hundreds digit >= 3. Now folds in `u16` and range-checks via `u8::try_from`, so `999`/`624`/`300`/`256` are rejected. This covers the fuzzer-found reach through a duplicate/mid-body `10=` field, which `decode()` reaches for any tag-10 occurrence.

## Behaviour change

The decoder now rejects a `BodyLength` that does not match the actual body length. The `ironfix-dictionary` validator test fixtures declared a dummy `9=100`, so the test helper recomputes the real length.

## Version

Workspace bumped to 0.3.1.

## Tests

7 new regression tests: `usize::MAX` BodyLength via `9=` and `009=`, length mismatch, valid frame still decodes, trailing `010=` checksum, mid-body `10=624`, codec overflow and `MessageTooLarge`, and `parse_checksum` out-of-range.

`cargo test --workspace` — 23 suites pass, 0 failures. `cargo clippy --workspace --all-targets` clean. `cargo fmt` applied.
