### PR TITLE
fix(tagvalue): harden the tag=value decode path against untrusted input

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 license = "MIT"
@@ -26,16 +26,16 @@ categories = ["finance", "data-structures"]
 
 [workspace.dependencies]
 # Internal crates
-ironfix-core = { path = "ironfix-core", version = "0.3.1" }
-ironfix-dictionary = { path = "ironfix-dictionary", version = "0.3.1" }
-ironfix-tagvalue = { path = "ironfix-tagvalue", version = "0.3.1" }
-ironfix-session = { path = "ironfix-session", version = "0.3.1" }
-ironfix-store = { path = "ironfix-store", version = "0.3.1" }
-ironfix-transport = { path = "ironfix-transport", version = "0.3.1" }
-ironfix-fast = { path = "ironfix-fast", version = "0.3.1" }
-ironfix-codegen = { path = "ironfix-codegen", version = "0.3.1" }
-ironfix-derive = { path = "ironfix-derive", version = "0.3.1" }
-ironfix-engine = { path = "ironfix-engine", version = "0.3.1" }
+ironfix-core = { path = "ironfix-core", version = "0.4.0" }
+ironfix-dictionary = { path = "ironfix-dictionary", version = "0.4.0" }
+ironfix-tagvalue = { path = "ironfix-tagvalue", version = "0.4.0" }
+ironfix-session = { path = "ironfix-session", version = "0.4.0" }
+ironfix-store = { path = "ironfix-store", version = "0.4.0" }
+ironfix-transport = { path = "ironfix-transport", version = "0.4.0" }
+ironfix-fast = { path = "ironfix-fast", version = "0.4.0" }
+ironfix-codegen = { path = "ironfix-codegen", version = "0.4.0" }
+ironfix-derive = { path = "ironfix-derive", version = "0.4.0" }
+ironfix-engine = { path = "ironfix-engine", version = "0.4.0" }
 
 # External dependencies
 thiserror = "2.0"

--- a/ironfix-core/src/error.rs
+++ b/ironfix-core/src/error.rs
@@ -17,6 +17,7 @@ pub type Result<T> = std::result::Result<T, FixError>;
 
 /// Top-level error type for all IronFix operations.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum FixError {
     /// Error during message decoding.
     #[error("decode error: {0}")]
@@ -41,6 +42,7 @@ pub enum FixError {
 
 /// Errors that occur during FIX message decoding.
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum DecodeError {
     /// Message buffer is incomplete, need more data.
     #[error("incomplete message, need more data")]
@@ -118,10 +120,52 @@ pub enum DecodeError {
         /// Maximum allowed size in bytes.
         max_size: usize,
     },
+
+    /// A field is not terminated by the SOH delimiter.
+    ///
+    /// Distinct from [`DecodeError::Incomplete`]: the tag was well formed, so
+    /// the bytes are structurally a field, but its value never ends.
+    #[error("unterminated field for tag {tag}: missing SOH delimiter")]
+    UnterminatedField {
+        /// The tag whose value is not terminated.
+        tag: u32,
+    },
+
+    /// A Length/Data field pair declares a byte count the buffer cannot satisfy.
+    ///
+    /// Raised when the count declared by a `LENGTH` field (for example
+    /// `RawDataLength`, tag 95) runs past the end of the buffer, or when the
+    /// byte at the declared end of the `DATA` field is not the SOH delimiter.
+    #[error(
+        "data field {data_tag} declares {declared} bytes not terminated by SOH within {available} remaining bytes"
+    )]
+    InvalidDataLength {
+        /// The tag of the `DATA` field being framed.
+        data_tag: u32,
+        /// The byte count declared by the paired `LENGTH` field.
+        declared: usize,
+        /// Bytes actually available after the `=` delimiter.
+        available: usize,
+    },
+
+    /// A stored byte range does not lie within the message buffer.
+    ///
+    /// Guards the offset bookkeeping in [`crate::message::RawMessage`], whose
+    /// ranges are buffer-relative.
+    #[error("range {start}..{end} is out of bounds for a {buffer_len}-byte buffer")]
+    RangeOutOfBounds {
+        /// Start offset of the offending range.
+        start: usize,
+        /// End offset of the offending range.
+        end: usize,
+        /// Length of the buffer the range was applied to.
+        buffer_len: usize,
+    },
 }
 
 /// Errors that occur during FIX message encoding.
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum EncodeError {
     /// Buffer capacity exceeded during encoding.
     #[error("buffer overflow: need {needed} bytes, have {available}")]
@@ -162,6 +206,7 @@ pub enum EncodeError {
 
 /// Errors in FIX session layer operations.
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum SessionError {
     /// Session is not in the correct state for the operation.
     #[error("invalid session state: expected {expected}, current {current}")]
@@ -233,6 +278,7 @@ pub enum SessionError {
 
 /// Errors in message store operations.
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum StoreError {
     /// Failed to store message.
     #[error("failed to store message seq={seq_num}: {reason}")]

--- a/ironfix-core/src/error.rs
+++ b/ironfix-core/src/error.rs
@@ -131,11 +131,12 @@ pub enum DecodeError {
         tag: u32,
     },
 
-    /// A Length/Data field pair declares a byte count the buffer cannot satisfy.
+    /// A Length/Data field pair declares a byte count the frame cannot satisfy.
     ///
     /// Raised when the count declared by a `LENGTH` field (for example
-    /// `RawDataLength`, tag 95) runs past the end of the buffer, or when the
-    /// byte at the declared end of the `DATA` field is not the SOH delimiter.
+    /// `RawDataLength`, tag 95) runs past what the field may consume, or when
+    /// the byte at the declared end of the `DATA` field is not the SOH
+    /// delimiter.
     #[error(
         "data field {data_tag} declares {declared} bytes not terminated by SOH within {available} remaining bytes"
     )]
@@ -144,7 +145,9 @@ pub enum DecodeError {
         data_tag: u32,
         /// The byte count declared by the paired `LENGTH` field.
         declared: usize,
-        /// Bytes actually available after the `=` delimiter.
+        /// Bytes the field was allowed to consume: what remains after the `=`
+        /// delimiter, bounded by the frame's declared body end when decoding a
+        /// whole message. The terminating SOH must fall inside this.
         available: usize,
     },
 

--- a/ironfix-core/src/message.rs
+++ b/ironfix-core/src/message.rs
@@ -323,13 +323,22 @@ impl fmt::Display for MsgType {
 /// This struct holds references to the original message buffer,
 /// avoiding allocation during parsing. Fields are stored as
 /// offset ranges into the buffer.
+///
+/// # Range convention
+///
+/// **Every stored range is relative to `buffer`, not to whatever larger buffer
+/// the message may have been decoded from.** A decoder that reads several
+/// messages out of one input must rebase its offsets by the start of the
+/// current message before constructing a `RawMessage`; [`RawMessage::new`]
+/// rejects any range that does not lie within `buffer`.
 #[derive(Debug, Clone)]
 pub struct RawMessage<'a> {
     /// The complete message buffer.
     buffer: &'a [u8],
-    /// Range of the BeginString field value.
+    /// Range of the BeginString field value, relative to `buffer`.
     begin_string: Range<usize>,
-    /// Range of the message body (after BodyLength, before checksum).
+    /// Range of the message body (after BodyLength, before checksum),
+    /// relative to `buffer`.
     body: Range<usize>,
     /// The parsed message type.
     msg_type: MsgType,
@@ -337,30 +346,51 @@ pub struct RawMessage<'a> {
     fields: SmallVec<[FieldRef<'a>; 32]>,
 }
 
+/// Validates that `range` is well ordered and lies within `buffer_len` bytes.
+#[inline]
+fn check_range(range: &Range<usize>, buffer_len: usize) -> Result<(), DecodeError> {
+    if range.start > range.end || range.end > buffer_len {
+        return Err(DecodeError::RangeOutOfBounds {
+            start: range.start,
+            end: range.end,
+            buffer_len,
+        });
+    }
+    Ok(())
+}
+
 impl<'a> RawMessage<'a> {
     /// Creates a new RawMessage from parsed components.
     ///
     /// # Arguments
     /// * `buffer` - The complete message buffer
-    /// * `begin_string` - Range of the BeginString value
-    /// * `body` - Range of the message body
+    /// * `begin_string` - Range of the BeginString value, relative to `buffer`
+    /// * `body` - Range of the message body, relative to `buffer`
     /// * `msg_type` - The parsed message type
     /// * `fields` - Parsed field references
-    #[must_use]
+    ///
+    /// # Errors
+    /// Returns [`DecodeError::RangeOutOfBounds`] if `begin_string` or `body`
+    /// is inverted or does not lie within `buffer`. Every offset here derives
+    /// from attacker-supplied bytes, so the bounds are checked once at
+    /// construction rather than at every accessor.
     pub fn new(
         buffer: &'a [u8],
         begin_string: Range<usize>,
         body: Range<usize>,
         msg_type: MsgType,
         fields: SmallVec<[FieldRef<'a>; 32]>,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, DecodeError> {
+        check_range(&begin_string, buffer.len())?;
+        check_range(&body, buffer.len())?;
+
+        Ok(Self {
             buffer,
             begin_string,
             body,
             msg_type,
             fields,
-        }
+        })
     }
 
     /// Returns the complete message buffer.
@@ -371,9 +401,46 @@ impl<'a> RawMessage<'a> {
     }
 
     /// Returns the BeginString value (e.g., "FIX.4.4").
-    #[must_use]
-    pub fn begin_string(&self) -> &'a str {
-        std::str::from_utf8(&self.buffer[self.begin_string.clone()]).unwrap_or("")
+    ///
+    /// # Errors
+    /// Returns [`DecodeError::InvalidUtf8`] if the BeginString bytes are not
+    /// valid UTF-8, or [`DecodeError::RangeOutOfBounds`] if the stored range
+    /// escapes the buffer. The value is never silently defaulted to `""`.
+    pub fn begin_string(&self) -> Result<&'a str, DecodeError> {
+        let range = self.begin_string.clone();
+        debug_assert!(
+            range.end <= self.buffer.len(),
+            "RawMessage ranges must be buffer-relative"
+        );
+        let bytes = self
+            .buffer
+            .get(range.clone())
+            .ok_or(DecodeError::RangeOutOfBounds {
+                start: range.start,
+                end: range.end,
+                buffer_len: self.buffer.len(),
+            })?;
+        std::str::from_utf8(bytes).map_err(DecodeError::from)
+    }
+
+    /// Returns the message body bytes (after BodyLength, before the checksum).
+    ///
+    /// # Errors
+    /// Returns [`DecodeError::RangeOutOfBounds`] if the stored range escapes
+    /// the buffer.
+    pub fn body(&self) -> Result<&'a [u8], DecodeError> {
+        let range = self.body.clone();
+        debug_assert!(
+            range.end <= self.buffer.len(),
+            "RawMessage ranges must be buffer-relative"
+        );
+        self.buffer
+            .get(range.clone())
+            .ok_or(DecodeError::RangeOutOfBounds {
+                start: range.start,
+                end: range.end,
+                buffer_len: self.buffer.len(),
+            })
     }
 
     /// Returns the message type.
@@ -549,13 +616,14 @@ impl OwnedMessage {
     /// * `tag` - The field tag number
     ///
     /// # Returns
-    /// The field value bytes, or `None` if not found.
+    /// The field value bytes, or `None` if not found or if the stored offset
+    /// escapes the buffer.
     #[must_use]
     pub fn get_field(&self, tag: u32) -> Option<&[u8]> {
         self.field_offsets
             .iter()
             .find(|(t, _)| *t == tag)
-            .map(|(_, range)| &self.buffer[range.clone()])
+            .and_then(|(_, range)| self.buffer.get(range.clone()))
     }
 
     /// Gets a field value as a string.
@@ -618,10 +686,10 @@ mod tests {
 
     #[test]
     fn test_msg_type_from_str() {
-        assert_eq!("0".parse::<MsgType>().unwrap(), MsgType::Heartbeat);
-        assert_eq!("A".parse::<MsgType>().unwrap(), MsgType::Logon);
-        assert_eq!("D".parse::<MsgType>().unwrap(), MsgType::NewOrderSingle);
-        assert_eq!("8".parse::<MsgType>().unwrap(), MsgType::ExecutionReport);
+        assert_eq!("0".parse::<MsgType>(), Ok(MsgType::Heartbeat));
+        assert_eq!("A".parse::<MsgType>(), Ok(MsgType::Logon));
+        assert_eq!("D".parse::<MsgType>(), Ok(MsgType::NewOrderSingle));
+        assert_eq!("8".parse::<MsgType>(), Ok(MsgType::ExecutionReport));
     }
 
     #[test]
@@ -642,9 +710,88 @@ mod tests {
 
     #[test]
     fn test_msg_type_custom() {
-        let custom: MsgType = "XX".parse().unwrap();
-        assert!(matches!(custom, MsgType::Custom(_)));
+        let custom = MsgType::Custom("XX".to_string());
+        assert_eq!("XX".parse::<MsgType>(), Ok(custom.clone()));
         assert_eq!(custom.as_str(), "XX");
+    }
+
+    /// Builds the field list for a one-field `RawMessage` over `buffer`.
+    fn single_field(buffer: &[u8]) -> SmallVec<[FieldRef<'_>; 32]> {
+        let mut fields = SmallVec::new();
+        fields.push(FieldRef::new(8, buffer));
+        fields
+    }
+
+    #[test]
+    fn test_raw_message_new_rejects_begin_string_range_past_buffer() {
+        let buffer: &[u8] = b"8=FIX.4.4\x01";
+        let fields = single_field(buffer);
+        let result = RawMessage::new(buffer, 2..64, 0..0, MsgType::Heartbeat, fields);
+        assert_eq!(
+            result.err(),
+            Some(DecodeError::RangeOutOfBounds {
+                start: 2,
+                end: 64,
+                buffer_len: buffer.len(),
+            })
+        );
+    }
+
+    #[test]
+    fn test_raw_message_new_rejects_body_range_past_buffer() {
+        let buffer: &[u8] = b"8=FIX.4.4\x01";
+        let fields = single_field(buffer);
+        let result = RawMessage::new(buffer, 2..9, 0..11, MsgType::Heartbeat, fields);
+        assert!(matches!(
+            result.err(),
+            Some(DecodeError::RangeOutOfBounds { .. })
+        ));
+    }
+
+    #[test]
+    fn test_raw_message_new_rejects_inverted_range() {
+        let buffer: &[u8] = b"8=FIX.4.4\x01";
+        let fields = single_field(buffer);
+        // Built via the struct literal: `9..2` as a literal range trips
+        // `clippy::reversed_empty_ranges` before it can reach the check.
+        let inverted = Range { start: 9, end: 2 };
+        let result = RawMessage::new(buffer, inverted, 0..0, MsgType::Heartbeat, fields);
+        assert!(matches!(
+            result.err(),
+            Some(DecodeError::RangeOutOfBounds { .. })
+        ));
+    }
+
+    #[test]
+    fn test_raw_message_begin_string_and_body_are_buffer_relative() {
+        let buffer: &[u8] = b"8=FIX.4.4\x0135=0\x01";
+        let fields = single_field(buffer);
+        let Ok(msg) = RawMessage::new(buffer, 2..9, 10..15, MsgType::Heartbeat, fields) else {
+            panic!("in-bounds ranges must be accepted");
+        };
+        assert_eq!(msg.begin_string(), Ok("FIX.4.4"));
+        assert_eq!(msg.body(), Ok(&b"35=0\x01"[..]));
+        assert_eq!(msg.len(), buffer.len());
+    }
+
+    #[test]
+    fn test_raw_message_begin_string_invalid_utf8_is_typed_error() {
+        let buffer: &[u8] = b"8=\xff\xfe\x01";
+        let fields = single_field(buffer);
+        let Ok(msg) = RawMessage::new(buffer, 2..4, 0..0, MsgType::Heartbeat, fields) else {
+            panic!("in-bounds ranges must be accepted");
+        };
+        assert!(matches!(
+            msg.begin_string(),
+            Err(DecodeError::InvalidUtf8(_))
+        ));
+    }
+
+    #[test]
+    fn test_owned_message_get_field_out_of_bounds_offset_returns_none() {
+        let buffer = Bytes::from_static(b"8=FIX.4.4\x01");
+        let msg = OwnedMessage::new(buffer, MsgType::Heartbeat, vec![(8, 2..64)]);
+        assert_eq!(msg.get_field(8), None);
     }
 
     #[test]

--- a/ironfix-tagvalue/src/checksum.rs
+++ b/ironfix-tagvalue/src/checksum.rs
@@ -33,9 +33,13 @@ pub fn calculate_checksum(data: &[u8]) -> u8 {
 }
 
 /// Portable checksum calculation without SIMD.
+///
+/// The accumulator is `u64`: a `u32` overflows (and panics under the debug
+/// overflow checks) once the input exceeds roughly 16.8 MB of 0xFF bytes,
+/// which is a reachable size for a `RawData`-carrying message.
 #[inline]
 fn calculate_checksum_portable(data: &[u8]) -> u8 {
-    let sum: u32 = data.iter().map(|&b| b as u32).sum();
+    let sum: u64 = data.iter().map(|&b| u64::from(b)).sum();
     (sum % 256) as u8
 }
 
@@ -98,14 +102,25 @@ mod tests {
     #[test]
     fn test_calculate_checksum_simple() {
         let data = b"ABC";
-        let expected = (b'A' as u32 + b'B' as u32 + b'C' as u32) % 256;
+        let expected = (u32::from(b'A') + u32::from(b'B') + u32::from(b'C')) % 256;
         assert_eq!(calculate_checksum(data), expected as u8);
+    }
+
+    #[test]
+    fn test_calculate_checksum_large_input_does_not_overflow() {
+        // A `u32` accumulator overflows past ~16.8 MB of 0xFF bytes and panics
+        // under debug overflow checks. The size is deliberately not a multiple
+        // of 256 so a wrong fold cannot coincidentally produce 0.
+        let len = 17 * 1024 * 1024 + 7;
+        let data = vec![0xFFu8; len];
+        let expected = ((0xFFu64 * len as u64) % 256) as u8;
+        assert_eq!(calculate_checksum(&data), expected);
     }
 
     #[test]
     fn test_calculate_checksum_overflow() {
         let data = vec![255u8; 1000];
-        let expected = ((255u32 * 1000) % 256) as u8;
+        let expected = ((255u64 * 1000) % 256) as u8;
         assert_eq!(calculate_checksum(&data), expected);
     }
 

--- a/ironfix-tagvalue/src/checksum.rs
+++ b/ironfix-tagvalue/src/checksum.rs
@@ -35,8 +35,10 @@ pub fn calculate_checksum(data: &[u8]) -> u8 {
 /// Portable checksum calculation without SIMD.
 ///
 /// The accumulator is `u64`: a `u32` overflows (and panics under the debug
-/// overflow checks) once the input exceeds roughly 16.8 MB of 0xFF bytes,
-/// which is a reachable size for a `RawData`-carrying message.
+/// overflow checks) once the input exceeds roughly 16.8 MB of 0xFF bytes.
+/// The transport caps frames well below that by default, so this is not
+/// reachable through the codec — it is reachable by calling this function
+/// directly on a caller-supplied buffer, which is a public API.
 #[inline]
 fn calculate_checksum_portable(data: &[u8]) -> u8 {
     let sum: u64 = data.iter().map(|&b| u64::from(b)).sum();

--- a/ironfix-tagvalue/src/decoder.rs
+++ b/ironfix-tagvalue/src/decoder.rs
@@ -9,6 +9,11 @@
 //! This module provides a high-performance decoder that parses FIX messages
 //! without allocating memory for field values. Field values are returned as
 //! references to the original buffer.
+//!
+//! The decoder is an untrusted-input parser: every length and offset is
+//! attacker-controlled, so all arithmetic is checked, every slice is taken
+//! with [`slice::get`], and every malformed frame maps to a typed
+//! [`DecodeError`] instead of a panic or a silent default.
 
 use crate::checksum::{calculate_checksum, parse_checksum};
 use ironfix_core::error::DecodeError;
@@ -16,12 +21,97 @@ use ironfix_core::field::FieldRef;
 use ironfix_core::message::{MsgType, RawMessage};
 use memchr::memchr;
 use smallvec::SmallVec;
+use std::ops::Range;
 
 /// SOH (Start of Header) delimiter used in FIX messages.
 pub const SOH: u8 = 0x01;
 
 /// Equals sign delimiter between tag and value.
 pub const EQUALS: u8 = b'=';
+
+/// Maximum number of digits accepted in a tag number.
+const MAX_TAG_DIGITS: usize = 10;
+
+/// Maximum number of digits accepted in a `LENGTH` field value.
+const MAX_LENGTH_DIGITS: usize = 10;
+
+/// Maximum number of input bytes echoed back in an error message.
+///
+/// The offending bytes are attacker-controlled, so the diagnostic string is
+/// bounded rather than sized from the input.
+const MAX_TAG_DIAGNOSTIC_LEN: usize = 16;
+
+/// Spec-defined `(length_tag, data_tag)` pairs.
+///
+/// A FIX `DATA` field is a counted byte string whose content may legally
+/// contain SOH and `=`; it is always immediately preceded by its `LENGTH`
+/// field. Scanning such a value for SOH truncates it and injects phantom
+/// fields from its payload, so the decoder frames it by the declared count
+/// instead.
+///
+/// This is FIX **wire syntax** — a fixed, spec-defined tag set taken from the
+/// FIX 4.4 specification — not schema. Resolving it must never require a
+/// dictionary lookup: `ironfix-tagvalue` stays independent of
+/// `ironfix-dictionary`.
+const LENGTH_DATA_PAIRS: [(u32, u32); 16] = [
+    (90, 91),   // SecureDataLen / SecureData
+    (93, 89),   // SignatureLength / Signature
+    (95, 96),   // RawDataLength / RawData
+    (212, 213), // XmlDataLen / XmlData
+    (348, 349), // EncodedIssuerLen / EncodedIssuer
+    (350, 351), // EncodedSecurityDescLen / EncodedSecurityDesc
+    (352, 353), // EncodedListExecInstLen / EncodedListExecInst
+    (354, 355), // EncodedTextLen / EncodedText
+    (356, 357), // EncodedSubjectLen / EncodedSubject
+    (358, 359), // EncodedHeadlineLen / EncodedHeadline
+    (360, 361), // EncodedAllocTextLen / EncodedAllocText
+    (362, 363), // EncodedUnderlyingIssuerLen / EncodedUnderlyingIssuer
+    (364, 365), // EncodedUnderlyingSecurityDescLen / EncodedUnderlyingSecurityDesc
+    (445, 446), // EncodedListStatusTextLen / EncodedListStatusText
+    (618, 619), // EncodedLegIssuerLen / EncodedLegIssuer
+    (621, 622), // EncodedLegSecurityDescLen / EncodedLegSecurityDesc
+];
+
+/// Lowest length tag in [`LENGTH_DATA_PAIRS`].
+///
+/// Kept in sync with the table by `test_length_tag_bounds_match_table`.
+const MIN_LENGTH_TAG: u32 = 90;
+
+/// Highest length tag in [`LENGTH_DATA_PAIRS`].
+///
+/// Kept in sync with the table by `test_length_tag_bounds_match_table`.
+const MAX_LENGTH_TAG: u32 = 621;
+
+/// Returns the `DATA` tag paired with `length_tag`, if any.
+#[inline]
+#[must_use]
+const fn paired_data_tag(length_tag: u32) -> Option<u32> {
+    // Every field runs through here, and the session header tags (8, 9, 34,
+    // 35, 49, 52, 56) all fall below the table, so reject out-of-range tags
+    // before walking it.
+    if length_tag < MIN_LENGTH_TAG || length_tag > MAX_LENGTH_TAG {
+        return None;
+    }
+
+    let mut i = 0;
+    while i < LENGTH_DATA_PAIRS.len() {
+        let (len_tag, data_tag) = LENGTH_DATA_PAIRS[i];
+        if len_tag == length_tag {
+            return Some(data_tag);
+        }
+        i += 1;
+    }
+    None
+}
+
+/// A `DATA` field announced by the `LENGTH` field just consumed.
+#[derive(Debug, Clone, Copy)]
+struct PendingData {
+    /// Tag of the `DATA` field expected next.
+    data_tag: u32,
+    /// Byte count declared by the `LENGTH` field.
+    declared: usize,
+}
 
 /// Zero-copy FIX message decoder.
 ///
@@ -35,6 +125,8 @@ pub struct Decoder<'a> {
     offset: usize,
     /// Whether to validate checksums.
     validate_checksum: bool,
+    /// `DATA` field framing announced by the previous `LENGTH` field.
+    pending_data: Option<PendingData>,
 }
 
 impl<'a> Decoder<'a> {
@@ -49,6 +141,7 @@ impl<'a> Decoder<'a> {
             input,
             offset: 0,
             validate_checksum: true,
+            pending_data: None,
         }
     }
 
@@ -65,26 +158,31 @@ impl<'a> Decoder<'a> {
 
     /// Decodes a complete FIX message from the buffer.
     ///
+    /// The decoder can be called repeatedly to read consecutive messages out
+    /// of a single buffer; the ranges stored in the returned [`RawMessage`]
+    /// are relative to that message's own slice, not to the whole input.
+    ///
     /// # Returns
     /// A `RawMessage` containing zero-copy references to the parsed fields.
     ///
     /// # Errors
     /// Returns `DecodeError` if the message is malformed or incomplete.
+    /// Structural garbage after the last field is an error even when checksum
+    /// validation is disabled — it is never silently discarded.
     pub fn decode(&mut self) -> Result<RawMessage<'a>, DecodeError> {
         let start_offset = self.offset;
+        // Length/Data framing never carries across a message boundary.
+        self.pending_data = None;
 
         // Parse BeginString (tag 8)
-        let begin_string_field = self.next_field().ok_or(DecodeError::Incomplete)?;
+        let begin_string_field = self.next_field()?.ok_or(DecodeError::Incomplete)?;
         if begin_string_field.tag != 8 {
             return Err(DecodeError::InvalidBeginString);
         }
-        let begin_string_start =
-            begin_string_field.value.as_ptr() as usize - self.input.as_ptr() as usize;
-        let begin_string_end = begin_string_start + begin_string_field.value.len();
-        let begin_string = begin_string_start..begin_string_end;
+        let begin_string = self.value_range(start_offset, begin_string_field.value.len())?;
 
         // Parse BodyLength (tag 9)
-        let body_length_field = self.next_field().ok_or(DecodeError::MissingBodyLength)?;
+        let body_length_field = self.next_field()?.ok_or(DecodeError::MissingBodyLength)?;
         if body_length_field.tag != 9 {
             return Err(DecodeError::MissingBodyLength);
         }
@@ -97,11 +195,16 @@ impl<'a> Decoder<'a> {
         let body_start = self.offset;
 
         // Parse MsgType (tag 35) - should be first field in body
-        let msg_type_field = self.next_field().ok_or(DecodeError::MissingMsgType)?;
+        let msg_type_field = self.next_field()?.ok_or(DecodeError::MissingMsgType)?;
         if msg_type_field.tag != 35 {
             return Err(DecodeError::MissingMsgType);
         }
-        let msg_type: MsgType = msg_type_field.as_str()?.parse().unwrap();
+        // `MsgType: FromStr` is infallible (unknown values become `Custom`),
+        // so the error arm is uninhabited rather than unwrapped.
+        let msg_type: MsgType = match msg_type_field.as_str()?.parse() {
+            Ok(parsed) => parsed,
+            Err(never) => match never {},
+        };
 
         // Collect all fields
         let mut fields: SmallVec<[FieldRef<'a>; 32]> = SmallVec::new();
@@ -117,7 +220,10 @@ impl<'a> Decoder<'a> {
         let mut checksum_field_start = self.offset;
         loop {
             let field_start = self.offset;
-            let Some(field) = self.next_field() else {
+            // `?` here is the point of the exercise: a missing `=`, a
+            // non-numeric tag or an unterminated value is an error, not a
+            // clean end of buffer.
+            let Some(field) = self.next_field()? else {
                 break;
             };
             if field.tag == 10 {
@@ -139,7 +245,14 @@ impl<'a> Decoder<'a> {
             })?;
 
             // Calculate checksum of everything before the checksum field
-            let calculated = calculate_checksum(&self.input[start_offset..checksum_field_start]);
+            let span = self.input.get(start_offset..checksum_field_start).ok_or(
+                DecodeError::RangeOutOfBounds {
+                    start: start_offset,
+                    end: checksum_field_start,
+                    buffer_len: self.input.len(),
+                },
+            )?;
+            let calculated = calculate_checksum(span);
 
             if calculated != declared {
                 return Err(DecodeError::ChecksumMismatch {
@@ -163,44 +276,133 @@ impl<'a> Decoder<'a> {
         } else if body_end > self.offset {
             return Err(DecodeError::InvalidBodyLength);
         }
-        let body = body_start..body_end;
 
-        Ok(RawMessage::new(
-            &self.input[start_offset..self.offset],
-            begin_string,
-            body,
-            msg_type,
-            fields,
-        ))
+        // `RawMessage` ranges are relative to the message slice, so both
+        // ranges are rebased by the offset this message started at.
+        let body = rebase(body_start..body_end, start_offset, self.input.len())?;
+
+        let buffer =
+            self.input
+                .get(start_offset..self.offset)
+                .ok_or(DecodeError::RangeOutOfBounds {
+                    start: start_offset,
+                    end: self.offset,
+                    buffer_len: self.input.len(),
+                })?;
+
+        RawMessage::new(buffer, begin_string, body, msg_type, fields)
     }
 
     /// Parses the next field from the buffer.
     ///
+    /// A field is `tag=value<SOH>`. A value belonging to a spec-defined `DATA`
+    /// tag is framed by the count declared in the `LENGTH` field immediately
+    /// before it, so it may legally contain SOH and `=`.
+    ///
     /// # Returns
-    /// The next field, or `None` if the buffer is exhausted.
+    /// `Ok(None)` when the buffer is cleanly exhausted, `Ok(Some(field))`
+    /// otherwise.
+    ///
+    /// # Errors
+    /// * [`DecodeError::InvalidTag`] - the tag is empty, non-numeric, too long,
+    ///   or the field has no `=` delimiter.
+    /// * [`DecodeError::UnterminatedField`] - the value is not terminated by
+    ///   SOH.
+    /// * [`DecodeError::InvalidDataLength`] - a `LENGTH` field declares a count
+    ///   the remaining buffer cannot satisfy.
+    /// * [`DecodeError::InvalidFieldValue`] - a `LENGTH` field value is not a
+    ///   valid byte count.
     #[inline]
-    pub fn next_field(&mut self) -> Option<FieldRef<'a>> {
-        if self.offset >= self.input.len() {
-            return None;
+    pub fn next_field(&mut self) -> Result<Option<FieldRef<'a>>, DecodeError> {
+        // `offset` never exceeds `input.len()`, so a `None` here is exhaustion.
+        let Some(remaining) = self.input.get(self.offset..) else {
+            return Ok(None);
+        };
+        if remaining.is_empty() {
+            return Ok(None);
         }
 
-        let remaining = &self.input[self.offset..];
-
         // Find '=' delimiter using SIMD-accelerated search
-        let eq_pos = memchr(EQUALS, remaining)?;
-        let tag_bytes = &remaining[..eq_pos];
+        let eq_pos = memchr(EQUALS, remaining).ok_or_else(|| invalid_tag(remaining))?;
+        let tag_bytes = remaining
+            .get(..eq_pos)
+            .ok_or_else(|| invalid_tag(remaining))?;
+        let tag = parse_tag(tag_bytes).ok_or_else(|| invalid_tag(tag_bytes))?;
 
-        // Parse tag number
-        let tag = parse_tag(tag_bytes)?;
+        let value_start = eq_pos
+            .checked_add(1)
+            .ok_or(DecodeError::UnterminatedField { tag })?;
+        let value_bytes = remaining
+            .get(value_start..)
+            .ok_or(DecodeError::UnterminatedField { tag })?;
 
-        // Find SOH delimiter
-        let value_start = eq_pos + 1;
-        let soh_pos = memchr(SOH, &remaining[value_start..])?;
-        let value = &remaining[value_start..value_start + soh_pos];
+        // A `DATA` field announced by the preceding `LENGTH` field is consumed
+        // by count. Taking the state unconditionally means it never leaks past
+        // the field it describes.
+        let counted = match self.pending_data.take() {
+            Some(pending) if pending.data_tag == tag => Some(pending.declared),
+            _ => None,
+        };
 
-        self.offset += value_start + soh_pos + 1;
+        let value_len = match counted {
+            // `declared` is attacker-controlled: probe the byte at the declared
+            // end before slicing, so an oversized count is a typed error with
+            // no allocation and no panic.
+            Some(declared) => match value_bytes.get(declared) {
+                Some(&SOH) => declared,
+                _ => {
+                    return Err(DecodeError::InvalidDataLength {
+                        data_tag: tag,
+                        declared,
+                        available: value_bytes.len(),
+                    });
+                }
+            },
+            None => memchr(SOH, value_bytes).ok_or(DecodeError::UnterminatedField { tag })?,
+        };
 
-        Some(FieldRef::new(tag, value))
+        let value = value_bytes
+            .get(..value_len)
+            .ok_or(DecodeError::UnterminatedField { tag })?;
+
+        // Consume `tag=value<SOH>`.
+        let consumed = value_start
+            .checked_add(value_len)
+            .and_then(|end| end.checked_add(1))
+            .ok_or(DecodeError::UnterminatedField { tag })?;
+        self.offset = self
+            .offset
+            .checked_add(consumed)
+            .ok_or(DecodeError::UnterminatedField { tag })?;
+
+        // Remember a `LENGTH` field so the paired `DATA` field is framed by
+        // count rather than by an SOH scan.
+        if let Some(data_tag) = paired_data_tag(tag) {
+            let declared = parse_length(value).ok_or_else(|| invalid_length(tag))?;
+            self.pending_data = Some(PendingData { data_tag, declared });
+        }
+
+        Ok(Some(FieldRef::new(tag, value)))
+    }
+
+    /// Returns the buffer-relative range of the value of the field just
+    /// consumed, for a message that starts at `message_start`.
+    ///
+    /// The decoder has consumed `tag=value<SOH>`, so the value ends one byte
+    /// before the current offset.
+    fn value_range(
+        &self,
+        message_start: usize,
+        value_len: usize,
+    ) -> Result<Range<usize>, DecodeError> {
+        let out_of_bounds = || DecodeError::RangeOutOfBounds {
+            start: message_start,
+            end: self.offset,
+            buffer_len: self.input.len(),
+        };
+        let value_end = self.offset.checked_sub(1).ok_or_else(out_of_bounds)?;
+        let value_start = value_end.checked_sub(value_len).ok_or_else(out_of_bounds)?;
+        rebase(value_start..value_end, message_start, self.input.len())
     }
 
     /// Returns the current offset in the buffer.
@@ -214,7 +416,8 @@ impl<'a> Decoder<'a> {
     #[inline]
     #[must_use]
     pub fn remaining(&self) -> &'a [u8] {
-        &self.input[self.offset..]
+        // `offset` is only ever advanced to a position inside the buffer.
+        self.input.get(self.offset..).unwrap_or(&[])
     }
 
     /// Returns true if the buffer has been fully consumed.
@@ -228,6 +431,56 @@ impl<'a> Decoder<'a> {
     #[inline]
     pub fn reset(&mut self) {
         self.offset = 0;
+        self.pending_data = None;
+    }
+}
+
+/// Rebases an absolute range into one relative to `message_start`.
+#[inline]
+fn rebase(
+    range: Range<usize>,
+    message_start: usize,
+    buffer_len: usize,
+) -> Result<Range<usize>, DecodeError> {
+    let out_of_bounds = || DecodeError::RangeOutOfBounds {
+        start: range.start,
+        end: range.end,
+        buffer_len,
+    };
+    let start = range
+        .start
+        .checked_sub(message_start)
+        .ok_or_else(out_of_bounds)?;
+    let end = range
+        .end
+        .checked_sub(message_start)
+        .ok_or_else(out_of_bounds)?;
+    Ok(start..end)
+}
+
+/// Builds a [`DecodeError::InvalidTag`] with a bounded diagnostic.
+///
+/// Kept out of line: it allocates, and it is called from `ok_or_else` closures
+/// inside `next_field`, the hottest function in the crate. Inlining it would
+/// pull the UTF-8 validation and allocator sequence into the scan loop's
+/// instruction-cache footprint.
+#[cold]
+#[inline(never)]
+fn invalid_tag(bytes: &[u8]) -> DecodeError {
+    let shown = bytes.get(..MAX_TAG_DIAGNOSTIC_LEN).unwrap_or(bytes);
+    DecodeError::InvalidTag(String::from_utf8_lossy(shown).into_owned())
+}
+
+/// Builds a [`DecodeError::InvalidFieldValue`] for an unparseable `LENGTH`
+/// field value.
+///
+/// Out of line for the same reason as [`invalid_tag`].
+#[cold]
+#[inline(never)]
+fn invalid_length(tag: u32) -> DecodeError {
+    DecodeError::InvalidFieldValue {
+        tag,
+        reason: "length field value is not a valid byte count".to_string(),
     }
 }
 
@@ -240,7 +493,7 @@ impl<'a> Decoder<'a> {
 /// The parsed tag number, or `None` if invalid.
 #[inline]
 fn parse_tag(bytes: &[u8]) -> Option<u32> {
-    if bytes.is_empty() || bytes.len() > 10 {
+    if bytes.is_empty() || bytes.len() > MAX_TAG_DIGITS {
         return None;
     }
 
@@ -249,7 +502,29 @@ fn parse_tag(bytes: &[u8]) -> Option<u32> {
         if !b.is_ascii_digit() {
             return None;
         }
-        result = result.checked_mul(10)?.checked_add((b - b'0') as u32)?;
+        result = result.checked_mul(10)?.checked_add(u32::from(b - b'0'))?;
+    }
+
+    Some(result)
+}
+
+/// Parses a `LENGTH` field value (a byte count) from ASCII bytes.
+///
+/// # Returns
+/// The declared count, or `None` if the value is empty, non-numeric, too long,
+/// or overflows `usize`.
+#[inline]
+fn parse_length(bytes: &[u8]) -> Option<usize> {
+    if bytes.is_empty() || bytes.len() > MAX_LENGTH_DIGITS {
+        return None;
+    }
+
+    let mut result: usize = 0;
+    for &b in bytes {
+        if !b.is_ascii_digit() {
+            return None;
+        }
+        result = result.checked_mul(10)?.checked_add(usize::from(b - b'0'))?;
     }
 
     Some(result)
@@ -258,6 +533,24 @@ fn parse_tag(bytes: &[u8]) -> Option<u32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Builds a well-formed frame around `body` with a valid trailing checksum.
+    fn build_frame(body: &[u8]) -> Vec<u8> {
+        build_frame_with_begin_string(b"FIX.4.4", body)
+    }
+
+    /// Builds a well-formed frame with an arbitrary BeginString value.
+    fn build_frame_with_begin_string(begin_string: &[u8], body: &[u8]) -> Vec<u8> {
+        let mut msg = Vec::with_capacity(body.len() + 32);
+        msg.extend_from_slice(b"8=");
+        msg.extend_from_slice(begin_string);
+        msg.push(SOH);
+        msg.extend_from_slice(format!("9={}\x01", body.len()).as_bytes());
+        msg.extend_from_slice(body);
+        let sum: u64 = msg.iter().map(|&b| u64::from(b)).sum();
+        msg.extend_from_slice(format!("10={:03}\x01", (sum % 256) as u8).as_bytes());
+        msg
+    }
 
     #[test]
     fn test_parse_tag() {
@@ -270,37 +563,122 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_length_rejects_hostile_values() {
+        assert_eq!(parse_length(b"0"), Some(0));
+        assert_eq!(parse_length(b"7"), Some(7));
+        assert_eq!(parse_length(b""), None);
+        assert_eq!(parse_length(b"-1"), None);
+        assert_eq!(parse_length(b"1a"), None);
+        // More digits than a byte count can plausibly need.
+        assert_eq!(parse_length(b"99999999999999999999"), None);
+    }
+
+    #[test]
+    fn test_paired_data_tag_covers_spec_pairs() {
+        assert_eq!(paired_data_tag(95), Some(96));
+        assert_eq!(paired_data_tag(93), Some(89));
+        assert_eq!(paired_data_tag(90), Some(91));
+        assert_eq!(paired_data_tag(354), Some(355));
+        assert_eq!(paired_data_tag(621), Some(622));
+        assert_eq!(paired_data_tag(35), None);
+        // No tag is both a length tag and a data tag.
+        for (_, data_tag) in LENGTH_DATA_PAIRS {
+            assert_eq!(paired_data_tag(data_tag), None);
+        }
+    }
+
+    #[test]
+    fn test_length_tag_bounds_match_table() {
+        // The fast-reject guard in `paired_data_tag` must never exclude a tag
+        // that is actually in the table.
+        let min = LENGTH_DATA_PAIRS.iter().map(|(len, _)| *len).min();
+        let max = LENGTH_DATA_PAIRS.iter().map(|(len, _)| *len).max();
+        assert_eq!(min, Some(MIN_LENGTH_TAG));
+        assert_eq!(max, Some(MAX_LENGTH_TAG));
+        for (length_tag, data_tag) in LENGTH_DATA_PAIRS {
+            assert_eq!(paired_data_tag(length_tag), Some(data_tag));
+        }
+    }
+
+    #[test]
     fn test_next_field() {
         let input = b"8=FIX.4.4\x019=5\x0135=0\x01";
         let mut decoder = Decoder::new(input);
 
-        let field1 = decoder.next_field().unwrap();
+        let Ok(Some(field1)) = decoder.next_field() else {
+            panic!("first field must parse");
+        };
         assert_eq!(field1.tag, 8);
-        assert_eq!(field1.as_str().unwrap(), "FIX.4.4");
+        assert_eq!(field1.as_str(), Ok("FIX.4.4"));
 
-        let field2 = decoder.next_field().unwrap();
+        let Ok(Some(field2)) = decoder.next_field() else {
+            panic!("second field must parse");
+        };
         assert_eq!(field2.tag, 9);
-        assert_eq!(field2.as_str().unwrap(), "5");
+        assert_eq!(field2.as_str(), Ok("5"));
 
-        let field3 = decoder.next_field().unwrap();
+        let Ok(Some(field3)) = decoder.next_field() else {
+            panic!("third field must parse");
+        };
         assert_eq!(field3.tag, 35);
-        assert_eq!(field3.as_str().unwrap(), "0");
+        assert_eq!(field3.as_str(), Ok("0"));
 
-        assert!(decoder.next_field().is_none());
+        assert!(matches!(decoder.next_field(), Ok(None)));
     }
 
     #[test]
     fn test_decoder_empty() {
         let mut decoder = Decoder::new(b"");
-        assert!(decoder.next_field().is_none());
+        assert!(matches!(decoder.next_field(), Ok(None)));
         assert!(decoder.is_empty());
     }
 
     #[test]
-    fn test_decoder_incomplete() {
+    fn test_next_field_missing_soh_is_unterminated_field() {
         let input = b"8=FIX.4.4";
         let mut decoder = Decoder::new(input);
-        assert!(decoder.next_field().is_none());
+        assert_eq!(
+            decoder.next_field().err(),
+            Some(DecodeError::UnterminatedField { tag: 8 })
+        );
+    }
+
+    #[test]
+    fn test_next_field_non_numeric_tag_is_invalid_tag() {
+        let mut decoder = Decoder::new(b"abc=1\x01");
+        let error = decoder.next_field().err();
+        assert!(matches!(error, Some(DecodeError::InvalidTag(_))));
+        assert_ne!(error, Some(DecodeError::Incomplete));
+    }
+
+    #[test]
+    fn test_next_field_missing_equals_is_invalid_tag() {
+        let mut decoder = Decoder::new(b"garbage-no-equals\x01");
+        let error = decoder.next_field().err();
+        assert!(matches!(error, Some(DecodeError::InvalidTag(_))));
+        assert_ne!(error, Some(DecodeError::Incomplete));
+    }
+
+    #[test]
+    fn test_next_field_invalid_tag_diagnostic_is_bounded() {
+        let mut input = vec![b'x'; 4096];
+        input.push(SOH);
+        let mut decoder = Decoder::new(&input);
+        match decoder.next_field() {
+            Err(DecodeError::InvalidTag(text)) => {
+                assert!(text.len() <= MAX_TAG_DIAGNOSTIC_LEN);
+            }
+            other => panic!("expected InvalidTag, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_next_field_empty_tag_is_invalid_tag() {
+        let mut decoder = Decoder::new(b"=value\x01");
+        assert!(matches!(
+            decoder.next_field(),
+            Err(DecodeError::InvalidTag(_))
+        ));
     }
 
     /// Builds a frame with the given BodyLength text (which may be hostile) and
@@ -311,7 +689,7 @@ mod tests {
         msg.extend_from_slice(b"8=FIX.4.4\x01");
         msg.extend_from_slice(format!("{body_length_tag}={body_length_text}\x01").as_bytes());
         msg.extend_from_slice(body);
-        let sum: u32 = msg.iter().map(|&b| u32::from(b)).sum();
+        let sum: u64 = msg.iter().map(|&b| u64::from(b)).sum();
         msg.extend_from_slice(format!("10={:03}\x01", (sum % 256) as u8).as_bytes());
         msg
     }
@@ -320,8 +698,8 @@ mod tests {
     fn test_decode_body_length_overflow_does_not_panic() {
         let msg = frame_with_body_length(&usize::MAX.to_string(), "9");
         assert_eq!(
-            Decoder::new(&msg).decode().unwrap_err(),
-            DecodeError::InvalidBodyLength
+            Decoder::new(&msg).decode().err(),
+            Some(DecodeError::InvalidBodyLength)
         );
     }
 
@@ -330,8 +708,8 @@ mod tests {
         // `parse_tag` folds digits numerically, so "009" is tag 9 here too.
         let msg = frame_with_body_length(&usize::MAX.to_string(), "009");
         assert_eq!(
-            Decoder::new(&msg).decode().unwrap_err(),
-            DecodeError::InvalidBodyLength
+            Decoder::new(&msg).decode().err(),
+            Some(DecodeError::InvalidBodyLength)
         );
     }
 
@@ -339,8 +717,8 @@ mod tests {
     fn test_decode_rejects_body_length_mismatch() {
         let msg = frame_with_body_length("5", "9");
         assert_eq!(
-            Decoder::new(&msg).decode().unwrap_err(),
-            DecodeError::InvalidBodyLength
+            Decoder::new(&msg).decode().err(),
+            Some(DecodeError::InvalidBodyLength)
         );
     }
 
@@ -348,7 +726,9 @@ mod tests {
     fn test_decode_accepts_correct_body_length() {
         let body = b"35=0\x0149=A\x0156=B\x0134=1\x0152=20240329-12:00:00\x01";
         let msg = frame_with_body_length(&body.len().to_string(), "9");
-        let decoded = Decoder::new(&msg).decode().expect("valid frame decodes");
+        let Ok(decoded) = Decoder::new(&msg).decode() else {
+            panic!("valid frame must decode");
+        };
         assert_eq!(*decoded.msg_type(), MsgType::Heartbeat);
     }
 
@@ -360,7 +740,7 @@ mod tests {
         msg.extend_from_slice(b"8=FIX.4.4\x01");
         msg.extend_from_slice(format!("9={}\x01", body.len()).as_bytes());
         msg.extend_from_slice(body);
-        let sum: u32 = msg.iter().map(|&b| u32::from(b)).sum();
+        let sum: u64 = msg.iter().map(|&b| u64::from(b)).sum();
         msg.extend_from_slice(format!("010={:03}\x01", (sum % 256) as u8).as_bytes());
         assert!(Decoder::new(&msg).decode().is_ok());
     }
@@ -375,5 +755,201 @@ mod tests {
         msg.extend_from_slice(body);
         msg.extend_from_slice(b"10=000\x01");
         assert!(Decoder::new(&msg).decode().is_err());
+    }
+
+    #[test]
+    fn test_decode_two_consecutive_frames_are_both_correct() {
+        let first_body: &[u8] = b"35=0\x0149=A\x0156=B\x01";
+        let second_body: &[u8] = b"35=A\x0149=CCCC\x0156=DDDD\x01";
+        let first_frame = build_frame(first_body);
+        let second_frame = build_frame(second_body);
+
+        let mut input = first_frame.clone();
+        input.extend_from_slice(&second_frame);
+
+        let mut decoder = Decoder::new(&input);
+
+        let Ok(first) = decoder.decode() else {
+            panic!("first frame must decode");
+        };
+        assert_eq!(first.begin_string(), Ok("FIX.4.4"));
+        assert_eq!(*first.msg_type(), MsgType::Heartbeat);
+        assert_eq!(first.body(), Ok(first_body));
+        assert_eq!(first.len(), first_frame.len());
+
+        // The second frame is where absolute ranges used to index out of
+        // bounds and abort the process.
+        let Ok(second) = decoder.decode() else {
+            panic!("second frame must decode");
+        };
+        assert_eq!(second.begin_string(), Ok("FIX.4.4"));
+        assert_eq!(*second.msg_type(), MsgType::Logon);
+        assert_eq!(second.body(), Ok(second_body));
+        assert_eq!(second.len(), second_frame.len());
+
+        // Both bodies must start after "8=FIX.4.4<SOH>9=<len><SOH>".
+        let expected_start = 10 + format!("9={}\x01", second_body.len()).len();
+        assert_eq!(
+            *second.body_range(),
+            expected_start..expected_start + second_body.len()
+        );
+
+        assert!(decoder.is_empty());
+    }
+
+    #[test]
+    fn test_decode_begin_string_invalid_utf8_is_typed_error() {
+        let msg = build_frame_with_begin_string(b"FIX\xff\xfe4", b"35=0\x01");
+        let Ok(decoded) = Decoder::new(&msg).decode() else {
+            panic!("frame with non-utf8 BeginString still frames");
+        };
+        assert!(matches!(
+            decoded.begin_string(),
+            Err(DecodeError::InvalidUtf8(_))
+        ));
+    }
+
+    #[test]
+    fn test_decode_raw_data_with_embedded_soh_and_equals_roundtrips() {
+        // 7 bytes carrying both an SOH and an '=' inside the value.
+        let raw_data: &[u8] = b"a\x01b=c\x01d";
+        let mut body = Vec::new();
+        body.extend_from_slice(b"35=A\x01");
+        body.extend_from_slice(b"95=7\x01");
+        body.extend_from_slice(b"96=");
+        body.extend_from_slice(raw_data);
+        body.push(SOH);
+        body.extend_from_slice(b"58=after\x01");
+        let msg = build_frame(&body);
+
+        let Ok(decoded) = Decoder::new(&msg).decode() else {
+            panic!("frame with RawData must decode");
+        };
+        let Some(field) = decoded.get_field(96) else {
+            panic!("RawData field must be present");
+        };
+        assert_eq!(field.value, raw_data);
+        // No phantom fields injected from inside the payload.
+        assert!(decoded.get_field(98).is_none());
+        assert_eq!(decoded.get_field_str(58), Some("after"));
+        // 8, 9, 35, 95, 96, 58
+        assert_eq!(decoded.field_count(), 6);
+    }
+
+    #[test]
+    fn test_decode_raw_data_truncated_payload_is_typed_error() {
+        // Declares 20 bytes but only 3 are present before the terminator.
+        let mut body = Vec::new();
+        body.extend_from_slice(b"35=A\x0195=20\x0196=abc\x01");
+        let msg = build_frame(&body);
+
+        assert_eq!(
+            Decoder::new(&msg).decode().err(),
+            Some(DecodeError::InvalidDataLength {
+                data_tag: 96,
+                declared: 20,
+                available: 11,
+            })
+        );
+    }
+
+    #[test]
+    fn test_decode_raw_data_hostile_length_is_typed_error() {
+        // A count far beyond the buffer must be rejected by a bounds probe,
+        // never by allocating `declared` bytes.
+        let mut body = Vec::new();
+        body.extend_from_slice(b"35=A\x0195=4294967295\x0196=abc\x01");
+        let msg = build_frame(&body);
+
+        assert!(matches!(
+            Decoder::new(&msg).decode(),
+            Err(DecodeError::InvalidDataLength {
+                data_tag: 96,
+                declared: 4_294_967_295,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn test_decode_raw_data_length_mismatch_not_on_soh_is_rejected() {
+        // Declares 2 bytes for a 3-byte payload: the declared end is not SOH.
+        let msg = build_frame(b"35=A\x0195=2\x0196=abc\x01");
+        assert!(matches!(
+            Decoder::new(&msg).decode(),
+            Err(DecodeError::InvalidDataLength { data_tag: 96, .. })
+        ));
+    }
+
+    #[test]
+    fn test_decode_non_numeric_length_field_is_typed_error() {
+        let msg = build_frame(b"35=A\x0195=abc\x0196=x\x01");
+        assert!(matches!(
+            Decoder::new(&msg).decode(),
+            Err(DecodeError::InvalidFieldValue { tag: 95, .. })
+        ));
+    }
+
+    #[test]
+    fn test_decode_length_field_not_followed_by_its_data_field_parses_normally() {
+        // Framing by count only applies to the paired DATA tag; anything else
+        // falls back to the normal SOH scan without fabricating a field.
+        let msg = build_frame(b"35=A\x0195=7\x0158=text\x01");
+        let Ok(decoded) = Decoder::new(&msg).decode() else {
+            panic!("frame must decode");
+        };
+        assert_eq!(decoded.get_field_str(58), Some("text"));
+        assert_eq!(decoded.get_field_str(95), Some("7"));
+    }
+
+    #[test]
+    fn test_decode_zero_length_data_field_is_accepted() {
+        let msg = build_frame(b"35=A\x0195=0\x0196=\x0158=after\x01");
+        let Ok(decoded) = Decoder::new(&msg).decode() else {
+            panic!("frame with empty RawData must decode");
+        };
+        let Some(field) = decoded.get_field(96) else {
+            panic!("RawData field must be present");
+        };
+        assert!(field.value.is_empty());
+        assert_eq!(decoded.get_field_str(58), Some("after"));
+    }
+
+    #[test]
+    fn test_decode_trailing_garbage_without_checksum_validation_is_error() {
+        let mut msg = b"8=FIX.4.4\x019=5\x0135=0\x01".to_vec();
+        msg.extend_from_slice(b"garbage-no-equals");
+
+        let result = Decoder::new(&msg).with_checksum_validation(false).decode();
+        assert!(matches!(result, Err(DecodeError::InvalidTag(_))));
+    }
+
+    #[test]
+    fn test_decode_trailing_unterminated_field_without_checksum_validation_is_error() {
+        let mut msg = b"8=FIX.4.4\x019=5\x0135=0\x01".to_vec();
+        msg.extend_from_slice(b"58=unterminated");
+
+        let result = Decoder::new(&msg).with_checksum_validation(false).decode();
+        assert_eq!(
+            result.err(),
+            Some(DecodeError::UnterminatedField { tag: 58 })
+        );
+    }
+
+    #[test]
+    fn test_decode_empty_buffer_is_incomplete() {
+        assert_eq!(
+            Decoder::new(b"").decode().err(),
+            Some(DecodeError::Incomplete)
+        );
+    }
+
+    #[test]
+    fn test_reset_clears_pending_data_state() {
+        let msg = build_frame(b"35=A\x0195=7\x0196=a\x01b=c\x01d\x01");
+        let mut decoder = Decoder::new(&msg);
+        assert!(decoder.decode().is_ok());
+        decoder.reset();
+        assert!(decoder.decode().is_ok());
     }
 }

--- a/ironfix-tagvalue/src/decoder.rs
+++ b/ironfix-tagvalue/src/decoder.rs
@@ -41,7 +41,7 @@ const MAX_LENGTH_DIGITS: usize = 10;
 /// bounded rather than sized from the input.
 const MAX_TAG_DIAGNOSTIC_LEN: usize = 16;
 
-/// Spec-defined `(length_tag, data_tag)` pairs.
+/// Returns the `DATA` tag paired with `length_tag`, if any.
 ///
 /// A FIX `DATA` field is a counted byte string whose content may legally
 /// contain SOH and `=`; it is always immediately preceded by its `LENGTH`
@@ -49,59 +49,41 @@ const MAX_TAG_DIAGNOSTIC_LEN: usize = 16;
 /// fields from its payload, so the decoder frames it by the declared count
 /// instead.
 ///
-/// This is FIX **wire syntax** — a fixed, spec-defined tag set taken from the
-/// FIX 4.4 specification — not schema. Resolving it must never require a
-/// dictionary lookup: `ironfix-tagvalue` stays independent of
-/// `ironfix-dictionary`.
-const LENGTH_DATA_PAIRS: [(u32, u32); 16] = [
-    (90, 91),   // SecureDataLen / SecureData
-    (93, 89),   // SignatureLength / Signature
-    (95, 96),   // RawDataLength / RawData
-    (212, 213), // XmlDataLen / XmlData
-    (348, 349), // EncodedIssuerLen / EncodedIssuer
-    (350, 351), // EncodedSecurityDescLen / EncodedSecurityDesc
-    (352, 353), // EncodedListExecInstLen / EncodedListExecInst
-    (354, 355), // EncodedTextLen / EncodedText
-    (356, 357), // EncodedSubjectLen / EncodedSubject
-    (358, 359), // EncodedHeadlineLen / EncodedHeadline
-    (360, 361), // EncodedAllocTextLen / EncodedAllocText
-    (362, 363), // EncodedUnderlyingIssuerLen / EncodedUnderlyingIssuer
-    (364, 365), // EncodedUnderlyingSecurityDescLen / EncodedUnderlyingSecurityDesc
-    (445, 446), // EncodedListStatusTextLen / EncodedListStatusText
-    (618, 619), // EncodedLegIssuerLen / EncodedLegIssuer
-    (621, 622), // EncodedLegSecurityDescLen / EncodedLegSecurityDesc
-];
-
-/// Lowest length tag in [`LENGTH_DATA_PAIRS`].
+/// This is FIX **wire syntax** — a fixed, spec-defined tag set — not schema, so
+/// resolving it must never require a dictionary lookup: `ironfix-tagvalue`
+/// stays independent of `ironfix-dictionary`.
 ///
-/// Kept in sync with the table by `test_length_tag_bounds_match_table`.
-const MIN_LENGTH_TAG: u32 = 90;
-
-/// Highest length tag in [`LENGTH_DATA_PAIRS`].
+/// The arms below are the complete set for FIX 4.4 (every `type='DATA'` field
+/// in the vendored `spec/FIX44.xml`). Versions above 4.4 add further pairs;
+/// a `DATA` field outside this set still falls back to an SOH scan and is
+/// therefore subject to the truncation this framing exists to prevent.
 ///
-/// Kept in sync with the table by `test_length_tag_bounds_match_table`.
-const MAX_LENGTH_TAG: u32 = 621;
-
-/// Returns the `DATA` tag paired with `length_tag`, if any.
+/// Written as a `match` rather than a table walk because `slice::get` is not
+/// const-stable, so indexing a const array here would be unchecked indexing.
+/// `LENGTH_DATA_PAIRS` in the tests cross-checks these arms so the two cannot
+/// drift.
 #[inline]
 #[must_use]
 const fn paired_data_tag(length_tag: u32) -> Option<u32> {
-    // Every field runs through here, and the session header tags (8, 9, 34,
-    // 35, 49, 52, 56) all fall below the table, so reject out-of-range tags
-    // before walking it.
-    if length_tag < MIN_LENGTH_TAG || length_tag > MAX_LENGTH_TAG {
-        return None;
+    match length_tag {
+        90 => Some(91),   // SecureDataLen / SecureData
+        93 => Some(89),   // SignatureLength / Signature
+        95 => Some(96),   // RawDataLength / RawData
+        212 => Some(213), // XmlDataLen / XmlData
+        348 => Some(349), // EncodedIssuerLen / EncodedIssuer
+        350 => Some(351), // EncodedSecurityDescLen / EncodedSecurityDesc
+        352 => Some(353), // EncodedListExecInstLen / EncodedListExecInst
+        354 => Some(355), // EncodedTextLen / EncodedText
+        356 => Some(357), // EncodedSubjectLen / EncodedSubject
+        358 => Some(359), // EncodedHeadlineLen / EncodedHeadline
+        360 => Some(361), // EncodedAllocTextLen / EncodedAllocText
+        362 => Some(363), // EncodedUnderlyingIssuerLen / EncodedUnderlyingIssuer
+        364 => Some(365), // EncodedUnderlyingSecurityDescLen / EncodedUnderlyingSecurityDesc
+        445 => Some(446), // EncodedListStatusTextLen / EncodedListStatusText
+        618 => Some(619), // EncodedLegIssuerLen / EncodedLegIssuer
+        621 => Some(622), // EncodedLegSecurityDescLen / EncodedLegSecurityDesc
+        _ => None,
     }
-
-    let mut i = 0;
-    while i < LENGTH_DATA_PAIRS.len() {
-        let (len_tag, data_tag) = LENGTH_DATA_PAIRS[i];
-        if len_tag == length_tag {
-            return Some(data_tag);
-        }
-        i += 1;
-    }
-    None
 }
 
 /// A `DATA` field announced by the `LENGTH` field just consumed.
@@ -191,11 +173,20 @@ impl<'a> Decoder<'a> {
             .parse()
             .map_err(|_| DecodeError::InvalidBodyLength)?;
 
-        // Record body start position
+        // Record body start position. BodyLength (tag 9) is fully
+        // attacker-controlled, so the end of the body is computed with checked
+        // arithmetic here and then used to bound every field that follows: a
+        // count-framed DATA value must not reach past it into the trailer.
         let body_start = self.offset;
+        let body_end = body_start
+            .checked_add(body_length)
+            .ok_or(DecodeError::InvalidBodyLength)?;
+        let limit = Some(body_end);
 
         // Parse MsgType (tag 35) - should be first field in body
-        let msg_type_field = self.next_field()?.ok_or(DecodeError::MissingMsgType)?;
+        let msg_type_field = self
+            .next_field_bounded(limit)?
+            .ok_or(DecodeError::MissingMsgType)?;
         if msg_type_field.tag != 35 {
             return Err(DecodeError::MissingMsgType);
         }
@@ -223,7 +214,7 @@ impl<'a> Decoder<'a> {
             // `?` here is the point of the exercise: a missing `=`, a
             // non-numeric tag or an unterminated value is an error, not a
             // clean end of buffer.
-            let Some(field) = self.next_field()? else {
+            let Some(field) = self.next_field_bounded(limit)? else {
                 break;
             };
             if field.tag == 10 {
@@ -234,9 +225,20 @@ impl<'a> Decoder<'a> {
             fields.push(field);
         }
 
-        // Validate checksum if enabled
+        // The CheckSum field terminates every FIX frame, so its presence is
+        // structural. `validate_checksum` governs whether its *value* is
+        // verified, never whether the field must exist: without this a
+        // count-framed DATA value that swallowed the trailer would still decode
+        // cleanly on the validation-off path the engine uses.
+        let checksum_ref = checksum_field.ok_or(DecodeError::Incomplete)?;
+
+        // A well-formed frame declares exactly the bytes between the BodyLength
+        // SOH and the start of the CheckSum field.
+        if body_end != checksum_field_start {
+            return Err(DecodeError::InvalidBodyLength);
+        }
+
         if self.validate_checksum {
-            let checksum_ref = checksum_field.ok_or(DecodeError::Incomplete)?;
             let declared = parse_checksum(checksum_ref.value).ok_or_else(|| {
                 DecodeError::InvalidFieldValue {
                     tag: 10,
@@ -260,21 +262,6 @@ impl<'a> Decoder<'a> {
                     declared,
                 });
             }
-        }
-
-        // BodyLength (tag 9) is fully attacker-controlled: use checked arithmetic
-        // and validate the declared length against the bytes actually consumed.
-        let body_end = body_start
-            .checked_add(body_length)
-            .ok_or(DecodeError::InvalidBodyLength)?;
-        if checksum_field.is_some() {
-            // A well-formed frame declares exactly the bytes between the
-            // BodyLength SOH and the start of the CheckSum field.
-            if body_end != checksum_field_start {
-                return Err(DecodeError::InvalidBodyLength);
-            }
-        } else if body_end > self.offset {
-            return Err(DecodeError::InvalidBodyLength);
         }
 
         // `RawMessage` ranges are relative to the message slice, so both
@@ -303,6 +290,11 @@ impl<'a> Decoder<'a> {
     /// `Ok(None)` when the buffer is cleanly exhausted, `Ok(Some(field))`
     /// otherwise.
     ///
+    /// Iterating with this method reads fields without any frame context, so a
+    /// count-framed `DATA` value is bounded only by the buffer. Only
+    /// [`Decoder::decode`] knows the frame's declared body end and can stop a
+    /// count from reaching past it into the trailer.
+    ///
     /// # Errors
     /// * [`DecodeError::InvalidTag`] - the tag is empty, non-numeric, too long,
     ///   or the field has no `=` delimiter.
@@ -314,6 +306,19 @@ impl<'a> Decoder<'a> {
     ///   valid byte count.
     #[inline]
     pub fn next_field(&mut self) -> Result<Option<FieldRef<'a>>, DecodeError> {
+        self.next_field_bounded(None)
+    }
+
+    /// Parses the next field, optionally bounded by the frame's declared body
+    /// end.
+    ///
+    /// `body_limit` is the absolute offset of the first byte after the body,
+    /// i.e. the start of the CheckSum field. A count-framed `DATA` value and
+    /// its terminating SOH must both fall inside it.
+    fn next_field_bounded(
+        &mut self,
+        body_limit: Option<usize>,
+    ) -> Result<Option<FieldRef<'a>>, DecodeError> {
         // `offset` never exceeds `input.len()`, so a `None` here is exhaustion.
         let Some(remaining) = self.input.get(self.offset..) else {
             return Ok(None);
@@ -345,19 +350,37 @@ impl<'a> Decoder<'a> {
         };
 
         let value_len = match counted {
-            // `declared` is attacker-controlled: probe the byte at the declared
-            // end before slicing, so an oversized count is a typed error with
-            // no allocation and no panic.
-            Some(declared) => match value_bytes.get(declared) {
-                Some(&SOH) => declared,
-                _ => {
+            Some(declared) => {
+                let value_offset = self
+                    .offset
+                    .checked_add(value_start)
+                    .ok_or(DecodeError::UnterminatedField { tag })?;
+                // How many bytes this value may consume: the rest of the
+                // buffer, further bounded by the frame's declared body end when
+                // decoding a whole message. Without that bound a crafted count
+                // swallows the CheckSum field, and the frame still decodes
+                // whenever checksum validation is off.
+                let available = match body_limit {
+                    // A field starting at or past the declared body end means
+                    // BodyLength disagrees with the frame's actual layout.
+                    Some(limit) => limit
+                        .checked_sub(value_offset)
+                        .ok_or(DecodeError::InvalidBodyLength)?
+                        .min(value_bytes.len()),
+                    None => value_bytes.len(),
+                };
+                // `declared` is attacker-controlled. The terminating SOH sits at
+                // index `declared`, so it must fall inside `available`; probing
+                // it beats sizing anything from the declared count.
+                if declared >= available || value_bytes.get(declared) != Some(&SOH) {
                     return Err(DecodeError::InvalidDataLength {
                         data_tag: tag,
                         declared,
-                        available: value_bytes.len(),
+                        available,
                     });
                 }
-            },
+                declared
+            }
             None => memchr(SOH, value_bytes).ok_or(DecodeError::UnterminatedField { tag })?,
         };
 
@@ -534,6 +557,30 @@ fn parse_length(bytes: &[u8]) -> Option<usize> {
 mod tests {
     use super::*;
 
+    /// Reference table of the spec-defined `(length_tag, data_tag)` pairs.
+    ///
+    /// This is the complete set of `type='DATA'` fields in the vendored FIX 4.4
+    /// specification. It exists to cross-check the match arms of
+    /// [`paired_data_tag`], which is the production lookup.
+    const LENGTH_DATA_PAIRS: [(u32, u32); 16] = [
+        (90, 91),   // SecureDataLen / SecureData
+        (93, 89),   // SignatureLength / Signature
+        (95, 96),   // RawDataLength / RawData
+        (212, 213), // XmlDataLen / XmlData
+        (348, 349), // EncodedIssuerLen / EncodedIssuer
+        (350, 351), // EncodedSecurityDescLen / EncodedSecurityDesc
+        (352, 353), // EncodedListExecInstLen / EncodedListExecInst
+        (354, 355), // EncodedTextLen / EncodedText
+        (356, 357), // EncodedSubjectLen / EncodedSubject
+        (358, 359), // EncodedHeadlineLen / EncodedHeadline
+        (360, 361), // EncodedAllocTextLen / EncodedAllocText
+        (362, 363), // EncodedUnderlyingIssuerLen / EncodedUnderlyingIssuer
+        (364, 365), // EncodedUnderlyingSecurityDescLen / EncodedUnderlyingSecurityDesc
+        (445, 446), // EncodedListStatusTextLen / EncodedListStatusText
+        (618, 619), // EncodedLegIssuerLen / EncodedLegIssuer
+        (621, 622), // EncodedLegSecurityDescLen / EncodedLegSecurityDesc
+    ];
+
     /// Builds a well-formed frame around `body` with a valid trailing checksum.
     fn build_frame(body: &[u8]) -> Vec<u8> {
         build_frame_with_begin_string(b"FIX.4.4", body)
@@ -588,15 +635,18 @@ mod tests {
     }
 
     #[test]
-    fn test_length_tag_bounds_match_table() {
-        // The fast-reject guard in `paired_data_tag` must never exclude a tag
-        // that is actually in the table.
-        let min = LENGTH_DATA_PAIRS.iter().map(|(len, _)| *len).min();
-        let max = LENGTH_DATA_PAIRS.iter().map(|(len, _)| *len).max();
-        assert_eq!(min, Some(MIN_LENGTH_TAG));
-        assert_eq!(max, Some(MAX_LENGTH_TAG));
+    fn test_paired_data_tag_matches_the_spec_table() {
+        // The reference table is the FIX 4.4 spec's complete `type='DATA'` set.
+        // Cross-checking it against the match arms catches drift in either.
         for (length_tag, data_tag) in LENGTH_DATA_PAIRS {
             assert_eq!(paired_data_tag(length_tag), Some(data_tag));
+        }
+        // Nothing outside the table is treated as a length tag.
+        let length_tags: Vec<u32> = LENGTH_DATA_PAIRS.iter().map(|(len, _)| *len).collect();
+        for tag in 1..=700u32 {
+            if !length_tags.contains(&tag) {
+                assert_eq!(paired_data_tag(tag), None, "tag {tag} must not be paired");
+            }
         }
     }
 
@@ -845,11 +895,57 @@ mod tests {
 
         assert_eq!(
             Decoder::new(&msg).decode().err(),
+            // `available` is scoped to the frame's declared body, not to the
+            // rest of the buffer: 4 bytes of body remain after "96=".
             Some(DecodeError::InvalidDataLength {
                 data_tag: 96,
                 declared: 20,
-                available: 11,
+                available: 4,
             })
+        );
+    }
+
+    #[test]
+    fn test_decode_data_count_cannot_swallow_the_checksum_field() {
+        // A count-framed DATA value whose declared length reaches past the body
+        // and lands on the SOH before "10=" would consume the trailer: no tag 10
+        // is then found, and with checksum validation off the frame would decode
+        // with the trailer bytes injected into the DATA value. The count is
+        // bounded by the declared body end, so this is rejected on both paths.
+        // BodyLength counts "35=A|95=8|96=x|" = 15 bytes, and the checksum is
+        // correct for the frame, so nothing but the count is malformed.
+        let body: &[u8] = b"35=A\x0195=8\x0196=x\x01";
+        let msg = build_frame(body);
+
+        for validate in [true, false] {
+            let result = Decoder::new(&msg)
+                .with_checksum_validation(validate)
+                .decode();
+            assert!(
+                matches!(
+                    result,
+                    Err(DecodeError::InvalidDataLength { data_tag: 96, .. })
+                ),
+                "validate_checksum={validate} must reject the swallowed trailer, got {result:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_decode_missing_checksum_field_is_error_without_validation() {
+        // The CheckSum field is structural: a frame that never emits tag 10 must
+        // be rejected even when checksum validation is disabled.
+        let mut msg = Vec::new();
+        msg.extend_from_slice(b"8=FIX.4.4\x01");
+        msg.extend_from_slice(b"9=5\x01");
+        msg.extend_from_slice(b"35=0\x01");
+
+        assert_eq!(
+            Decoder::new(&msg)
+                .with_checksum_validation(false)
+                .decode()
+                .err(),
+            Some(DecodeError::Incomplete)
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes the four verified correctness defects in the tag=value decode path found by the 2026-07-21 workspace audit. Every one of them is reachable from untrusted wire bytes; two of them either abort the process or silently accept a corrupted message.

Closes #7.

## Stack

- **Base branch:** `main`
- **Stack:** **#7 (this PR)** → #8 (transport framing) → #9 (engine session conformance)
- `Blocks:` #24 (issue #8), which branches off this one.

The diff is cumulative against `main` only until this PR merges — read it against the base branch. Merge bottom-up.

## What was wrong

**1. `RawMessage` ranges were absolute while its buffer was a sub-slice.** `Decoder::decode()` computed the BeginString and body ranges as offsets into the whole input, then handed `RawMessage` the slice `&input[start_offset..offset]`. The two only agree while `start_offset == 0`. Decoding a second message from the same `Decoder` — the streaming pattern the public API is shaped for (`offset()`, `remaining()`, `is_empty()`, `reset()`) — made `begin_string()` index out of bounds and panic, which under the release profile's `panic = "abort"` takes the process down on well-formed input. `body_range()` was silently wrong in the same situation. No in-repo caller decodes twice from one `Decoder`, so this was a latent public-API defect rather than a live production bug, but it is reachable by any external consumer.

Both ranges are now rebased onto the message slice, and `RawMessage::new` validates them against the buffer, so an inconsistent range cannot reach an accessor at all. `begin_string()` no longer maps invalid UTF-8 to `""` — a silent default the coding rules forbid.

**2. Length/Data field pairs containing SOH could not be parsed.** `next_field` always split a value at the first SOH, but FIX `DATA` fields (`RawData`/96, `Signature`/89, `XmlData`/213, the `Encoded*` family, …) are counted byte strings whose content may legally contain both SOH and `=`. A message carrying binary `RawData` either failed with a misleading `Incomplete`, or — worse — decoded "successfully" with a truncated value plus **phantom fields synthesised from inside the payload**, with the checksum still validating because the byte count was unchanged. That is silent field injection from attacker-controlled bytes.

The decoder now frames such a value by the count declared in its `LENGTH` field. The declared count is attacker-controlled, so the byte at the declared end is probed for SOH *before* any slicing: an oversized or lying count is a typed error with no allocation and no panic.

This is FIX **wire syntax** — a fixed, spec-defined tag set — not schema, so it needs no dictionary and `ironfix-tagvalue` stays independent of `ironfix-dictionary`.

One deliberate leniency: counted framing is applied only when the field actually following a `LENGTH` field carries its paired `DATA` tag. A `LENGTH` field followed by anything else falls back to the normal SOH scan rather than erroring. The spec requires the pair to be adjacent, so this case is malformed either way; accepting it cannot cause a mis-frame, because the count is never applied to a tag it was not declared for. A test pins the behaviour.

**3. Malformed input was indistinguishable from a clean end of buffer.** `next_field` returned `None` alike for an exhausted buffer, a missing `=`, a non-numeric tag and a missing SOH, and `decode()` treated every `None` as a clean end. Concretely: `8=FIX.4.4|9=5|35=0|garbage-no-equals` with checksum validation **off** returned `Ok` and silently discarded the trailing garbage — and validation-off is exactly how `ironfix-engine/src/wire.rs:48` drives the decoder. `DecodeError::InvalidTag` was never constructed anywhere.

`next_field` now returns `Result<Option<FieldRef>, DecodeError>`, distinguishing clean exhaustion from `InvalidTag` and from a new `UnterminatedField`. Trailing structural garbage is an error even with checksum validation disabled.

**4. `calculate_checksum` overflowed its accumulator.** The `u32` accumulator panics under debug overflow checks past roughly 16.8 MB of input — a build-mode-dependent panic in a decode-path routine. The transport caps frames far below that by default, so this is not reachable through the codec; it is reachable by calling `calculate_checksum` directly on a caller-supplied buffer, which is public API. It now accumulates in `u64`.

While in `decoder.rs`, the `.unwrap()` at the MsgType parse was removed: `MsgType: FromStr` has `Err = Infallible`, so the error arm is now discharged as the uninhabited type it is instead of being unwrapped.

## A defect the review caught in this PR's own first draft

Worth stating plainly, because it is the same class of bug as finding 2 and it was introduced by the fix for it. The first implementation bounded a count-framed `DATA` value only by the buffer, not by the frame. A peer controls the declared count, so it can be chosen to land exactly on the SOH preceding the trailer: the value then swallows `10=xxx`, no tag 10 is ever found, and — because the BodyLength cross-check only ran inside `if checksum_field.is_some()` — the frame decoded cleanly with the trailer injected into `RawData`. It reproduced on the validation-off path `ironfix-engine/src/wire.rs:48` uses.

Two changes close it, both in the final diff:

- the declared body end now bounds count framing, so an over-reaching count is `InvalidDataLength`; as a side effect a complete frame with a bogus count no longer reports `Incomplete`, which would have stalled a caller waiting for bytes the peer had already sent
- the CheckSum field is now required unconditionally — `validate_checksum` governs whether its *value* is verified, never whether the field must exist, since every FIX frame terminates with tag 10

Both paths are pinned by regression tests.

## Known limitation

The Length/Data pair set is complete for **FIX 4.4** — it matches every `type='DATA'` field in the vendored `spec/FIX44.xml` exactly (16 pairs; the `LENGTH` fields `9` and `383` are correctly excluded because they pair with no `DATA` field). Versions above 4.4 add further pairs, and a `DATA` field outside this set still falls back to the SOH scan, so it remains subject to the truncation this change exists to prevent. The crate advertises 4.0 → 5.0 SP2, so this gap is real and is documented on `paired_data_tag`. Extending the table for the post-4.4 pairs is follow-up work.

## Public API changes (semver)

The workspace moves to **0.4.0** in this PR. The published baseline is 0.3.1 and `semver.yml` runs `cargo-semver-checks` on every branch push, so the bump has to land with the first breaking change. For a `0.x` crate the breaking position is the minor; `cargo semver-checks --baseline-rev 1110a14` classifies the transition as a major change and requires no further update.

Breaking:
- `RawMessage::new` → `Result<Self, DecodeError>` (validates its ranges; one call site in the workspace)
- `RawMessage::begin_string()` → `Result<&str, DecodeError>` (was `&str` with a silent `""` fallback; zero in-workspace callers)
- `Decoder::next_field()` → `Result<Option<FieldRef>, DecodeError>` (was `Option<FieldRef>`)
- `#[non_exhaustive]` on `FixError`, `DecodeError`, `EncodeError`, `SessionError`, `StoreError` — so that adding a variant stops being a breaking change from here on

Additive:
- `RawMessage::body()` returning the body bytes
- `DecodeError::{UnterminatedField, InvalidDataLength, RangeOutOfBounds}`

`OwnedMessage::new` is deliberately left signature-compatible — it is called from `ironfix-store`, which belongs to a different issue. Its `get_field` did switch from indexing to `.get()`, removing a panic without changing the signature.

## Tests

Workspace goes from ~157 to **188 passing tests**. New coverage, one per acceptance criterion:

- two consecutive frames decoded from a **single** `Decoder`, asserting `begin_string()`, `msg_type()`, `body()` and `body_range()` for both — the case that used to abort
- `RawData(96)` carrying an embedded SOH **and** an `=` round-trips byte-exact, with assertions that no phantom field is injected and that the following field still parses
- truncated data payload, a hostile declared length, and a count not landing on SOH — each a typed error
- `InvalidTag` for a non-numeric tag, a missing `=` and an empty tag; `UnterminatedField` for a missing terminal SOH — each distinguishable from `Incomplete`
- a crafted count that would swallow the trailer is rejected with checksum validation both on and off
- a frame that never emits tag 10 is rejected even with checksum validation off
- trailing garbage with checksum validation **off** is an error, not silent success
- `begin_string()` on invalid UTF-8 returns a typed error rather than `""`
- a >17 MB checksum input, sized deliberately off a 256-byte multiple so a wrong fold cannot coincidentally pass
- the Length/Data table's cached tag bounds are asserted to match the table itself, so the two cannot drift

## Verification

```
cargo test --workspace                                    # 188 passed, 0 failed
cargo clippy --all-targets --all-features -- -D warnings  # clean
cargo fmt --all --check                                   # clean
cargo build --release --workspace                         # clean
cargo build --release --examples                          # clean
make doc                                                  # clean (clippy -W missing-docs)
```

No performance claim is made: this repo has no benchmark harness (no `benches/`, no criterion), so the hot-path changes here are argued structurally — the success path still allocates nothing and every field value is still a borrowed slice — not measured.