### PR TITLE
fix(transport): verify framing, bound buffering and define garbled-message recovery

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 license = "MIT"
@@ -26,16 +26,16 @@ categories = ["finance", "data-structures"]
 
 [workspace.dependencies]
 # Internal crates
-ironfix-core = { path = "ironfix-core", version = "0.3.1" }
-ironfix-dictionary = { path = "ironfix-dictionary", version = "0.3.1" }
-ironfix-tagvalue = { path = "ironfix-tagvalue", version = "0.3.1" }
-ironfix-session = { path = "ironfix-session", version = "0.3.1" }
-ironfix-store = { path = "ironfix-store", version = "0.3.1" }
-ironfix-transport = { path = "ironfix-transport", version = "0.3.1" }
-ironfix-fast = { path = "ironfix-fast", version = "0.3.1" }
-ironfix-codegen = { path = "ironfix-codegen", version = "0.3.1" }
-ironfix-derive = { path = "ironfix-derive", version = "0.3.1" }
-ironfix-engine = { path = "ironfix-engine", version = "0.3.1" }
+ironfix-core = { path = "ironfix-core", version = "0.4.0" }
+ironfix-dictionary = { path = "ironfix-dictionary", version = "0.4.0" }
+ironfix-tagvalue = { path = "ironfix-tagvalue", version = "0.4.0" }
+ironfix-session = { path = "ironfix-session", version = "0.4.0" }
+ironfix-store = { path = "ironfix-store", version = "0.4.0" }
+ironfix-transport = { path = "ironfix-transport", version = "0.4.0" }
+ironfix-fast = { path = "ironfix-fast", version = "0.4.0" }
+ironfix-codegen = { path = "ironfix-codegen", version = "0.4.0" }
+ironfix-derive = { path = "ironfix-derive", version = "0.4.0" }
+ironfix-engine = { path = "ironfix-engine", version = "0.4.0" }
 
 # External dependencies
 thiserror = "2.0"

--- a/doc/fix_operations.md
+++ b/doc/fix_operations.md
@@ -598,6 +598,82 @@ These messages are required for establishing and maintaining FIX sessions.
 
 ## Error Handling
 
+### Garbled Messages and Transport Resynchronization
+
+**Scope**: `ironfix-transport::FixCodec` — the framing layer that turns a byte
+stream into complete FIX frames. This subsection is the codec's contract; it
+does not describe session-level rejection.
+
+**FIX convention**: a *garbled* message — one whose framing cannot be trusted:
+BeginString (8) is not the first field, BodyLength (9) is missing or does not
+agree with the frame layout, or CheckSum (10) is absent or malformed — is
+**ignored**. The receiver does **not** send a Reject, does **not** send a
+ResendRequest for it, and does **not** increment the inbound MsgSeqNum, because
+the sequence number of a garbled message cannot be trusted either. Recovery is
+left to the normal gap-detection path on the next well-formed message.
+
+**What IronFix implements today**
+
+The codec detects garbling and, for the errors where a frame boundary can be
+inferred, decides how many bytes to discard so that a caller which keeps reading
+can make progress. The remaining variants consume nothing and a caller must
+treat them as fatal. Consumption per error:
+
+| `CodecError` | Bytes consumed from the read buffer |
+|---|---|
+| `InvalidBeginString` | up to and including the `<SOH>` of the next `<SOH>8` pair, so the buffer restarts at the `8` (the whole buffer when there is no such pair, minus a trailing `<SOH>` that may still be the first half of one) |
+| `InvalidTrailer` | the same resync as above — the trailer is absent from the offsets BodyLength implies, so BodyLength is not corroborated and its declared length is not trusted to bound the discard |
+| `InvalidChecksumFormat`, `ChecksumMismatch` | the whole declared frame (`BodyLength` + header + 7-byte trailer) |
+| `MissingBodyLength`, `InvalidBodyLength`, `HeaderTooLong`, `MessageTooLarge`, `Io` | none — no frame boundary can be inferred |
+
+Rationale for the two policies:
+
+- After `InvalidBeginString` the stream position is unknown, so the only safe
+  anchor is the next byte sequence that can legally start a frame: an SOH
+  followed by `8`. Scanning to it is bounded by the buffer length and never
+  allocates.
+- After a checksum error the trailer literal is exactly where BodyLength said it
+  would be, so the declared boundary is corroborated by the frame's own
+  structure: consuming `BodyLength`-worth of bytes keeps a stream of otherwise
+  well-formed frames aligned.
+- A missing trailer is the opposite case — nothing corroborates BodyLength, and
+  trusting it to size the discard hands an attacker a lever. A short header
+  declaring a large body would otherwise consume every well-formed frame that
+  merely follows it (tens of thousands, at the default ceiling) and report the
+  loss as a single error. So this case resyncs instead.
+- Recovery is best-effort, not lossless: because the anchor is `<SOH>8` rather
+  than a bare `8=` (which occurs inside ordinary tags such as `18=` and `58=`),
+  a well-formed frame arriving immediately after garbage is normally discarded
+  with it, unless the garbage happens to end on an SOH. Recovery resumes at the
+  frame after that one.
+- Before the header is complete no boundary exists at all, so the codec keeps
+  the bytes and bounds them instead: the header region `8=…<SOH>9=…<SOH>` is
+  capped at 64 bytes and the whole frame at `max_message_size` (1 MiB by
+  default). Exceeding either is an error, never a request for more data — this
+  is what stops a peer from growing the read buffer without bound.
+
+**What IronFix does not implement**
+
+- **The MsgSeqNum half of the convention is the session layer's
+  responsibility and is not implemented.** The codec has no access to session
+  state and never touches sequence numbers; nothing in `ironfix-session` or
+  `ironfix-engine` currently distinguishes "garbled, do not count" from any
+  other failure.
+- **The resynchronization above is not reachable from the engine as built, and
+  not only because `ironfix-engine::Initiator` treats every codec error as
+  fatal.** `tokio_util::Framed` terminates its stream after *any* decoder error:
+  it latches an internal error flag and returns `None` on the next poll, so the
+  well-formed frame the resync had just aligned onto is discarded along with the
+  stream. No way of writing the caller changes that. Honouring the convention
+  from the engine would require either the codec to report garbling as
+  `Ok(None)` while skipping the bad bytes internally — which is itself a change
+  to framing semantics — or the engine to drive `Decoder::decode` by hand
+  instead of using `Framed`. The consumption policy above is therefore
+  observable today only by a caller that drives the codec directly, which is how
+  it is tested.
+
+---
+
 ### Business Message Reject (MsgType = j)
 
 **Purpose**: Reject an application-level message.

--- a/ironfix-core/src/error.rs
+++ b/ironfix-core/src/error.rs
@@ -17,6 +17,7 @@ pub type Result<T> = std::result::Result<T, FixError>;
 
 /// Top-level error type for all IronFix operations.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum FixError {
     /// Error during message decoding.
     #[error("decode error: {0}")]
@@ -41,6 +42,7 @@ pub enum FixError {
 
 /// Errors that occur during FIX message decoding.
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum DecodeError {
     /// Message buffer is incomplete, need more data.
     #[error("incomplete message, need more data")]
@@ -118,10 +120,52 @@ pub enum DecodeError {
         /// Maximum allowed size in bytes.
         max_size: usize,
     },
+
+    /// A field is not terminated by the SOH delimiter.
+    ///
+    /// Distinct from [`DecodeError::Incomplete`]: the tag was well formed, so
+    /// the bytes are structurally a field, but its value never ends.
+    #[error("unterminated field for tag {tag}: missing SOH delimiter")]
+    UnterminatedField {
+        /// The tag whose value is not terminated.
+        tag: u32,
+    },
+
+    /// A Length/Data field pair declares a byte count the buffer cannot satisfy.
+    ///
+    /// Raised when the count declared by a `LENGTH` field (for example
+    /// `RawDataLength`, tag 95) runs past the end of the buffer, or when the
+    /// byte at the declared end of the `DATA` field is not the SOH delimiter.
+    #[error(
+        "data field {data_tag} declares {declared} bytes not terminated by SOH within {available} remaining bytes"
+    )]
+    InvalidDataLength {
+        /// The tag of the `DATA` field being framed.
+        data_tag: u32,
+        /// The byte count declared by the paired `LENGTH` field.
+        declared: usize,
+        /// Bytes actually available after the `=` delimiter.
+        available: usize,
+    },
+
+    /// A stored byte range does not lie within the message buffer.
+    ///
+    /// Guards the offset bookkeeping in [`crate::message::RawMessage`], whose
+    /// ranges are buffer-relative.
+    #[error("range {start}..{end} is out of bounds for a {buffer_len}-byte buffer")]
+    RangeOutOfBounds {
+        /// Start offset of the offending range.
+        start: usize,
+        /// End offset of the offending range.
+        end: usize,
+        /// Length of the buffer the range was applied to.
+        buffer_len: usize,
+    },
 }
 
 /// Errors that occur during FIX message encoding.
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum EncodeError {
     /// Buffer capacity exceeded during encoding.
     #[error("buffer overflow: need {needed} bytes, have {available}")]
@@ -162,6 +206,7 @@ pub enum EncodeError {
 
 /// Errors in FIX session layer operations.
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum SessionError {
     /// Session is not in the correct state for the operation.
     #[error("invalid session state: expected {expected}, current {current}")]
@@ -233,6 +278,7 @@ pub enum SessionError {
 
 /// Errors in message store operations.
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum StoreError {
     /// Failed to store message.
     #[error("failed to store message seq={seq_num}: {reason}")]

--- a/ironfix-core/src/error.rs
+++ b/ironfix-core/src/error.rs
@@ -131,11 +131,12 @@ pub enum DecodeError {
         tag: u32,
     },
 
-    /// A Length/Data field pair declares a byte count the buffer cannot satisfy.
+    /// A Length/Data field pair declares a byte count the frame cannot satisfy.
     ///
     /// Raised when the count declared by a `LENGTH` field (for example
-    /// `RawDataLength`, tag 95) runs past the end of the buffer, or when the
-    /// byte at the declared end of the `DATA` field is not the SOH delimiter.
+    /// `RawDataLength`, tag 95) runs past what the field may consume, or when
+    /// the byte at the declared end of the `DATA` field is not the SOH
+    /// delimiter.
     #[error(
         "data field {data_tag} declares {declared} bytes not terminated by SOH within {available} remaining bytes"
     )]
@@ -144,7 +145,9 @@ pub enum DecodeError {
         data_tag: u32,
         /// The byte count declared by the paired `LENGTH` field.
         declared: usize,
-        /// Bytes actually available after the `=` delimiter.
+        /// Bytes the field was allowed to consume: what remains after the `=`
+        /// delimiter, bounded by the frame's declared body end when decoding a
+        /// whole message. The terminating SOH must fall inside this.
         available: usize,
     },
 

--- a/ironfix-core/src/message.rs
+++ b/ironfix-core/src/message.rs
@@ -323,13 +323,22 @@ impl fmt::Display for MsgType {
 /// This struct holds references to the original message buffer,
 /// avoiding allocation during parsing. Fields are stored as
 /// offset ranges into the buffer.
+///
+/// # Range convention
+///
+/// **Every stored range is relative to `buffer`, not to whatever larger buffer
+/// the message may have been decoded from.** A decoder that reads several
+/// messages out of one input must rebase its offsets by the start of the
+/// current message before constructing a `RawMessage`; [`RawMessage::new`]
+/// rejects any range that does not lie within `buffer`.
 #[derive(Debug, Clone)]
 pub struct RawMessage<'a> {
     /// The complete message buffer.
     buffer: &'a [u8],
-    /// Range of the BeginString field value.
+    /// Range of the BeginString field value, relative to `buffer`.
     begin_string: Range<usize>,
-    /// Range of the message body (after BodyLength, before checksum).
+    /// Range of the message body (after BodyLength, before checksum),
+    /// relative to `buffer`.
     body: Range<usize>,
     /// The parsed message type.
     msg_type: MsgType,
@@ -337,30 +346,51 @@ pub struct RawMessage<'a> {
     fields: SmallVec<[FieldRef<'a>; 32]>,
 }
 
+/// Validates that `range` is well ordered and lies within `buffer_len` bytes.
+#[inline]
+fn check_range(range: &Range<usize>, buffer_len: usize) -> Result<(), DecodeError> {
+    if range.start > range.end || range.end > buffer_len {
+        return Err(DecodeError::RangeOutOfBounds {
+            start: range.start,
+            end: range.end,
+            buffer_len,
+        });
+    }
+    Ok(())
+}
+
 impl<'a> RawMessage<'a> {
     /// Creates a new RawMessage from parsed components.
     ///
     /// # Arguments
     /// * `buffer` - The complete message buffer
-    /// * `begin_string` - Range of the BeginString value
-    /// * `body` - Range of the message body
+    /// * `begin_string` - Range of the BeginString value, relative to `buffer`
+    /// * `body` - Range of the message body, relative to `buffer`
     /// * `msg_type` - The parsed message type
     /// * `fields` - Parsed field references
-    #[must_use]
+    ///
+    /// # Errors
+    /// Returns [`DecodeError::RangeOutOfBounds`] if `begin_string` or `body`
+    /// is inverted or does not lie within `buffer`. Every offset here derives
+    /// from attacker-supplied bytes, so the bounds are checked once at
+    /// construction rather than at every accessor.
     pub fn new(
         buffer: &'a [u8],
         begin_string: Range<usize>,
         body: Range<usize>,
         msg_type: MsgType,
         fields: SmallVec<[FieldRef<'a>; 32]>,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, DecodeError> {
+        check_range(&begin_string, buffer.len())?;
+        check_range(&body, buffer.len())?;
+
+        Ok(Self {
             buffer,
             begin_string,
             body,
             msg_type,
             fields,
-        }
+        })
     }
 
     /// Returns the complete message buffer.
@@ -371,9 +401,46 @@ impl<'a> RawMessage<'a> {
     }
 
     /// Returns the BeginString value (e.g., "FIX.4.4").
-    #[must_use]
-    pub fn begin_string(&self) -> &'a str {
-        std::str::from_utf8(&self.buffer[self.begin_string.clone()]).unwrap_or("")
+    ///
+    /// # Errors
+    /// Returns [`DecodeError::InvalidUtf8`] if the BeginString bytes are not
+    /// valid UTF-8, or [`DecodeError::RangeOutOfBounds`] if the stored range
+    /// escapes the buffer. The value is never silently defaulted to `""`.
+    pub fn begin_string(&self) -> Result<&'a str, DecodeError> {
+        let range = self.begin_string.clone();
+        debug_assert!(
+            range.end <= self.buffer.len(),
+            "RawMessage ranges must be buffer-relative"
+        );
+        let bytes = self
+            .buffer
+            .get(range.clone())
+            .ok_or(DecodeError::RangeOutOfBounds {
+                start: range.start,
+                end: range.end,
+                buffer_len: self.buffer.len(),
+            })?;
+        std::str::from_utf8(bytes).map_err(DecodeError::from)
+    }
+
+    /// Returns the message body bytes (after BodyLength, before the checksum).
+    ///
+    /// # Errors
+    /// Returns [`DecodeError::RangeOutOfBounds`] if the stored range escapes
+    /// the buffer.
+    pub fn body(&self) -> Result<&'a [u8], DecodeError> {
+        let range = self.body.clone();
+        debug_assert!(
+            range.end <= self.buffer.len(),
+            "RawMessage ranges must be buffer-relative"
+        );
+        self.buffer
+            .get(range.clone())
+            .ok_or(DecodeError::RangeOutOfBounds {
+                start: range.start,
+                end: range.end,
+                buffer_len: self.buffer.len(),
+            })
     }
 
     /// Returns the message type.
@@ -549,13 +616,14 @@ impl OwnedMessage {
     /// * `tag` - The field tag number
     ///
     /// # Returns
-    /// The field value bytes, or `None` if not found.
+    /// The field value bytes, or `None` if not found or if the stored offset
+    /// escapes the buffer.
     #[must_use]
     pub fn get_field(&self, tag: u32) -> Option<&[u8]> {
         self.field_offsets
             .iter()
             .find(|(t, _)| *t == tag)
-            .map(|(_, range)| &self.buffer[range.clone()])
+            .and_then(|(_, range)| self.buffer.get(range.clone()))
     }
 
     /// Gets a field value as a string.
@@ -618,10 +686,10 @@ mod tests {
 
     #[test]
     fn test_msg_type_from_str() {
-        assert_eq!("0".parse::<MsgType>().unwrap(), MsgType::Heartbeat);
-        assert_eq!("A".parse::<MsgType>().unwrap(), MsgType::Logon);
-        assert_eq!("D".parse::<MsgType>().unwrap(), MsgType::NewOrderSingle);
-        assert_eq!("8".parse::<MsgType>().unwrap(), MsgType::ExecutionReport);
+        assert_eq!("0".parse::<MsgType>(), Ok(MsgType::Heartbeat));
+        assert_eq!("A".parse::<MsgType>(), Ok(MsgType::Logon));
+        assert_eq!("D".parse::<MsgType>(), Ok(MsgType::NewOrderSingle));
+        assert_eq!("8".parse::<MsgType>(), Ok(MsgType::ExecutionReport));
     }
 
     #[test]
@@ -642,9 +710,88 @@ mod tests {
 
     #[test]
     fn test_msg_type_custom() {
-        let custom: MsgType = "XX".parse().unwrap();
-        assert!(matches!(custom, MsgType::Custom(_)));
+        let custom = MsgType::Custom("XX".to_string());
+        assert_eq!("XX".parse::<MsgType>(), Ok(custom.clone()));
         assert_eq!(custom.as_str(), "XX");
+    }
+
+    /// Builds the field list for a one-field `RawMessage` over `buffer`.
+    fn single_field(buffer: &[u8]) -> SmallVec<[FieldRef<'_>; 32]> {
+        let mut fields = SmallVec::new();
+        fields.push(FieldRef::new(8, buffer));
+        fields
+    }
+
+    #[test]
+    fn test_raw_message_new_rejects_begin_string_range_past_buffer() {
+        let buffer: &[u8] = b"8=FIX.4.4\x01";
+        let fields = single_field(buffer);
+        let result = RawMessage::new(buffer, 2..64, 0..0, MsgType::Heartbeat, fields);
+        assert_eq!(
+            result.err(),
+            Some(DecodeError::RangeOutOfBounds {
+                start: 2,
+                end: 64,
+                buffer_len: buffer.len(),
+            })
+        );
+    }
+
+    #[test]
+    fn test_raw_message_new_rejects_body_range_past_buffer() {
+        let buffer: &[u8] = b"8=FIX.4.4\x01";
+        let fields = single_field(buffer);
+        let result = RawMessage::new(buffer, 2..9, 0..11, MsgType::Heartbeat, fields);
+        assert!(matches!(
+            result.err(),
+            Some(DecodeError::RangeOutOfBounds { .. })
+        ));
+    }
+
+    #[test]
+    fn test_raw_message_new_rejects_inverted_range() {
+        let buffer: &[u8] = b"8=FIX.4.4\x01";
+        let fields = single_field(buffer);
+        // Built via the struct literal: `9..2` as a literal range trips
+        // `clippy::reversed_empty_ranges` before it can reach the check.
+        let inverted = Range { start: 9, end: 2 };
+        let result = RawMessage::new(buffer, inverted, 0..0, MsgType::Heartbeat, fields);
+        assert!(matches!(
+            result.err(),
+            Some(DecodeError::RangeOutOfBounds { .. })
+        ));
+    }
+
+    #[test]
+    fn test_raw_message_begin_string_and_body_are_buffer_relative() {
+        let buffer: &[u8] = b"8=FIX.4.4\x0135=0\x01";
+        let fields = single_field(buffer);
+        let Ok(msg) = RawMessage::new(buffer, 2..9, 10..15, MsgType::Heartbeat, fields) else {
+            panic!("in-bounds ranges must be accepted");
+        };
+        assert_eq!(msg.begin_string(), Ok("FIX.4.4"));
+        assert_eq!(msg.body(), Ok(&b"35=0\x01"[..]));
+        assert_eq!(msg.len(), buffer.len());
+    }
+
+    #[test]
+    fn test_raw_message_begin_string_invalid_utf8_is_typed_error() {
+        let buffer: &[u8] = b"8=\xff\xfe\x01";
+        let fields = single_field(buffer);
+        let Ok(msg) = RawMessage::new(buffer, 2..4, 0..0, MsgType::Heartbeat, fields) else {
+            panic!("in-bounds ranges must be accepted");
+        };
+        assert!(matches!(
+            msg.begin_string(),
+            Err(DecodeError::InvalidUtf8(_))
+        ));
+    }
+
+    #[test]
+    fn test_owned_message_get_field_out_of_bounds_offset_returns_none() {
+        let buffer = Bytes::from_static(b"8=FIX.4.4\x01");
+        let msg = OwnedMessage::new(buffer, MsgType::Heartbeat, vec![(8, 2..64)]);
+        assert_eq!(msg.get_field(8), None);
     }
 
     #[test]

--- a/ironfix-tagvalue/src/checksum.rs
+++ b/ironfix-tagvalue/src/checksum.rs
@@ -33,9 +33,13 @@ pub fn calculate_checksum(data: &[u8]) -> u8 {
 }
 
 /// Portable checksum calculation without SIMD.
+///
+/// The accumulator is `u64`: a `u32` overflows (and panics under the debug
+/// overflow checks) once the input exceeds roughly 16.8 MB of 0xFF bytes,
+/// which is a reachable size for a `RawData`-carrying message.
 #[inline]
 fn calculate_checksum_portable(data: &[u8]) -> u8 {
-    let sum: u32 = data.iter().map(|&b| b as u32).sum();
+    let sum: u64 = data.iter().map(|&b| u64::from(b)).sum();
     (sum % 256) as u8
 }
 
@@ -98,14 +102,25 @@ mod tests {
     #[test]
     fn test_calculate_checksum_simple() {
         let data = b"ABC";
-        let expected = (b'A' as u32 + b'B' as u32 + b'C' as u32) % 256;
+        let expected = (u32::from(b'A') + u32::from(b'B') + u32::from(b'C')) % 256;
         assert_eq!(calculate_checksum(data), expected as u8);
+    }
+
+    #[test]
+    fn test_calculate_checksum_large_input_does_not_overflow() {
+        // A `u32` accumulator overflows past ~16.8 MB of 0xFF bytes and panics
+        // under debug overflow checks. The size is deliberately not a multiple
+        // of 256 so a wrong fold cannot coincidentally produce 0.
+        let len = 17 * 1024 * 1024 + 7;
+        let data = vec![0xFFu8; len];
+        let expected = ((0xFFu64 * len as u64) % 256) as u8;
+        assert_eq!(calculate_checksum(&data), expected);
     }
 
     #[test]
     fn test_calculate_checksum_overflow() {
         let data = vec![255u8; 1000];
-        let expected = ((255u32 * 1000) % 256) as u8;
+        let expected = ((255u64 * 1000) % 256) as u8;
         assert_eq!(calculate_checksum(&data), expected);
     }
 

--- a/ironfix-tagvalue/src/checksum.rs
+++ b/ironfix-tagvalue/src/checksum.rs
@@ -35,8 +35,10 @@ pub fn calculate_checksum(data: &[u8]) -> u8 {
 /// Portable checksum calculation without SIMD.
 ///
 /// The accumulator is `u64`: a `u32` overflows (and panics under the debug
-/// overflow checks) once the input exceeds roughly 16.8 MB of 0xFF bytes,
-/// which is a reachable size for a `RawData`-carrying message.
+/// overflow checks) once the input exceeds roughly 16.8 MB of 0xFF bytes.
+/// The transport caps frames well below that by default, so this is not
+/// reachable through the codec — it is reachable by calling this function
+/// directly on a caller-supplied buffer, which is a public API.
 #[inline]
 fn calculate_checksum_portable(data: &[u8]) -> u8 {
     let sum: u64 = data.iter().map(|&b| u64::from(b)).sum();

--- a/ironfix-tagvalue/src/decoder.rs
+++ b/ironfix-tagvalue/src/decoder.rs
@@ -9,6 +9,11 @@
 //! This module provides a high-performance decoder that parses FIX messages
 //! without allocating memory for field values. Field values are returned as
 //! references to the original buffer.
+//!
+//! The decoder is an untrusted-input parser: every length and offset is
+//! attacker-controlled, so all arithmetic is checked, every slice is taken
+//! with [`slice::get`], and every malformed frame maps to a typed
+//! [`DecodeError`] instead of a panic or a silent default.
 
 use crate::checksum::{calculate_checksum, parse_checksum};
 use ironfix_core::error::DecodeError;
@@ -16,12 +21,97 @@ use ironfix_core::field::FieldRef;
 use ironfix_core::message::{MsgType, RawMessage};
 use memchr::memchr;
 use smallvec::SmallVec;
+use std::ops::Range;
 
 /// SOH (Start of Header) delimiter used in FIX messages.
 pub const SOH: u8 = 0x01;
 
 /// Equals sign delimiter between tag and value.
 pub const EQUALS: u8 = b'=';
+
+/// Maximum number of digits accepted in a tag number.
+const MAX_TAG_DIGITS: usize = 10;
+
+/// Maximum number of digits accepted in a `LENGTH` field value.
+const MAX_LENGTH_DIGITS: usize = 10;
+
+/// Maximum number of input bytes echoed back in an error message.
+///
+/// The offending bytes are attacker-controlled, so the diagnostic string is
+/// bounded rather than sized from the input.
+const MAX_TAG_DIAGNOSTIC_LEN: usize = 16;
+
+/// Spec-defined `(length_tag, data_tag)` pairs.
+///
+/// A FIX `DATA` field is a counted byte string whose content may legally
+/// contain SOH and `=`; it is always immediately preceded by its `LENGTH`
+/// field. Scanning such a value for SOH truncates it and injects phantom
+/// fields from its payload, so the decoder frames it by the declared count
+/// instead.
+///
+/// This is FIX **wire syntax** — a fixed, spec-defined tag set taken from the
+/// FIX 4.4 specification — not schema. Resolving it must never require a
+/// dictionary lookup: `ironfix-tagvalue` stays independent of
+/// `ironfix-dictionary`.
+const LENGTH_DATA_PAIRS: [(u32, u32); 16] = [
+    (90, 91),   // SecureDataLen / SecureData
+    (93, 89),   // SignatureLength / Signature
+    (95, 96),   // RawDataLength / RawData
+    (212, 213), // XmlDataLen / XmlData
+    (348, 349), // EncodedIssuerLen / EncodedIssuer
+    (350, 351), // EncodedSecurityDescLen / EncodedSecurityDesc
+    (352, 353), // EncodedListExecInstLen / EncodedListExecInst
+    (354, 355), // EncodedTextLen / EncodedText
+    (356, 357), // EncodedSubjectLen / EncodedSubject
+    (358, 359), // EncodedHeadlineLen / EncodedHeadline
+    (360, 361), // EncodedAllocTextLen / EncodedAllocText
+    (362, 363), // EncodedUnderlyingIssuerLen / EncodedUnderlyingIssuer
+    (364, 365), // EncodedUnderlyingSecurityDescLen / EncodedUnderlyingSecurityDesc
+    (445, 446), // EncodedListStatusTextLen / EncodedListStatusText
+    (618, 619), // EncodedLegIssuerLen / EncodedLegIssuer
+    (621, 622), // EncodedLegSecurityDescLen / EncodedLegSecurityDesc
+];
+
+/// Lowest length tag in [`LENGTH_DATA_PAIRS`].
+///
+/// Kept in sync with the table by `test_length_tag_bounds_match_table`.
+const MIN_LENGTH_TAG: u32 = 90;
+
+/// Highest length tag in [`LENGTH_DATA_PAIRS`].
+///
+/// Kept in sync with the table by `test_length_tag_bounds_match_table`.
+const MAX_LENGTH_TAG: u32 = 621;
+
+/// Returns the `DATA` tag paired with `length_tag`, if any.
+#[inline]
+#[must_use]
+const fn paired_data_tag(length_tag: u32) -> Option<u32> {
+    // Every field runs through here, and the session header tags (8, 9, 34,
+    // 35, 49, 52, 56) all fall below the table, so reject out-of-range tags
+    // before walking it.
+    if length_tag < MIN_LENGTH_TAG || length_tag > MAX_LENGTH_TAG {
+        return None;
+    }
+
+    let mut i = 0;
+    while i < LENGTH_DATA_PAIRS.len() {
+        let (len_tag, data_tag) = LENGTH_DATA_PAIRS[i];
+        if len_tag == length_tag {
+            return Some(data_tag);
+        }
+        i += 1;
+    }
+    None
+}
+
+/// A `DATA` field announced by the `LENGTH` field just consumed.
+#[derive(Debug, Clone, Copy)]
+struct PendingData {
+    /// Tag of the `DATA` field expected next.
+    data_tag: u32,
+    /// Byte count declared by the `LENGTH` field.
+    declared: usize,
+}
 
 /// Zero-copy FIX message decoder.
 ///
@@ -35,6 +125,8 @@ pub struct Decoder<'a> {
     offset: usize,
     /// Whether to validate checksums.
     validate_checksum: bool,
+    /// `DATA` field framing announced by the previous `LENGTH` field.
+    pending_data: Option<PendingData>,
 }
 
 impl<'a> Decoder<'a> {
@@ -49,6 +141,7 @@ impl<'a> Decoder<'a> {
             input,
             offset: 0,
             validate_checksum: true,
+            pending_data: None,
         }
     }
 
@@ -65,26 +158,31 @@ impl<'a> Decoder<'a> {
 
     /// Decodes a complete FIX message from the buffer.
     ///
+    /// The decoder can be called repeatedly to read consecutive messages out
+    /// of a single buffer; the ranges stored in the returned [`RawMessage`]
+    /// are relative to that message's own slice, not to the whole input.
+    ///
     /// # Returns
     /// A `RawMessage` containing zero-copy references to the parsed fields.
     ///
     /// # Errors
     /// Returns `DecodeError` if the message is malformed or incomplete.
+    /// Structural garbage after the last field is an error even when checksum
+    /// validation is disabled — it is never silently discarded.
     pub fn decode(&mut self) -> Result<RawMessage<'a>, DecodeError> {
         let start_offset = self.offset;
+        // Length/Data framing never carries across a message boundary.
+        self.pending_data = None;
 
         // Parse BeginString (tag 8)
-        let begin_string_field = self.next_field().ok_or(DecodeError::Incomplete)?;
+        let begin_string_field = self.next_field()?.ok_or(DecodeError::Incomplete)?;
         if begin_string_field.tag != 8 {
             return Err(DecodeError::InvalidBeginString);
         }
-        let begin_string_start =
-            begin_string_field.value.as_ptr() as usize - self.input.as_ptr() as usize;
-        let begin_string_end = begin_string_start + begin_string_field.value.len();
-        let begin_string = begin_string_start..begin_string_end;
+        let begin_string = self.value_range(start_offset, begin_string_field.value.len())?;
 
         // Parse BodyLength (tag 9)
-        let body_length_field = self.next_field().ok_or(DecodeError::MissingBodyLength)?;
+        let body_length_field = self.next_field()?.ok_or(DecodeError::MissingBodyLength)?;
         if body_length_field.tag != 9 {
             return Err(DecodeError::MissingBodyLength);
         }
@@ -97,11 +195,16 @@ impl<'a> Decoder<'a> {
         let body_start = self.offset;
 
         // Parse MsgType (tag 35) - should be first field in body
-        let msg_type_field = self.next_field().ok_or(DecodeError::MissingMsgType)?;
+        let msg_type_field = self.next_field()?.ok_or(DecodeError::MissingMsgType)?;
         if msg_type_field.tag != 35 {
             return Err(DecodeError::MissingMsgType);
         }
-        let msg_type: MsgType = msg_type_field.as_str()?.parse().unwrap();
+        // `MsgType: FromStr` is infallible (unknown values become `Custom`),
+        // so the error arm is uninhabited rather than unwrapped.
+        let msg_type: MsgType = match msg_type_field.as_str()?.parse() {
+            Ok(parsed) => parsed,
+            Err(never) => match never {},
+        };
 
         // Collect all fields
         let mut fields: SmallVec<[FieldRef<'a>; 32]> = SmallVec::new();
@@ -117,7 +220,10 @@ impl<'a> Decoder<'a> {
         let mut checksum_field_start = self.offset;
         loop {
             let field_start = self.offset;
-            let Some(field) = self.next_field() else {
+            // `?` here is the point of the exercise: a missing `=`, a
+            // non-numeric tag or an unterminated value is an error, not a
+            // clean end of buffer.
+            let Some(field) = self.next_field()? else {
                 break;
             };
             if field.tag == 10 {
@@ -139,7 +245,14 @@ impl<'a> Decoder<'a> {
             })?;
 
             // Calculate checksum of everything before the checksum field
-            let calculated = calculate_checksum(&self.input[start_offset..checksum_field_start]);
+            let span = self.input.get(start_offset..checksum_field_start).ok_or(
+                DecodeError::RangeOutOfBounds {
+                    start: start_offset,
+                    end: checksum_field_start,
+                    buffer_len: self.input.len(),
+                },
+            )?;
+            let calculated = calculate_checksum(span);
 
             if calculated != declared {
                 return Err(DecodeError::ChecksumMismatch {
@@ -163,44 +276,133 @@ impl<'a> Decoder<'a> {
         } else if body_end > self.offset {
             return Err(DecodeError::InvalidBodyLength);
         }
-        let body = body_start..body_end;
 
-        Ok(RawMessage::new(
-            &self.input[start_offset..self.offset],
-            begin_string,
-            body,
-            msg_type,
-            fields,
-        ))
+        // `RawMessage` ranges are relative to the message slice, so both
+        // ranges are rebased by the offset this message started at.
+        let body = rebase(body_start..body_end, start_offset, self.input.len())?;
+
+        let buffer =
+            self.input
+                .get(start_offset..self.offset)
+                .ok_or(DecodeError::RangeOutOfBounds {
+                    start: start_offset,
+                    end: self.offset,
+                    buffer_len: self.input.len(),
+                })?;
+
+        RawMessage::new(buffer, begin_string, body, msg_type, fields)
     }
 
     /// Parses the next field from the buffer.
     ///
+    /// A field is `tag=value<SOH>`. A value belonging to a spec-defined `DATA`
+    /// tag is framed by the count declared in the `LENGTH` field immediately
+    /// before it, so it may legally contain SOH and `=`.
+    ///
     /// # Returns
-    /// The next field, or `None` if the buffer is exhausted.
+    /// `Ok(None)` when the buffer is cleanly exhausted, `Ok(Some(field))`
+    /// otherwise.
+    ///
+    /// # Errors
+    /// * [`DecodeError::InvalidTag`] - the tag is empty, non-numeric, too long,
+    ///   or the field has no `=` delimiter.
+    /// * [`DecodeError::UnterminatedField`] - the value is not terminated by
+    ///   SOH.
+    /// * [`DecodeError::InvalidDataLength`] - a `LENGTH` field declares a count
+    ///   the remaining buffer cannot satisfy.
+    /// * [`DecodeError::InvalidFieldValue`] - a `LENGTH` field value is not a
+    ///   valid byte count.
     #[inline]
-    pub fn next_field(&mut self) -> Option<FieldRef<'a>> {
-        if self.offset >= self.input.len() {
-            return None;
+    pub fn next_field(&mut self) -> Result<Option<FieldRef<'a>>, DecodeError> {
+        // `offset` never exceeds `input.len()`, so a `None` here is exhaustion.
+        let Some(remaining) = self.input.get(self.offset..) else {
+            return Ok(None);
+        };
+        if remaining.is_empty() {
+            return Ok(None);
         }
 
-        let remaining = &self.input[self.offset..];
-
         // Find '=' delimiter using SIMD-accelerated search
-        let eq_pos = memchr(EQUALS, remaining)?;
-        let tag_bytes = &remaining[..eq_pos];
+        let eq_pos = memchr(EQUALS, remaining).ok_or_else(|| invalid_tag(remaining))?;
+        let tag_bytes = remaining
+            .get(..eq_pos)
+            .ok_or_else(|| invalid_tag(remaining))?;
+        let tag = parse_tag(tag_bytes).ok_or_else(|| invalid_tag(tag_bytes))?;
 
-        // Parse tag number
-        let tag = parse_tag(tag_bytes)?;
+        let value_start = eq_pos
+            .checked_add(1)
+            .ok_or(DecodeError::UnterminatedField { tag })?;
+        let value_bytes = remaining
+            .get(value_start..)
+            .ok_or(DecodeError::UnterminatedField { tag })?;
 
-        // Find SOH delimiter
-        let value_start = eq_pos + 1;
-        let soh_pos = memchr(SOH, &remaining[value_start..])?;
-        let value = &remaining[value_start..value_start + soh_pos];
+        // A `DATA` field announced by the preceding `LENGTH` field is consumed
+        // by count. Taking the state unconditionally means it never leaks past
+        // the field it describes.
+        let counted = match self.pending_data.take() {
+            Some(pending) if pending.data_tag == tag => Some(pending.declared),
+            _ => None,
+        };
 
-        self.offset += value_start + soh_pos + 1;
+        let value_len = match counted {
+            // `declared` is attacker-controlled: probe the byte at the declared
+            // end before slicing, so an oversized count is a typed error with
+            // no allocation and no panic.
+            Some(declared) => match value_bytes.get(declared) {
+                Some(&SOH) => declared,
+                _ => {
+                    return Err(DecodeError::InvalidDataLength {
+                        data_tag: tag,
+                        declared,
+                        available: value_bytes.len(),
+                    });
+                }
+            },
+            None => memchr(SOH, value_bytes).ok_or(DecodeError::UnterminatedField { tag })?,
+        };
 
-        Some(FieldRef::new(tag, value))
+        let value = value_bytes
+            .get(..value_len)
+            .ok_or(DecodeError::UnterminatedField { tag })?;
+
+        // Consume `tag=value<SOH>`.
+        let consumed = value_start
+            .checked_add(value_len)
+            .and_then(|end| end.checked_add(1))
+            .ok_or(DecodeError::UnterminatedField { tag })?;
+        self.offset = self
+            .offset
+            .checked_add(consumed)
+            .ok_or(DecodeError::UnterminatedField { tag })?;
+
+        // Remember a `LENGTH` field so the paired `DATA` field is framed by
+        // count rather than by an SOH scan.
+        if let Some(data_tag) = paired_data_tag(tag) {
+            let declared = parse_length(value).ok_or_else(|| invalid_length(tag))?;
+            self.pending_data = Some(PendingData { data_tag, declared });
+        }
+
+        Ok(Some(FieldRef::new(tag, value)))
+    }
+
+    /// Returns the buffer-relative range of the value of the field just
+    /// consumed, for a message that starts at `message_start`.
+    ///
+    /// The decoder has consumed `tag=value<SOH>`, so the value ends one byte
+    /// before the current offset.
+    fn value_range(
+        &self,
+        message_start: usize,
+        value_len: usize,
+    ) -> Result<Range<usize>, DecodeError> {
+        let out_of_bounds = || DecodeError::RangeOutOfBounds {
+            start: message_start,
+            end: self.offset,
+            buffer_len: self.input.len(),
+        };
+        let value_end = self.offset.checked_sub(1).ok_or_else(out_of_bounds)?;
+        let value_start = value_end.checked_sub(value_len).ok_or_else(out_of_bounds)?;
+        rebase(value_start..value_end, message_start, self.input.len())
     }
 
     /// Returns the current offset in the buffer.
@@ -214,7 +416,8 @@ impl<'a> Decoder<'a> {
     #[inline]
     #[must_use]
     pub fn remaining(&self) -> &'a [u8] {
-        &self.input[self.offset..]
+        // `offset` is only ever advanced to a position inside the buffer.
+        self.input.get(self.offset..).unwrap_or(&[])
     }
 
     /// Returns true if the buffer has been fully consumed.
@@ -228,6 +431,56 @@ impl<'a> Decoder<'a> {
     #[inline]
     pub fn reset(&mut self) {
         self.offset = 0;
+        self.pending_data = None;
+    }
+}
+
+/// Rebases an absolute range into one relative to `message_start`.
+#[inline]
+fn rebase(
+    range: Range<usize>,
+    message_start: usize,
+    buffer_len: usize,
+) -> Result<Range<usize>, DecodeError> {
+    let out_of_bounds = || DecodeError::RangeOutOfBounds {
+        start: range.start,
+        end: range.end,
+        buffer_len,
+    };
+    let start = range
+        .start
+        .checked_sub(message_start)
+        .ok_or_else(out_of_bounds)?;
+    let end = range
+        .end
+        .checked_sub(message_start)
+        .ok_or_else(out_of_bounds)?;
+    Ok(start..end)
+}
+
+/// Builds a [`DecodeError::InvalidTag`] with a bounded diagnostic.
+///
+/// Kept out of line: it allocates, and it is called from `ok_or_else` closures
+/// inside `next_field`, the hottest function in the crate. Inlining it would
+/// pull the UTF-8 validation and allocator sequence into the scan loop's
+/// instruction-cache footprint.
+#[cold]
+#[inline(never)]
+fn invalid_tag(bytes: &[u8]) -> DecodeError {
+    let shown = bytes.get(..MAX_TAG_DIAGNOSTIC_LEN).unwrap_or(bytes);
+    DecodeError::InvalidTag(String::from_utf8_lossy(shown).into_owned())
+}
+
+/// Builds a [`DecodeError::InvalidFieldValue`] for an unparseable `LENGTH`
+/// field value.
+///
+/// Out of line for the same reason as [`invalid_tag`].
+#[cold]
+#[inline(never)]
+fn invalid_length(tag: u32) -> DecodeError {
+    DecodeError::InvalidFieldValue {
+        tag,
+        reason: "length field value is not a valid byte count".to_string(),
     }
 }
 
@@ -240,7 +493,7 @@ impl<'a> Decoder<'a> {
 /// The parsed tag number, or `None` if invalid.
 #[inline]
 fn parse_tag(bytes: &[u8]) -> Option<u32> {
-    if bytes.is_empty() || bytes.len() > 10 {
+    if bytes.is_empty() || bytes.len() > MAX_TAG_DIGITS {
         return None;
     }
 
@@ -249,7 +502,29 @@ fn parse_tag(bytes: &[u8]) -> Option<u32> {
         if !b.is_ascii_digit() {
             return None;
         }
-        result = result.checked_mul(10)?.checked_add((b - b'0') as u32)?;
+        result = result.checked_mul(10)?.checked_add(u32::from(b - b'0'))?;
+    }
+
+    Some(result)
+}
+
+/// Parses a `LENGTH` field value (a byte count) from ASCII bytes.
+///
+/// # Returns
+/// The declared count, or `None` if the value is empty, non-numeric, too long,
+/// or overflows `usize`.
+#[inline]
+fn parse_length(bytes: &[u8]) -> Option<usize> {
+    if bytes.is_empty() || bytes.len() > MAX_LENGTH_DIGITS {
+        return None;
+    }
+
+    let mut result: usize = 0;
+    for &b in bytes {
+        if !b.is_ascii_digit() {
+            return None;
+        }
+        result = result.checked_mul(10)?.checked_add(usize::from(b - b'0'))?;
     }
 
     Some(result)
@@ -258,6 +533,24 @@ fn parse_tag(bytes: &[u8]) -> Option<u32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Builds a well-formed frame around `body` with a valid trailing checksum.
+    fn build_frame(body: &[u8]) -> Vec<u8> {
+        build_frame_with_begin_string(b"FIX.4.4", body)
+    }
+
+    /// Builds a well-formed frame with an arbitrary BeginString value.
+    fn build_frame_with_begin_string(begin_string: &[u8], body: &[u8]) -> Vec<u8> {
+        let mut msg = Vec::with_capacity(body.len() + 32);
+        msg.extend_from_slice(b"8=");
+        msg.extend_from_slice(begin_string);
+        msg.push(SOH);
+        msg.extend_from_slice(format!("9={}\x01", body.len()).as_bytes());
+        msg.extend_from_slice(body);
+        let sum: u64 = msg.iter().map(|&b| u64::from(b)).sum();
+        msg.extend_from_slice(format!("10={:03}\x01", (sum % 256) as u8).as_bytes());
+        msg
+    }
 
     #[test]
     fn test_parse_tag() {
@@ -270,37 +563,122 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_length_rejects_hostile_values() {
+        assert_eq!(parse_length(b"0"), Some(0));
+        assert_eq!(parse_length(b"7"), Some(7));
+        assert_eq!(parse_length(b""), None);
+        assert_eq!(parse_length(b"-1"), None);
+        assert_eq!(parse_length(b"1a"), None);
+        // More digits than a byte count can plausibly need.
+        assert_eq!(parse_length(b"99999999999999999999"), None);
+    }
+
+    #[test]
+    fn test_paired_data_tag_covers_spec_pairs() {
+        assert_eq!(paired_data_tag(95), Some(96));
+        assert_eq!(paired_data_tag(93), Some(89));
+        assert_eq!(paired_data_tag(90), Some(91));
+        assert_eq!(paired_data_tag(354), Some(355));
+        assert_eq!(paired_data_tag(621), Some(622));
+        assert_eq!(paired_data_tag(35), None);
+        // No tag is both a length tag and a data tag.
+        for (_, data_tag) in LENGTH_DATA_PAIRS {
+            assert_eq!(paired_data_tag(data_tag), None);
+        }
+    }
+
+    #[test]
+    fn test_length_tag_bounds_match_table() {
+        // The fast-reject guard in `paired_data_tag` must never exclude a tag
+        // that is actually in the table.
+        let min = LENGTH_DATA_PAIRS.iter().map(|(len, _)| *len).min();
+        let max = LENGTH_DATA_PAIRS.iter().map(|(len, _)| *len).max();
+        assert_eq!(min, Some(MIN_LENGTH_TAG));
+        assert_eq!(max, Some(MAX_LENGTH_TAG));
+        for (length_tag, data_tag) in LENGTH_DATA_PAIRS {
+            assert_eq!(paired_data_tag(length_tag), Some(data_tag));
+        }
+    }
+
+    #[test]
     fn test_next_field() {
         let input = b"8=FIX.4.4\x019=5\x0135=0\x01";
         let mut decoder = Decoder::new(input);
 
-        let field1 = decoder.next_field().unwrap();
+        let Ok(Some(field1)) = decoder.next_field() else {
+            panic!("first field must parse");
+        };
         assert_eq!(field1.tag, 8);
-        assert_eq!(field1.as_str().unwrap(), "FIX.4.4");
+        assert_eq!(field1.as_str(), Ok("FIX.4.4"));
 
-        let field2 = decoder.next_field().unwrap();
+        let Ok(Some(field2)) = decoder.next_field() else {
+            panic!("second field must parse");
+        };
         assert_eq!(field2.tag, 9);
-        assert_eq!(field2.as_str().unwrap(), "5");
+        assert_eq!(field2.as_str(), Ok("5"));
 
-        let field3 = decoder.next_field().unwrap();
+        let Ok(Some(field3)) = decoder.next_field() else {
+            panic!("third field must parse");
+        };
         assert_eq!(field3.tag, 35);
-        assert_eq!(field3.as_str().unwrap(), "0");
+        assert_eq!(field3.as_str(), Ok("0"));
 
-        assert!(decoder.next_field().is_none());
+        assert!(matches!(decoder.next_field(), Ok(None)));
     }
 
     #[test]
     fn test_decoder_empty() {
         let mut decoder = Decoder::new(b"");
-        assert!(decoder.next_field().is_none());
+        assert!(matches!(decoder.next_field(), Ok(None)));
         assert!(decoder.is_empty());
     }
 
     #[test]
-    fn test_decoder_incomplete() {
+    fn test_next_field_missing_soh_is_unterminated_field() {
         let input = b"8=FIX.4.4";
         let mut decoder = Decoder::new(input);
-        assert!(decoder.next_field().is_none());
+        assert_eq!(
+            decoder.next_field().err(),
+            Some(DecodeError::UnterminatedField { tag: 8 })
+        );
+    }
+
+    #[test]
+    fn test_next_field_non_numeric_tag_is_invalid_tag() {
+        let mut decoder = Decoder::new(b"abc=1\x01");
+        let error = decoder.next_field().err();
+        assert!(matches!(error, Some(DecodeError::InvalidTag(_))));
+        assert_ne!(error, Some(DecodeError::Incomplete));
+    }
+
+    #[test]
+    fn test_next_field_missing_equals_is_invalid_tag() {
+        let mut decoder = Decoder::new(b"garbage-no-equals\x01");
+        let error = decoder.next_field().err();
+        assert!(matches!(error, Some(DecodeError::InvalidTag(_))));
+        assert_ne!(error, Some(DecodeError::Incomplete));
+    }
+
+    #[test]
+    fn test_next_field_invalid_tag_diagnostic_is_bounded() {
+        let mut input = vec![b'x'; 4096];
+        input.push(SOH);
+        let mut decoder = Decoder::new(&input);
+        match decoder.next_field() {
+            Err(DecodeError::InvalidTag(text)) => {
+                assert!(text.len() <= MAX_TAG_DIAGNOSTIC_LEN);
+            }
+            other => panic!("expected InvalidTag, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_next_field_empty_tag_is_invalid_tag() {
+        let mut decoder = Decoder::new(b"=value\x01");
+        assert!(matches!(
+            decoder.next_field(),
+            Err(DecodeError::InvalidTag(_))
+        ));
     }
 
     /// Builds a frame with the given BodyLength text (which may be hostile) and
@@ -311,7 +689,7 @@ mod tests {
         msg.extend_from_slice(b"8=FIX.4.4\x01");
         msg.extend_from_slice(format!("{body_length_tag}={body_length_text}\x01").as_bytes());
         msg.extend_from_slice(body);
-        let sum: u32 = msg.iter().map(|&b| u32::from(b)).sum();
+        let sum: u64 = msg.iter().map(|&b| u64::from(b)).sum();
         msg.extend_from_slice(format!("10={:03}\x01", (sum % 256) as u8).as_bytes());
         msg
     }
@@ -320,8 +698,8 @@ mod tests {
     fn test_decode_body_length_overflow_does_not_panic() {
         let msg = frame_with_body_length(&usize::MAX.to_string(), "9");
         assert_eq!(
-            Decoder::new(&msg).decode().unwrap_err(),
-            DecodeError::InvalidBodyLength
+            Decoder::new(&msg).decode().err(),
+            Some(DecodeError::InvalidBodyLength)
         );
     }
 
@@ -330,8 +708,8 @@ mod tests {
         // `parse_tag` folds digits numerically, so "009" is tag 9 here too.
         let msg = frame_with_body_length(&usize::MAX.to_string(), "009");
         assert_eq!(
-            Decoder::new(&msg).decode().unwrap_err(),
-            DecodeError::InvalidBodyLength
+            Decoder::new(&msg).decode().err(),
+            Some(DecodeError::InvalidBodyLength)
         );
     }
 
@@ -339,8 +717,8 @@ mod tests {
     fn test_decode_rejects_body_length_mismatch() {
         let msg = frame_with_body_length("5", "9");
         assert_eq!(
-            Decoder::new(&msg).decode().unwrap_err(),
-            DecodeError::InvalidBodyLength
+            Decoder::new(&msg).decode().err(),
+            Some(DecodeError::InvalidBodyLength)
         );
     }
 
@@ -348,7 +726,9 @@ mod tests {
     fn test_decode_accepts_correct_body_length() {
         let body = b"35=0\x0149=A\x0156=B\x0134=1\x0152=20240329-12:00:00\x01";
         let msg = frame_with_body_length(&body.len().to_string(), "9");
-        let decoded = Decoder::new(&msg).decode().expect("valid frame decodes");
+        let Ok(decoded) = Decoder::new(&msg).decode() else {
+            panic!("valid frame must decode");
+        };
         assert_eq!(*decoded.msg_type(), MsgType::Heartbeat);
     }
 
@@ -360,7 +740,7 @@ mod tests {
         msg.extend_from_slice(b"8=FIX.4.4\x01");
         msg.extend_from_slice(format!("9={}\x01", body.len()).as_bytes());
         msg.extend_from_slice(body);
-        let sum: u32 = msg.iter().map(|&b| u32::from(b)).sum();
+        let sum: u64 = msg.iter().map(|&b| u64::from(b)).sum();
         msg.extend_from_slice(format!("010={:03}\x01", (sum % 256) as u8).as_bytes());
         assert!(Decoder::new(&msg).decode().is_ok());
     }
@@ -375,5 +755,201 @@ mod tests {
         msg.extend_from_slice(body);
         msg.extend_from_slice(b"10=000\x01");
         assert!(Decoder::new(&msg).decode().is_err());
+    }
+
+    #[test]
+    fn test_decode_two_consecutive_frames_are_both_correct() {
+        let first_body: &[u8] = b"35=0\x0149=A\x0156=B\x01";
+        let second_body: &[u8] = b"35=A\x0149=CCCC\x0156=DDDD\x01";
+        let first_frame = build_frame(first_body);
+        let second_frame = build_frame(second_body);
+
+        let mut input = first_frame.clone();
+        input.extend_from_slice(&second_frame);
+
+        let mut decoder = Decoder::new(&input);
+
+        let Ok(first) = decoder.decode() else {
+            panic!("first frame must decode");
+        };
+        assert_eq!(first.begin_string(), Ok("FIX.4.4"));
+        assert_eq!(*first.msg_type(), MsgType::Heartbeat);
+        assert_eq!(first.body(), Ok(first_body));
+        assert_eq!(first.len(), first_frame.len());
+
+        // The second frame is where absolute ranges used to index out of
+        // bounds and abort the process.
+        let Ok(second) = decoder.decode() else {
+            panic!("second frame must decode");
+        };
+        assert_eq!(second.begin_string(), Ok("FIX.4.4"));
+        assert_eq!(*second.msg_type(), MsgType::Logon);
+        assert_eq!(second.body(), Ok(second_body));
+        assert_eq!(second.len(), second_frame.len());
+
+        // Both bodies must start after "8=FIX.4.4<SOH>9=<len><SOH>".
+        let expected_start = 10 + format!("9={}\x01", second_body.len()).len();
+        assert_eq!(
+            *second.body_range(),
+            expected_start..expected_start + second_body.len()
+        );
+
+        assert!(decoder.is_empty());
+    }
+
+    #[test]
+    fn test_decode_begin_string_invalid_utf8_is_typed_error() {
+        let msg = build_frame_with_begin_string(b"FIX\xff\xfe4", b"35=0\x01");
+        let Ok(decoded) = Decoder::new(&msg).decode() else {
+            panic!("frame with non-utf8 BeginString still frames");
+        };
+        assert!(matches!(
+            decoded.begin_string(),
+            Err(DecodeError::InvalidUtf8(_))
+        ));
+    }
+
+    #[test]
+    fn test_decode_raw_data_with_embedded_soh_and_equals_roundtrips() {
+        // 7 bytes carrying both an SOH and an '=' inside the value.
+        let raw_data: &[u8] = b"a\x01b=c\x01d";
+        let mut body = Vec::new();
+        body.extend_from_slice(b"35=A\x01");
+        body.extend_from_slice(b"95=7\x01");
+        body.extend_from_slice(b"96=");
+        body.extend_from_slice(raw_data);
+        body.push(SOH);
+        body.extend_from_slice(b"58=after\x01");
+        let msg = build_frame(&body);
+
+        let Ok(decoded) = Decoder::new(&msg).decode() else {
+            panic!("frame with RawData must decode");
+        };
+        let Some(field) = decoded.get_field(96) else {
+            panic!("RawData field must be present");
+        };
+        assert_eq!(field.value, raw_data);
+        // No phantom fields injected from inside the payload.
+        assert!(decoded.get_field(98).is_none());
+        assert_eq!(decoded.get_field_str(58), Some("after"));
+        // 8, 9, 35, 95, 96, 58
+        assert_eq!(decoded.field_count(), 6);
+    }
+
+    #[test]
+    fn test_decode_raw_data_truncated_payload_is_typed_error() {
+        // Declares 20 bytes but only 3 are present before the terminator.
+        let mut body = Vec::new();
+        body.extend_from_slice(b"35=A\x0195=20\x0196=abc\x01");
+        let msg = build_frame(&body);
+
+        assert_eq!(
+            Decoder::new(&msg).decode().err(),
+            Some(DecodeError::InvalidDataLength {
+                data_tag: 96,
+                declared: 20,
+                available: 11,
+            })
+        );
+    }
+
+    #[test]
+    fn test_decode_raw_data_hostile_length_is_typed_error() {
+        // A count far beyond the buffer must be rejected by a bounds probe,
+        // never by allocating `declared` bytes.
+        let mut body = Vec::new();
+        body.extend_from_slice(b"35=A\x0195=4294967295\x0196=abc\x01");
+        let msg = build_frame(&body);
+
+        assert!(matches!(
+            Decoder::new(&msg).decode(),
+            Err(DecodeError::InvalidDataLength {
+                data_tag: 96,
+                declared: 4_294_967_295,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn test_decode_raw_data_length_mismatch_not_on_soh_is_rejected() {
+        // Declares 2 bytes for a 3-byte payload: the declared end is not SOH.
+        let msg = build_frame(b"35=A\x0195=2\x0196=abc\x01");
+        assert!(matches!(
+            Decoder::new(&msg).decode(),
+            Err(DecodeError::InvalidDataLength { data_tag: 96, .. })
+        ));
+    }
+
+    #[test]
+    fn test_decode_non_numeric_length_field_is_typed_error() {
+        let msg = build_frame(b"35=A\x0195=abc\x0196=x\x01");
+        assert!(matches!(
+            Decoder::new(&msg).decode(),
+            Err(DecodeError::InvalidFieldValue { tag: 95, .. })
+        ));
+    }
+
+    #[test]
+    fn test_decode_length_field_not_followed_by_its_data_field_parses_normally() {
+        // Framing by count only applies to the paired DATA tag; anything else
+        // falls back to the normal SOH scan without fabricating a field.
+        let msg = build_frame(b"35=A\x0195=7\x0158=text\x01");
+        let Ok(decoded) = Decoder::new(&msg).decode() else {
+            panic!("frame must decode");
+        };
+        assert_eq!(decoded.get_field_str(58), Some("text"));
+        assert_eq!(decoded.get_field_str(95), Some("7"));
+    }
+
+    #[test]
+    fn test_decode_zero_length_data_field_is_accepted() {
+        let msg = build_frame(b"35=A\x0195=0\x0196=\x0158=after\x01");
+        let Ok(decoded) = Decoder::new(&msg).decode() else {
+            panic!("frame with empty RawData must decode");
+        };
+        let Some(field) = decoded.get_field(96) else {
+            panic!("RawData field must be present");
+        };
+        assert!(field.value.is_empty());
+        assert_eq!(decoded.get_field_str(58), Some("after"));
+    }
+
+    #[test]
+    fn test_decode_trailing_garbage_without_checksum_validation_is_error() {
+        let mut msg = b"8=FIX.4.4\x019=5\x0135=0\x01".to_vec();
+        msg.extend_from_slice(b"garbage-no-equals");
+
+        let result = Decoder::new(&msg).with_checksum_validation(false).decode();
+        assert!(matches!(result, Err(DecodeError::InvalidTag(_))));
+    }
+
+    #[test]
+    fn test_decode_trailing_unterminated_field_without_checksum_validation_is_error() {
+        let mut msg = b"8=FIX.4.4\x019=5\x0135=0\x01".to_vec();
+        msg.extend_from_slice(b"58=unterminated");
+
+        let result = Decoder::new(&msg).with_checksum_validation(false).decode();
+        assert_eq!(
+            result.err(),
+            Some(DecodeError::UnterminatedField { tag: 58 })
+        );
+    }
+
+    #[test]
+    fn test_decode_empty_buffer_is_incomplete() {
+        assert_eq!(
+            Decoder::new(b"").decode().err(),
+            Some(DecodeError::Incomplete)
+        );
+    }
+
+    #[test]
+    fn test_reset_clears_pending_data_state() {
+        let msg = build_frame(b"35=A\x0195=7\x0196=a\x01b=c\x01d\x01");
+        let mut decoder = Decoder::new(&msg);
+        assert!(decoder.decode().is_ok());
+        decoder.reset();
+        assert!(decoder.decode().is_ok());
     }
 }

--- a/ironfix-tagvalue/src/decoder.rs
+++ b/ironfix-tagvalue/src/decoder.rs
@@ -41,7 +41,7 @@ const MAX_LENGTH_DIGITS: usize = 10;
 /// bounded rather than sized from the input.
 const MAX_TAG_DIAGNOSTIC_LEN: usize = 16;
 
-/// Spec-defined `(length_tag, data_tag)` pairs.
+/// Returns the `DATA` tag paired with `length_tag`, if any.
 ///
 /// A FIX `DATA` field is a counted byte string whose content may legally
 /// contain SOH and `=`; it is always immediately preceded by its `LENGTH`
@@ -49,59 +49,41 @@ const MAX_TAG_DIAGNOSTIC_LEN: usize = 16;
 /// fields from its payload, so the decoder frames it by the declared count
 /// instead.
 ///
-/// This is FIX **wire syntax** — a fixed, spec-defined tag set taken from the
-/// FIX 4.4 specification — not schema. Resolving it must never require a
-/// dictionary lookup: `ironfix-tagvalue` stays independent of
-/// `ironfix-dictionary`.
-const LENGTH_DATA_PAIRS: [(u32, u32); 16] = [
-    (90, 91),   // SecureDataLen / SecureData
-    (93, 89),   // SignatureLength / Signature
-    (95, 96),   // RawDataLength / RawData
-    (212, 213), // XmlDataLen / XmlData
-    (348, 349), // EncodedIssuerLen / EncodedIssuer
-    (350, 351), // EncodedSecurityDescLen / EncodedSecurityDesc
-    (352, 353), // EncodedListExecInstLen / EncodedListExecInst
-    (354, 355), // EncodedTextLen / EncodedText
-    (356, 357), // EncodedSubjectLen / EncodedSubject
-    (358, 359), // EncodedHeadlineLen / EncodedHeadline
-    (360, 361), // EncodedAllocTextLen / EncodedAllocText
-    (362, 363), // EncodedUnderlyingIssuerLen / EncodedUnderlyingIssuer
-    (364, 365), // EncodedUnderlyingSecurityDescLen / EncodedUnderlyingSecurityDesc
-    (445, 446), // EncodedListStatusTextLen / EncodedListStatusText
-    (618, 619), // EncodedLegIssuerLen / EncodedLegIssuer
-    (621, 622), // EncodedLegSecurityDescLen / EncodedLegSecurityDesc
-];
-
-/// Lowest length tag in [`LENGTH_DATA_PAIRS`].
+/// This is FIX **wire syntax** — a fixed, spec-defined tag set — not schema, so
+/// resolving it must never require a dictionary lookup: `ironfix-tagvalue`
+/// stays independent of `ironfix-dictionary`.
 ///
-/// Kept in sync with the table by `test_length_tag_bounds_match_table`.
-const MIN_LENGTH_TAG: u32 = 90;
-
-/// Highest length tag in [`LENGTH_DATA_PAIRS`].
+/// The arms below are the complete set for FIX 4.4 (every `type='DATA'` field
+/// in the vendored `spec/FIX44.xml`). Versions above 4.4 add further pairs;
+/// a `DATA` field outside this set still falls back to an SOH scan and is
+/// therefore subject to the truncation this framing exists to prevent.
 ///
-/// Kept in sync with the table by `test_length_tag_bounds_match_table`.
-const MAX_LENGTH_TAG: u32 = 621;
-
-/// Returns the `DATA` tag paired with `length_tag`, if any.
+/// Written as a `match` rather than a table walk because `slice::get` is not
+/// const-stable, so indexing a const array here would be unchecked indexing.
+/// `LENGTH_DATA_PAIRS` in the tests cross-checks these arms so the two cannot
+/// drift.
 #[inline]
 #[must_use]
 const fn paired_data_tag(length_tag: u32) -> Option<u32> {
-    // Every field runs through here, and the session header tags (8, 9, 34,
-    // 35, 49, 52, 56) all fall below the table, so reject out-of-range tags
-    // before walking it.
-    if length_tag < MIN_LENGTH_TAG || length_tag > MAX_LENGTH_TAG {
-        return None;
+    match length_tag {
+        90 => Some(91),   // SecureDataLen / SecureData
+        93 => Some(89),   // SignatureLength / Signature
+        95 => Some(96),   // RawDataLength / RawData
+        212 => Some(213), // XmlDataLen / XmlData
+        348 => Some(349), // EncodedIssuerLen / EncodedIssuer
+        350 => Some(351), // EncodedSecurityDescLen / EncodedSecurityDesc
+        352 => Some(353), // EncodedListExecInstLen / EncodedListExecInst
+        354 => Some(355), // EncodedTextLen / EncodedText
+        356 => Some(357), // EncodedSubjectLen / EncodedSubject
+        358 => Some(359), // EncodedHeadlineLen / EncodedHeadline
+        360 => Some(361), // EncodedAllocTextLen / EncodedAllocText
+        362 => Some(363), // EncodedUnderlyingIssuerLen / EncodedUnderlyingIssuer
+        364 => Some(365), // EncodedUnderlyingSecurityDescLen / EncodedUnderlyingSecurityDesc
+        445 => Some(446), // EncodedListStatusTextLen / EncodedListStatusText
+        618 => Some(619), // EncodedLegIssuerLen / EncodedLegIssuer
+        621 => Some(622), // EncodedLegSecurityDescLen / EncodedLegSecurityDesc
+        _ => None,
     }
-
-    let mut i = 0;
-    while i < LENGTH_DATA_PAIRS.len() {
-        let (len_tag, data_tag) = LENGTH_DATA_PAIRS[i];
-        if len_tag == length_tag {
-            return Some(data_tag);
-        }
-        i += 1;
-    }
-    None
 }
 
 /// A `DATA` field announced by the `LENGTH` field just consumed.
@@ -191,11 +173,20 @@ impl<'a> Decoder<'a> {
             .parse()
             .map_err(|_| DecodeError::InvalidBodyLength)?;
 
-        // Record body start position
+        // Record body start position. BodyLength (tag 9) is fully
+        // attacker-controlled, so the end of the body is computed with checked
+        // arithmetic here and then used to bound every field that follows: a
+        // count-framed DATA value must not reach past it into the trailer.
         let body_start = self.offset;
+        let body_end = body_start
+            .checked_add(body_length)
+            .ok_or(DecodeError::InvalidBodyLength)?;
+        let limit = Some(body_end);
 
         // Parse MsgType (tag 35) - should be first field in body
-        let msg_type_field = self.next_field()?.ok_or(DecodeError::MissingMsgType)?;
+        let msg_type_field = self
+            .next_field_bounded(limit)?
+            .ok_or(DecodeError::MissingMsgType)?;
         if msg_type_field.tag != 35 {
             return Err(DecodeError::MissingMsgType);
         }
@@ -223,7 +214,7 @@ impl<'a> Decoder<'a> {
             // `?` here is the point of the exercise: a missing `=`, a
             // non-numeric tag or an unterminated value is an error, not a
             // clean end of buffer.
-            let Some(field) = self.next_field()? else {
+            let Some(field) = self.next_field_bounded(limit)? else {
                 break;
             };
             if field.tag == 10 {
@@ -234,9 +225,20 @@ impl<'a> Decoder<'a> {
             fields.push(field);
         }
 
-        // Validate checksum if enabled
+        // The CheckSum field terminates every FIX frame, so its presence is
+        // structural. `validate_checksum` governs whether its *value* is
+        // verified, never whether the field must exist: without this a
+        // count-framed DATA value that swallowed the trailer would still decode
+        // cleanly on the validation-off path the engine uses.
+        let checksum_ref = checksum_field.ok_or(DecodeError::Incomplete)?;
+
+        // A well-formed frame declares exactly the bytes between the BodyLength
+        // SOH and the start of the CheckSum field.
+        if body_end != checksum_field_start {
+            return Err(DecodeError::InvalidBodyLength);
+        }
+
         if self.validate_checksum {
-            let checksum_ref = checksum_field.ok_or(DecodeError::Incomplete)?;
             let declared = parse_checksum(checksum_ref.value).ok_or_else(|| {
                 DecodeError::InvalidFieldValue {
                     tag: 10,
@@ -260,21 +262,6 @@ impl<'a> Decoder<'a> {
                     declared,
                 });
             }
-        }
-
-        // BodyLength (tag 9) is fully attacker-controlled: use checked arithmetic
-        // and validate the declared length against the bytes actually consumed.
-        let body_end = body_start
-            .checked_add(body_length)
-            .ok_or(DecodeError::InvalidBodyLength)?;
-        if checksum_field.is_some() {
-            // A well-formed frame declares exactly the bytes between the
-            // BodyLength SOH and the start of the CheckSum field.
-            if body_end != checksum_field_start {
-                return Err(DecodeError::InvalidBodyLength);
-            }
-        } else if body_end > self.offset {
-            return Err(DecodeError::InvalidBodyLength);
         }
 
         // `RawMessage` ranges are relative to the message slice, so both
@@ -303,6 +290,11 @@ impl<'a> Decoder<'a> {
     /// `Ok(None)` when the buffer is cleanly exhausted, `Ok(Some(field))`
     /// otherwise.
     ///
+    /// Iterating with this method reads fields without any frame context, so a
+    /// count-framed `DATA` value is bounded only by the buffer. Only
+    /// [`Decoder::decode`] knows the frame's declared body end and can stop a
+    /// count from reaching past it into the trailer.
+    ///
     /// # Errors
     /// * [`DecodeError::InvalidTag`] - the tag is empty, non-numeric, too long,
     ///   or the field has no `=` delimiter.
@@ -314,6 +306,19 @@ impl<'a> Decoder<'a> {
     ///   valid byte count.
     #[inline]
     pub fn next_field(&mut self) -> Result<Option<FieldRef<'a>>, DecodeError> {
+        self.next_field_bounded(None)
+    }
+
+    /// Parses the next field, optionally bounded by the frame's declared body
+    /// end.
+    ///
+    /// `body_limit` is the absolute offset of the first byte after the body,
+    /// i.e. the start of the CheckSum field. A count-framed `DATA` value and
+    /// its terminating SOH must both fall inside it.
+    fn next_field_bounded(
+        &mut self,
+        body_limit: Option<usize>,
+    ) -> Result<Option<FieldRef<'a>>, DecodeError> {
         // `offset` never exceeds `input.len()`, so a `None` here is exhaustion.
         let Some(remaining) = self.input.get(self.offset..) else {
             return Ok(None);
@@ -345,19 +350,37 @@ impl<'a> Decoder<'a> {
         };
 
         let value_len = match counted {
-            // `declared` is attacker-controlled: probe the byte at the declared
-            // end before slicing, so an oversized count is a typed error with
-            // no allocation and no panic.
-            Some(declared) => match value_bytes.get(declared) {
-                Some(&SOH) => declared,
-                _ => {
+            Some(declared) => {
+                let value_offset = self
+                    .offset
+                    .checked_add(value_start)
+                    .ok_or(DecodeError::UnterminatedField { tag })?;
+                // How many bytes this value may consume: the rest of the
+                // buffer, further bounded by the frame's declared body end when
+                // decoding a whole message. Without that bound a crafted count
+                // swallows the CheckSum field, and the frame still decodes
+                // whenever checksum validation is off.
+                let available = match body_limit {
+                    // A field starting at or past the declared body end means
+                    // BodyLength disagrees with the frame's actual layout.
+                    Some(limit) => limit
+                        .checked_sub(value_offset)
+                        .ok_or(DecodeError::InvalidBodyLength)?
+                        .min(value_bytes.len()),
+                    None => value_bytes.len(),
+                };
+                // `declared` is attacker-controlled. The terminating SOH sits at
+                // index `declared`, so it must fall inside `available`; probing
+                // it beats sizing anything from the declared count.
+                if declared >= available || value_bytes.get(declared) != Some(&SOH) {
                     return Err(DecodeError::InvalidDataLength {
                         data_tag: tag,
                         declared,
-                        available: value_bytes.len(),
+                        available,
                     });
                 }
-            },
+                declared
+            }
             None => memchr(SOH, value_bytes).ok_or(DecodeError::UnterminatedField { tag })?,
         };
 
@@ -534,6 +557,30 @@ fn parse_length(bytes: &[u8]) -> Option<usize> {
 mod tests {
     use super::*;
 
+    /// Reference table of the spec-defined `(length_tag, data_tag)` pairs.
+    ///
+    /// This is the complete set of `type='DATA'` fields in the vendored FIX 4.4
+    /// specification. It exists to cross-check the match arms of
+    /// [`paired_data_tag`], which is the production lookup.
+    const LENGTH_DATA_PAIRS: [(u32, u32); 16] = [
+        (90, 91),   // SecureDataLen / SecureData
+        (93, 89),   // SignatureLength / Signature
+        (95, 96),   // RawDataLength / RawData
+        (212, 213), // XmlDataLen / XmlData
+        (348, 349), // EncodedIssuerLen / EncodedIssuer
+        (350, 351), // EncodedSecurityDescLen / EncodedSecurityDesc
+        (352, 353), // EncodedListExecInstLen / EncodedListExecInst
+        (354, 355), // EncodedTextLen / EncodedText
+        (356, 357), // EncodedSubjectLen / EncodedSubject
+        (358, 359), // EncodedHeadlineLen / EncodedHeadline
+        (360, 361), // EncodedAllocTextLen / EncodedAllocText
+        (362, 363), // EncodedUnderlyingIssuerLen / EncodedUnderlyingIssuer
+        (364, 365), // EncodedUnderlyingSecurityDescLen / EncodedUnderlyingSecurityDesc
+        (445, 446), // EncodedListStatusTextLen / EncodedListStatusText
+        (618, 619), // EncodedLegIssuerLen / EncodedLegIssuer
+        (621, 622), // EncodedLegSecurityDescLen / EncodedLegSecurityDesc
+    ];
+
     /// Builds a well-formed frame around `body` with a valid trailing checksum.
     fn build_frame(body: &[u8]) -> Vec<u8> {
         build_frame_with_begin_string(b"FIX.4.4", body)
@@ -588,15 +635,18 @@ mod tests {
     }
 
     #[test]
-    fn test_length_tag_bounds_match_table() {
-        // The fast-reject guard in `paired_data_tag` must never exclude a tag
-        // that is actually in the table.
-        let min = LENGTH_DATA_PAIRS.iter().map(|(len, _)| *len).min();
-        let max = LENGTH_DATA_PAIRS.iter().map(|(len, _)| *len).max();
-        assert_eq!(min, Some(MIN_LENGTH_TAG));
-        assert_eq!(max, Some(MAX_LENGTH_TAG));
+    fn test_paired_data_tag_matches_the_spec_table() {
+        // The reference table is the FIX 4.4 spec's complete `type='DATA'` set.
+        // Cross-checking it against the match arms catches drift in either.
         for (length_tag, data_tag) in LENGTH_DATA_PAIRS {
             assert_eq!(paired_data_tag(length_tag), Some(data_tag));
+        }
+        // Nothing outside the table is treated as a length tag.
+        let length_tags: Vec<u32> = LENGTH_DATA_PAIRS.iter().map(|(len, _)| *len).collect();
+        for tag in 1..=700u32 {
+            if !length_tags.contains(&tag) {
+                assert_eq!(paired_data_tag(tag), None, "tag {tag} must not be paired");
+            }
         }
     }
 
@@ -845,11 +895,57 @@ mod tests {
 
         assert_eq!(
             Decoder::new(&msg).decode().err(),
+            // `available` is scoped to the frame's declared body, not to the
+            // rest of the buffer: 4 bytes of body remain after "96=".
             Some(DecodeError::InvalidDataLength {
                 data_tag: 96,
                 declared: 20,
-                available: 11,
+                available: 4,
             })
+        );
+    }
+
+    #[test]
+    fn test_decode_data_count_cannot_swallow_the_checksum_field() {
+        // A count-framed DATA value whose declared length reaches past the body
+        // and lands on the SOH before "10=" would consume the trailer: no tag 10
+        // is then found, and with checksum validation off the frame would decode
+        // with the trailer bytes injected into the DATA value. The count is
+        // bounded by the declared body end, so this is rejected on both paths.
+        // BodyLength counts "35=A|95=8|96=x|" = 15 bytes, and the checksum is
+        // correct for the frame, so nothing but the count is malformed.
+        let body: &[u8] = b"35=A\x0195=8\x0196=x\x01";
+        let msg = build_frame(body);
+
+        for validate in [true, false] {
+            let result = Decoder::new(&msg)
+                .with_checksum_validation(validate)
+                .decode();
+            assert!(
+                matches!(
+                    result,
+                    Err(DecodeError::InvalidDataLength { data_tag: 96, .. })
+                ),
+                "validate_checksum={validate} must reject the swallowed trailer, got {result:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_decode_missing_checksum_field_is_error_without_validation() {
+        // The CheckSum field is structural: a frame that never emits tag 10 must
+        // be rejected even when checksum validation is disabled.
+        let mut msg = Vec::new();
+        msg.extend_from_slice(b"8=FIX.4.4\x01");
+        msg.extend_from_slice(b"9=5\x01");
+        msg.extend_from_slice(b"35=0\x01");
+
+        assert_eq!(
+            Decoder::new(&msg)
+                .with_checksum_validation(false)
+                .decode()
+                .err(),
+            Some(DecodeError::Incomplete)
         );
     }
 

--- a/ironfix-transport/src/codec.rs
+++ b/ironfix-transport/src/codec.rs
@@ -8,17 +8,65 @@
 //!
 //! This module provides a codec that handles FIX message framing over TCP,
 //! including BeginString, BodyLength, and Checksum validation.
+//!
+//! The codec sits at the untrusted-input boundary of the engine: every byte it
+//! sees is chosen by the counterparty. Three properties follow from that and
+//! are enforced here rather than assumed:
+//!
+//! * **Bounded buffering.** A frame is never accumulated past
+//!   [`FixCodec::with_max_message_size`], and the header region
+//!   (`8=…<SOH>9=…<SOH>`) is additionally capped at 64 bytes, so a peer that
+//!   never sends a delimiter cannot grow the read buffer. Note this bounds the
+//!   buffer's *length*, not its resident cost: on seeing a valid header the
+//!   codec reserves the declared frame size up front, so a peer can pin up to
+//!   `max_message_size` per connection with a 20-byte header and then stall.
+//!   That is the same trade-off `tokio_util`'s own `LengthDelimitedCodec`
+//!   makes; lower the ceiling if it matters for your deployment.
+//! * **Structural verification.** The trailer implied by the declared
+//!   BodyLength is checked to actually be `<SOH>10=NNN<SOH>` before any frame is
+//!   handed up, independently of whether checksum *values* are verified.
+//! * **Checked arithmetic.** Every offset derived from BodyLength is folded with
+//!   `checked_*`; a hostile declared length errors instead of wrapping into a
+//!   plausible-looking offset.
+//!
+//! Malformed input maps to a typed [`CodecError`]. See the module docs on
+//! [`CodecError`] for what each variant does to the read buffer, and
+//! `doc/fix_operations.md` ("Garbled Messages and Transport Resynchronization")
+//! for the protocol-level policy.
 
-use bytes::{BufMut, BytesMut};
+use bytes::{Buf, BufMut, BytesMut};
 use ironfix_tagvalue::checksum::{calculate_checksum, parse_checksum};
 use memchr::memchr;
 use thiserror::Error;
 use tokio_util::codec::{Decoder, Encoder};
 
 /// Errors that can occur during codec operations.
+///
+/// # Effect on the read buffer
+///
+/// [`Decoder::decode`] consumes bytes on some error paths so that a caller that
+/// chooses to continue reading is not stuck re-parsing the same garbage:
+///
+/// | Variant | Bytes consumed |
+/// |---|---|
+/// | [`Self::InvalidBeginString`] | up to and including the `<SOH>` of the next `<SOH>8` pair, so the buffer restarts at the `8` (the whole buffer if there is no such pair, minus a trailing `<SOH>` that may still be the start of one) |
+/// | [`Self::InvalidTrailer`] | same resync as above — BodyLength is not corroborated by anything, so the length it declares is not trusted to bound the discard |
+/// | [`Self::InvalidChecksumFormat`], [`Self::ChecksumMismatch`] | the whole declared frame — the trailer literal is exactly where BodyLength said, so the boundary is corroborated |
+/// | all other variants | none — the frame boundary is unknown |
+///
+/// The consumption above is observable only by a caller that drives
+/// [`Decoder::decode`] itself. `tokio_util::Framed` terminates its stream after
+/// any decoder error, and the in-repo engine treats every `Err` as fatal, so
+/// neither can act on it. It is specified and tested regardless, so that a
+/// caller which does drive the codec directly has a defined contract.
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum CodecError {
     /// Message is incomplete, need more data.
+    #[deprecated(
+        since = "0.4.0",
+        note = "never emitted: incomplete input is signalled by `Ok(None)`, the tokio-util idiom. Scheduled for removal in the next breaking release."
+    )]
     #[error("incomplete message")]
     Incomplete,
 
@@ -33,6 +81,35 @@ pub enum CodecError {
     /// Invalid BodyLength value.
     #[error("invalid body length value")]
     InvalidBodyLength,
+
+    /// No complete `8=…<SOH>9=…<SOH>` header within the header-region ceiling.
+    ///
+    /// Emitted instead of asking for more data, so a peer that never sends a
+    /// delimiter cannot grow the read buffer without bound.
+    #[error(
+        "malformed header: no complete BeginString/BodyLength header in the first {max_header_len} bytes"
+    )]
+    HeaderTooLong {
+        /// Header-region ceiling in bytes (64).
+        max_header_len: usize,
+    },
+
+    /// The bytes at the offsets implied by BodyLength are not a CheckSum
+    /// trailer.
+    ///
+    /// A well-formed frame ends with `<SOH>10=NNN<SOH>`. This is checked
+    /// unconditionally: the CheckSum field's *presence* is structural, while
+    /// [`FixCodec::with_checksum_validation`] only governs whether its *value*
+    /// is verified.
+    #[error("invalid trailer: expected <SOH>10=NNN<SOH> at offset {offset}")]
+    InvalidTrailer {
+        /// Offset at which the CheckSum field was expected to start.
+        offset: usize,
+    },
+
+    /// The CheckSum field value is not three decimal digits in `0..=255`.
+    #[error("invalid checksum format: tag 10 is not three decimal digits in 0..=255")]
+    InvalidChecksumFormat,
 
     /// Checksum mismatch.
     #[error("checksum mismatch: calculated {calculated}, declared {declared}")]
@@ -66,6 +143,111 @@ impl From<std::io::Error> for CodecError {
 /// SOH delimiter.
 const SOH: u8 = 0x01;
 
+/// The two bytes every FIX frame starts with.
+const BEGIN_STRING_PREFIX: &[u8] = b"8=";
+
+/// The two bytes that open the BodyLength field.
+const BODY_LENGTH_PREFIX: &[u8] = b"9=";
+
+/// The three bytes that open the CheckSum field.
+const CHECKSUM_PREFIX: &[u8] = b"10=";
+
+/// Length of the `10=NNN<SOH>` trailer in bytes.
+const TRAILER_LEN: usize = 7;
+
+/// Number of digits in a CheckSum value.
+const CHECKSUM_DIGITS: usize = 3;
+
+/// Shortest byte count that can possibly hold a complete frame.
+///
+/// The smallest legal FIX message — `8=FIX.4.0<SOH>9=5<SOH>35=0<SOH>10=NNN<SOH>`
+/// — is 26 bytes, so 20 is a conservative floor for any conforming peer. It is
+/// load-bearing rather than a pure optimisation: the framing arithmetic alone
+/// admits frames as short as 14 bytes, and those stall here until more bytes
+/// arrive. No real BeginString can produce one — the shortest, `FIX.4.4`,
+/// yields 21 bytes — so this is unreachable for a conforming counterparty.
+const MIN_FRAME_LEN: usize = 20;
+
+/// Maximum size of the header region `8=…<SOH>9=…<SOH>`, in bytes.
+///
+/// The header of a legal frame is short and its length is bounded by the
+/// specification, not by the payload: `8=` plus the longest BeginString in the
+/// FIX family (`FIXT.1.1`, 8 bytes) plus SOH is at most 12 bytes, and `9=` plus
+/// a 10-digit BodyLength plus SOH is at most 13 more — 25 bytes in the worst
+/// case. A buffer that has not produced both delimiters within 64 bytes is
+/// therefore already malformed, and continuing to ask for more data would let a
+/// peer sending `8=` followed by endless non-SOH bytes grow the read buffer
+/// (and force a quadratic re-scan on every poll). The ceiling is well above any
+/// legal header, so it can only reject garbage.
+const MAX_HEADER_LEN: usize = 64;
+
+/// Maximum number of digits accepted in a BodyLength value.
+///
+/// Ten digits already exceed any deliverable frame; the bound keeps the fold in
+/// [`parse_body_length`] short and makes an overflow attempt fail fast.
+const MAX_BODY_LENGTH_DIGITS: usize = 10;
+
+/// Parses a BodyLength value from ASCII digits.
+///
+/// FIX defines tag 9 as an unsigned integer, so a leading sign or any
+/// non-digit byte is rejected rather than coerced.
+///
+/// # Returns
+/// The declared body length, or `None` if the value is empty, non-numeric, too
+/// long, or overflows `usize`.
+#[inline]
+fn parse_body_length(bytes: &[u8]) -> Option<usize> {
+    if bytes.is_empty() || bytes.len() > MAX_BODY_LENGTH_DIGITS {
+        return None;
+    }
+
+    let mut result: usize = 0;
+    for &b in bytes {
+        if !b.is_ascii_digit() {
+            return None;
+        }
+        result = result.checked_mul(10)?.checked_add(usize::from(b - b'0'))?;
+    }
+
+    Some(result)
+}
+
+/// Returns how many bytes to discard so the buffer restarts at a candidate
+/// frame.
+///
+/// Scans for the next `<SOH>8` pair and returns the offset of that `8`, so the
+/// surviving buffer begins where a new BeginString may start. When no such pair
+/// exists the whole buffer is garbage and is discarded, except for a trailing
+/// SOH — that byte may be the first half of a pair whose `8` has not arrived
+/// yet, so it is kept.
+///
+/// Anchoring on `<SOH>8` rather than on a bare `8=` is deliberate: `8=` occurs
+/// as a substring of ordinary tags (`18=`, `58=`, …), so a bare scan would
+/// resynchronise onto the middle of a field. The cost is that a well-formed
+/// frame arriving immediately after garbage is normally lost too — its `8=` is
+/// preceded by that garbage rather than by SOH — unless the garbage happens to
+/// end on an SOH. Recovery resumes at the frame after it.
+#[must_use]
+fn resync_offset(src: &[u8]) -> usize {
+    let mut from = 0usize;
+    while let Some(relative) = memchr(SOH, src.get(from..).unwrap_or(&[])) {
+        let Some(soh) = from.checked_add(relative) else {
+            return src.len();
+        };
+        let Some(candidate) = soh.checked_add(1) else {
+            return src.len();
+        };
+        match src.get(candidate) {
+            // A frame may start here; keep everything from this byte on.
+            Some(&b'8') => return candidate,
+            // The SOH is the last byte: its partner may still arrive.
+            None => return soh,
+            Some(_) => from = candidate,
+        }
+    }
+    src.len()
+}
+
 /// Tokio codec for FIX message framing.
 ///
 /// Handles parsing of FIX messages from a byte stream, validating
@@ -80,8 +262,10 @@ pub struct FixCodec {
 
 impl FixCodec {
     /// Creates a new codec with default settings.
+    ///
+    /// Defaults: a 1 MiB maximum message size and checksum validation enabled.
     #[must_use]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             max_message_size: 1024 * 1024, // 1MB
             validate_checksum: true,
@@ -89,6 +273,9 @@ impl FixCodec {
     }
 
     /// Sets the maximum message size.
+    ///
+    /// The limit applies in both directions: a larger frame is neither
+    /// accumulated on decode nor written on encode.
     #[must_use]
     pub const fn with_max_message_size(mut self, size: usize) -> Self {
         self.max_message_size = size;
@@ -96,10 +283,41 @@ impl FixCodec {
     }
 
     /// Sets whether to validate checksums.
+    ///
+    /// This governs only whether the CheckSum *value* is compared. The presence
+    /// and shape of the trailer are structural and are always verified.
     #[must_use]
     pub const fn with_checksum_validation(mut self, validate: bool) -> Self {
         self.validate_checksum = validate;
         self
+    }
+
+    /// Decides what a header-phase miss means for a buffer of `src_len` bytes.
+    ///
+    /// Returns `Ok(None)` ("read more") only while the buffer is still within
+    /// both ceilings; past either one the input can no longer become a legal
+    /// frame, so it is rejected instead of buffered.
+    ///
+    /// # Errors
+    /// * [`CodecError::MessageTooLarge`] - the buffered prefix already exceeds
+    ///   the configured maximum message size.
+    /// * [`CodecError::HeaderTooLong`] - no complete header within
+    ///   [`MAX_HEADER_LEN`] bytes.
+    fn header_needs_more(&self, src_len: usize) -> Result<Option<BytesMut>, CodecError> {
+        // Checked first: when a single read delivers more bytes than any legal
+        // frame, the frame ceiling is the more informative diagnostic.
+        if src_len > self.max_message_size {
+            return Err(CodecError::MessageTooLarge {
+                size: src_len,
+                max_size: self.max_message_size,
+            });
+        }
+        if src_len >= MAX_HEADER_LEN {
+            return Err(CodecError::HeaderTooLong {
+                max_header_len: MAX_HEADER_LEN,
+            });
+        }
+        Ok(None)
     }
 }
 
@@ -113,55 +331,81 @@ impl Decoder for FixCodec {
     type Item = BytesMut;
     type Error = CodecError;
 
+    /// Extracts one complete FIX frame from `src`.
+    ///
+    /// # Errors
+    /// Returns a [`CodecError`] for any malformed frame; see that type for
+    /// which variants consume bytes from `src`.
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
-        // Minimum FIX message size: 8=FIX.4.2|9=X|35=0|10=XXX| (minimum ~25 bytes)
-        if src.len() < 20 {
+        if src.len() < MIN_FRAME_LEN {
             return Ok(None);
         }
 
-        // Validate BeginString starts with "8="
-        if src.len() < 2 || &src[0..2] != b"8=" {
+        // Validate BeginString starts with "8=". A frame that does not is
+        // garbled: discard up to the next candidate frame so a caller that
+        // keeps reading makes progress instead of re-parsing these bytes.
+        if src.get(..BEGIN_STRING_PREFIX.len()) != Some(BEGIN_STRING_PREFIX) {
+            let discarded = resync_offset(src);
+            src.advance(discarded);
+            tracing::warn!(
+                discarded,
+                "garbled FIX frame: resynchronised to the next <SOH>8"
+            );
             return Err(CodecError::InvalidBeginString);
         }
 
+        // The header is parsed inside a bounded window, so every "need more
+        // data" answer below is capped by MAX_HEADER_LEN rather than by the
+        // peer's willingness to send a delimiter.
+        let bytes: &[u8] = src.as_ref();
+        let header = bytes.get(..MAX_HEADER_LEN).unwrap_or(bytes);
+
         // Find first SOH to get BeginString value
-        let first_soh = match memchr(SOH, src) {
-            Some(pos) => pos,
-            None => return Ok(None),
+        let Some(first_soh) = memchr(SOH, header) else {
+            return self.header_needs_more(src.len());
         };
 
         // Find BodyLength field (9=XXX|)
-        let body_len_start = first_soh + 1;
-        if src.len() < body_len_start + 3 {
-            return Ok(None);
-        }
-
-        if &src[body_len_start..body_len_start + 2] != b"9=" {
-            return Err(CodecError::MissingBodyLength);
+        let Some(body_len_start) = first_soh.checked_add(1) else {
+            return Err(CodecError::InvalidBodyLength);
+        };
+        let Some(body_len_end) = body_len_start.checked_add(BODY_LENGTH_PREFIX.len()) else {
+            return Err(CodecError::InvalidBodyLength);
+        };
+        match header.get(body_len_start..body_len_end) {
+            Some(prefix) if prefix == BODY_LENGTH_PREFIX => {}
+            Some(_) => return Err(CodecError::MissingBodyLength),
+            None => return self.header_needs_more(src.len()),
         }
 
         // Find SOH after BodyLength
-        let body_len_soh = match memchr(SOH, &src[body_len_start..]) {
-            Some(pos) => body_len_start + pos,
-            None => return Ok(None),
+        let Some(after_prefix) = header.get(body_len_end..) else {
+            return self.header_needs_more(src.len());
         };
+        let Some(digits_len) = memchr(SOH, after_prefix) else {
+            return self.header_needs_more(src.len());
+        };
+        let Some(digits) = after_prefix.get(..digits_len) else {
+            return Err(CodecError::InvalidBodyLength);
+        };
+        let body_length = parse_body_length(digits).ok_or(CodecError::InvalidBodyLength)?;
+        let body_len_soh = body_len_end
+            .checked_add(digits_len)
+            .ok_or(CodecError::InvalidBodyLength)?;
 
-        // Parse BodyLength value
-        let body_len_str = std::str::from_utf8(&src[body_len_start + 2..body_len_soh])
-            .map_err(|_| CodecError::InvalidBodyLength)?;
-        let body_length: usize = body_len_str
-            .parse()
-            .map_err(|_| CodecError::InvalidBodyLength)?;
-
-        // Calculate total message length
-        // BodyLength counts from after 9=XXX| to before 10=
-        // Total = header + body + trailer (10=XXX|)
-        // BodyLength is attacker-controlled: fold with checked arithmetic so a
-        // hostile declared length errors instead of overflowing usize.
-        let total_length = body_len_soh
+        // BodyLength counts the bytes between the SOH that terminates it and
+        // the start of the CheckSum field, so the frame is
+        // `header + body + 10=NNN<SOH>`. BodyLength is attacker-controlled:
+        // fold with checked arithmetic so a hostile declared length errors
+        // instead of overflowing usize.
+        let body_start = body_len_soh
             .checked_add(1)
-            .and_then(|n| n.checked_add(body_length))
-            .and_then(|n| n.checked_add(7)) // +7 for |10=XXX|
+            .ok_or(CodecError::InvalidBodyLength)?;
+        let body_end = body_start
+            .checked_add(body_length)
+            .ok_or(CodecError::InvalidBodyLength)?;
+        let total_length = body_end
+            .checked_add(TRAILER_LEN)
             .ok_or(CodecError::InvalidBodyLength)?;
 
         // Check maximum size
@@ -173,28 +417,71 @@ impl Decoder for FixCodec {
         }
 
         // Check if we have the complete message
-        if src.len() < total_length {
-            src.reserve(total_length - src.len());
-            return Ok(None);
+        match total_length.checked_sub(src.len()) {
+            Some(0) | None => {}
+            Some(missing) => {
+                src.reserve(missing);
+                return Ok(None);
+            }
         }
+
+        // Verify the trailer the declared BodyLength points at. Without this a
+        // wrong BodyLength silently mis-frames the stream when checksum
+        // validation is off, and surfaces as a misleading ChecksumMismatch when
+        // it is on.
+        //
+        // How much to discard on failure depends on whether BodyLength is
+        // corroborated by anything:
+        //
+        // * the trailer is absent from the offsets it implies -> BodyLength is
+        //   not corroborated, and consuming `total_length` would discard an
+        //   attacker-chosen span. A 21-byte header declaring a large body can
+        //   name tens of thousands of well-formed frames that merely follow it.
+        //   Resync to the next candidate frame instead.
+        // * the trailer literal is exactly where BodyLength said, and only the
+        //   digits are wrong -> the boundary is corroborated, so consuming the
+        //   declared frame keeps a stream of good frames aligned.
+        //
+        // Bound before matching: the borrow of `src` must end before the error
+        // arms advance it.
+        let trailer = verify_trailer(src.as_ref(), body_end, total_length);
+        let declared = match trailer {
+            Ok(value) => value,
+            Err(error @ CodecError::InvalidTrailer { .. }) => {
+                let discarded = resync_offset(src);
+                src.advance(discarded);
+                tracing::warn!(
+                    discarded,
+                    "FIX trailer absent at the declared BodyLength offset: resynchronised"
+                );
+                return Err(error);
+            }
+            Err(error) => {
+                src.advance(total_length);
+                return Err(error);
+            }
+        };
 
         // Validate checksum if enabled
         if self.validate_checksum {
-            // Checksum is at total_length - 4 to total_length - 1 (3 digits)
-            let checksum_start = total_length - 4;
-            let checksum_bytes = &src[checksum_start..checksum_start + 3];
-
-            let declared = parse_checksum(checksum_bytes).ok_or(CodecError::InvalidBodyLength)?;
-
-            // Calculate checksum of everything before 10=
-            let checksum_field_start = total_length - 7;
-            let calculated = calculate_checksum(&src[..checksum_field_start]);
-
-            if calculated != declared {
-                return Err(CodecError::ChecksumMismatch {
-                    calculated,
-                    declared,
-                });
+            // Everything before the CheckSum field is covered by the checksum.
+            // The slice is always present here (`body_end < total_length <=
+            // src.len()`), but it is taken with `get` rather than indexed.
+            let calculated = src.get(..body_end).map(calculate_checksum);
+            match calculated {
+                Some(sum) if sum == declared => {}
+                Some(sum) => {
+                    src.advance(total_length);
+                    return Err(CodecError::ChecksumMismatch {
+                        calculated: sum,
+                        declared,
+                    });
+                }
+                None => {
+                    let discarded = resync_offset(src);
+                    src.advance(discarded);
+                    return Err(CodecError::InvalidTrailer { offset: body_end });
+                }
             }
         }
 
@@ -204,10 +491,67 @@ impl Decoder for FixCodec {
     }
 }
 
+/// Verifies the `<SOH>10=NNN<SOH>` trailer at `body_end` and returns the
+/// declared checksum.
+///
+/// `src` is known to hold at least `total_length` bytes, and
+/// `total_length == body_end + TRAILER_LEN`.
+///
+/// # Errors
+/// * [`CodecError::InvalidTrailer`] - the CheckSum field literal or either
+///   surrounding SOH is absent at the offsets BodyLength implies.
+/// * [`CodecError::InvalidChecksumFormat`] - the three CheckSum digits are not
+///   a decimal value in `0..=255`.
+fn verify_trailer(src: &[u8], body_end: usize, total_length: usize) -> Result<u8, CodecError> {
+    let malformed = || CodecError::InvalidTrailer { offset: body_end };
+
+    // The body's own terminating SOH sits immediately before the CheckSum field.
+    if body_end
+        .checked_sub(1)
+        .and_then(|index| src.get(index))
+        .copied()
+        != Some(SOH)
+    {
+        return Err(malformed());
+    }
+
+    let trailer = src.get(body_end..total_length).ok_or_else(malformed)?;
+    if trailer.get(..CHECKSUM_PREFIX.len()) != Some(CHECKSUM_PREFIX) {
+        return Err(malformed());
+    }
+    if trailer.last().copied() != Some(SOH) {
+        return Err(malformed());
+    }
+
+    let digits_end = CHECKSUM_PREFIX
+        .len()
+        .checked_add(CHECKSUM_DIGITS)
+        .ok_or_else(malformed)?;
+    let digits = trailer
+        .get(CHECKSUM_PREFIX.len()..digits_end)
+        .ok_or_else(malformed)?;
+
+    // The digits are structural too: a caller that disabled checksum
+    // *comparison* still gets a frame whose trailer is well formed.
+    parse_checksum(digits).ok_or(CodecError::InvalidChecksumFormat)
+}
+
 impl Encoder<&[u8]> for FixCodec {
     type Error = CodecError;
 
+    /// Appends `item` to `dst` verbatim.
+    ///
+    /// # Errors
+    /// Returns [`CodecError::MessageTooLarge`] when `item` exceeds the
+    /// configured maximum message size, so the codec never transmits a frame it
+    /// would refuse to receive.
     fn encode(&mut self, item: &[u8], dst: &mut BytesMut) -> Result<(), Self::Error> {
+        if item.len() > self.max_message_size {
+            return Err(CodecError::MessageTooLarge {
+                size: item.len(),
+                max_size: self.max_message_size,
+            });
+        }
         dst.reserve(item.len());
         dst.put_slice(item);
         Ok(())
@@ -217,10 +561,13 @@ impl Encoder<&[u8]> for FixCodec {
 impl Encoder<BytesMut> for FixCodec {
     type Error = CodecError;
 
+    /// Appends `item` to `dst` verbatim, delegating to the `&[u8]` impl.
+    ///
+    /// # Errors
+    /// Returns [`CodecError::MessageTooLarge`] when `item` exceeds the
+    /// configured maximum message size.
     fn encode(&mut self, item: BytesMut, dst: &mut BytesMut) -> Result<(), Self::Error> {
-        dst.reserve(item.len());
-        dst.put_slice(&item);
-        Ok(())
+        Encoder::<&[u8]>::encode(self, item.as_ref(), dst)
     }
 }
 
@@ -228,49 +575,292 @@ impl Encoder<BytesMut> for FixCodec {
 mod tests {
     use super::*;
 
+    /// Builds a well-formed frame around `body` with a correct checksum.
     fn make_fix_message(body: &str) -> Vec<u8> {
-        let header = format!("8=FIX.4.4\x019={}\x01", body.len());
-        let without_checksum = format!("{}{}", header, body);
+        let without_checksum = format!("8=FIX.4.4\x019={}\x01{}", body.len(), body);
         let checksum = calculate_checksum(without_checksum.as_bytes());
-        format!("{}10={:03}\x01", without_checksum, checksum).into_bytes()
+        format!("{without_checksum}10={checksum:03}\x01").into_bytes()
+    }
+
+    /// Decodes expecting success, returning the extracted frame.
+    fn decode_frame(codec: &mut FixCodec, buf: &mut BytesMut) -> BytesMut {
+        match codec.decode(buf) {
+            Ok(Some(frame)) => frame,
+            other => panic!("expected a complete frame, got {other:?}"),
+        }
     }
 
     #[test]
-    fn test_codec_decode_complete_message() {
+    fn test_decode_complete_message_consumes_the_frame() {
         let mut codec = FixCodec::new();
         let msg = make_fix_message("35=0\x01");
         let mut buf = BytesMut::from(&msg[..]);
 
-        let result = codec.decode(&mut buf).unwrap();
-        assert!(result.is_some());
+        let frame = decode_frame(&mut codec, &mut buf);
+        assert_eq!(&frame[..], &msg[..]);
         assert!(buf.is_empty());
     }
 
     #[test]
-    fn test_codec_decode_incomplete() {
+    fn test_decode_truncated_message_is_none() {
         let mut codec = FixCodec::new();
         let msg = make_fix_message("35=0\x01");
-        let mut buf = BytesMut::from(&msg[..msg.len() - 5]);
+        let Some(head) = msg.get(..msg.len() - 5) else {
+            panic!("message is longer than the truncation");
+        };
+        let mut buf = BytesMut::from(head);
 
-        let result = codec.decode(&mut buf).unwrap();
-        assert!(result.is_none());
+        assert!(matches!(codec.decode(&mut buf), Ok(None)));
     }
 
     #[test]
-    fn test_codec_decode_body_length_overflow() {
+    fn test_decode_split_buffer_remainder_reassembles() {
+        let mut codec = FixCodec::new();
+        let msg = make_fix_message("35=0\x0149=SENDER\x0156=TARGET\x01");
+        let split_at = msg.len() - 5;
+        let (Some(head), Some(tail)) = (msg.get(..split_at), msg.get(split_at..)) else {
+            panic!("split point is inside the message");
+        };
+
+        let mut buf = BytesMut::from(head);
+        assert!(matches!(codec.decode(&mut buf), Ok(None)));
+
+        buf.extend_from_slice(tail);
+        let frame = decode_frame(&mut codec, &mut buf);
+        assert_eq!(&frame[..], &msg[..]);
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn test_decode_byte_by_byte_feed_reassembles_one_message() {
+        let mut codec = FixCodec::new();
+        let msg = make_fix_message("35=A\x0149=SENDER\x0156=TARGET\x0198=0\x01108=30\x01");
+        let mut buf = BytesMut::new();
+        let mut decoded = None;
+
+        for (index, byte) in msg.iter().enumerate() {
+            buf.extend_from_slice(&[*byte]);
+            match codec.decode(&mut buf) {
+                Ok(None) => {}
+                Ok(Some(frame)) => {
+                    assert_eq!(index + 1, msg.len(), "frame emitted before the last byte");
+                    decoded = Some(frame);
+                }
+                Err(error) => panic!("byte {index} produced {error:?}"),
+            }
+        }
+
+        let Some(frame) = decoded else {
+            panic!("byte-by-byte feed never produced a frame");
+        };
+        assert_eq!(&frame[..], &msg[..]);
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn test_decode_chunk_boundary_inside_body_length_field() {
+        let mut codec = FixCodec::new();
+        // Body long enough that BodyLength is three digits, so a boundary can
+        // fall between them.
+        let body = format!("35=D\x0158={}\x01", "x".repeat(120));
+        let msg = make_fix_message(&body);
+        // "8=FIX.4.4<SOH>9=" is 12 bytes; cut after the first BodyLength digit.
+        let split_at = 13;
+        let (Some(head), Some(tail)) = (msg.get(..split_at), msg.get(split_at..)) else {
+            panic!("split point is inside the message");
+        };
+
+        let mut buf = BytesMut::from(head);
+        assert!(matches!(codec.decode(&mut buf), Ok(None)));
+
+        buf.extend_from_slice(tail);
+        let frame = decode_frame(&mut codec, &mut buf);
+        assert_eq!(&frame[..], &msg[..]);
+    }
+
+    #[test]
+    fn test_decode_chunk_boundary_inside_trailer() {
+        let mut codec = FixCodec::new();
+        let msg = make_fix_message("35=0\x0149=SENDER\x01");
+        // Cut between the "10=" literal and its digits.
+        let split_at = msg.len() - 4;
+        let (Some(head), Some(tail)) = (msg.get(..split_at), msg.get(split_at..)) else {
+            panic!("split point is inside the message");
+        };
+
+        let mut buf = BytesMut::from(head);
+        assert!(matches!(codec.decode(&mut buf), Ok(None)));
+
+        buf.extend_from_slice(tail);
+        let frame = decode_frame(&mut codec, &mut buf);
+        assert_eq!(&frame[..], &msg[..]);
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn test_decode_two_back_to_back_messages_both_decode() {
+        let mut codec = FixCodec::new();
+        let first = make_fix_message("35=0\x0149=A\x0156=B\x01");
+        let second = make_fix_message("35=A\x0149=CCCC\x0156=DDDD\x01");
+        let mut buf = BytesMut::from(&first[..]);
+        buf.extend_from_slice(&second);
+
+        let frame_one = decode_frame(&mut codec, &mut buf);
+        assert_eq!(&frame_one[..], &first[..]);
+
+        let frame_two = decode_frame(&mut codec, &mut buf);
+        assert_eq!(&frame_two[..], &second[..]);
+
+        assert!(buf.is_empty());
+        assert!(matches!(codec.decode(&mut buf), Ok(None)));
+    }
+
+    #[test]
+    fn test_decode_two_messages_exceeding_the_ceiling_in_total_still_decode() {
+        // The ceiling bounds one frame, not one read: a buffer holding several
+        // legal frames must not be rejected for its total size.
+        let mut codec = FixCodec::new().with_max_message_size(128);
+        let first = make_fix_message(&format!("35=0\x0158={}\x01", "a".repeat(60)));
+        let second = make_fix_message(&format!("35=0\x0158={}\x01", "b".repeat(60)));
+        assert!(first.len() <= 128 && second.len() <= 128);
+        assert!(first.len() + second.len() > 128);
+
+        let mut buf = BytesMut::from(&first[..]);
+        buf.extend_from_slice(&second);
+
+        let frame_one = decode_frame(&mut codec, &mut buf);
+        assert_eq!(&frame_one[..], &first[..]);
+        let frame_two = decode_frame(&mut codec, &mut buf);
+        assert_eq!(&frame_two[..], &second[..]);
+    }
+
+    #[test]
+    fn test_decode_soh_free_buffer_over_ceiling_is_message_too_large() {
+        let ceiling = 128;
+        let mut codec = FixCodec::new().with_max_message_size(ceiling);
+        let mut buf = BytesMut::from(&b"8="[..]);
+        buf.extend_from_slice(&vec![b'X'; ceiling]);
+        assert_eq!(buf.len(), ceiling + 2);
+
+        assert!(matches!(
+            codec.decode(&mut buf),
+            Err(CodecError::MessageTooLarge { max_size, .. }) if max_size == ceiling
+        ));
+    }
+
+    #[test]
+    fn test_decode_soh_free_header_is_bounded_and_never_asks_for_more() {
+        // A peer that sends "8=" and then never a delimiter must not be able to
+        // grow the read buffer: the codec errors once the header ceiling is
+        // reached, long before the message ceiling.
+        let mut codec = FixCodec::new();
+        let garbage = vec![b'X'; 4096];
+        let mut buf = BytesMut::from(&b"8="[..]);
+        let mut error = None;
+
+        for byte in &garbage {
+            buf.extend_from_slice(&[*byte]);
+            match codec.decode(&mut buf) {
+                Ok(None) => {}
+                Ok(Some(frame)) => panic!("garbage produced a frame of {} bytes", frame.len()),
+                Err(err) => {
+                    error = Some(err);
+                    break;
+                }
+            }
+            assert!(
+                buf.len() <= MAX_HEADER_LEN,
+                "buffer grew to {} bytes without an error",
+                buf.len()
+            );
+        }
+
+        assert_eq!(
+            error,
+            Some(CodecError::HeaderTooLong {
+                max_header_len: MAX_HEADER_LEN
+            })
+        );
+        assert!(buf.len() <= MAX_HEADER_LEN + 1);
+    }
+
+    #[test]
+    fn test_decode_long_body_length_digits_is_header_too_long() {
+        let mut codec = FixCodec::new();
+        let mut buf = BytesMut::from(&b"8=FIX.4.4\x019="[..]);
+        buf.extend_from_slice(&[b'9'; MAX_HEADER_LEN]);
+
+        assert_eq!(
+            codec.decode(&mut buf).err(),
+            Some(CodecError::HeaderTooLong {
+                max_header_len: MAX_HEADER_LEN
+            })
+        );
+    }
+
+    #[test]
+    fn test_decode_body_length_overflow_is_invalid_body_length() {
         let mut codec = FixCodec::new();
         let msg = format!("8=FIX.4.4\x019={}\x0135=0\x0110=000\x01", usize::MAX);
         let mut buf = BytesMut::from(msg.as_bytes());
 
         // Must error, not overflow the framing arithmetic.
-        assert!(matches!(
-            codec.decode(&mut buf),
-            Err(CodecError::InvalidBodyLength)
-        ));
+        assert_eq!(
+            codec.decode(&mut buf).err(),
+            Some(CodecError::InvalidBodyLength)
+        );
     }
 
     #[test]
-    fn test_codec_decode_body_length_too_large() {
+    fn test_decode_non_numeric_body_length_is_invalid_body_length() {
+        let mut codec = FixCodec::new();
+        let mut buf = BytesMut::from(&b"8=FIX.4.4\x019=abc\x0135=0\x0110=000\x01"[..]);
+
+        assert_eq!(
+            codec.decode(&mut buf).err(),
+            Some(CodecError::InvalidBodyLength)
+        );
+    }
+
+    #[test]
+    fn test_decode_empty_body_length_is_invalid_body_length() {
+        let mut codec = FixCodec::new();
+        let mut buf = BytesMut::from(&b"8=FIX.4.4\x019=\x0135=0\x0110=000\x01"[..]);
+
+        assert_eq!(
+            codec.decode(&mut buf).err(),
+            Some(CodecError::InvalidBodyLength)
+        );
+    }
+
+    #[test]
+    fn test_decode_signed_body_length_is_invalid_body_length() {
+        let mut codec = FixCodec::new();
+        let mut buf = BytesMut::from(&b"8=FIX.4.4\x019=+5\x0135=0\x0110=000\x01"[..]);
+
+        assert_eq!(
+            codec.decode(&mut buf).err(),
+            Some(CodecError::InvalidBodyLength)
+        );
+    }
+
+    #[test]
+    fn test_decode_missing_body_length_field_is_missing_body_length() {
+        let mut codec = FixCodec::new();
+        // Tag 35 where tag 9 must be.
+        let mut buf = BytesMut::from(&b"8=FIX.4.4\x0135=0\x0149=A\x0110=000\x01"[..]);
+        let total = buf.len();
+
+        assert_eq!(
+            codec.decode(&mut buf).err(),
+            Some(CodecError::MissingBodyLength)
+        );
+        // The frame boundary is unknown, so nothing is consumed.
+        assert_eq!(buf.len(), total);
+    }
+
+    #[test]
+    fn test_decode_body_length_too_large_is_message_too_large() {
         let mut codec = FixCodec::new();
         let msg = format!("8=FIX.4.4\x019={}\x0135=0\x0110=000\x01", 10 * 1024 * 1024);
         let mut buf = BytesMut::from(msg.as_bytes());
@@ -282,40 +872,278 @@ mod tests {
     }
 
     #[test]
-    fn test_codec_decode_invalid_begin_string() {
-        let mut codec = FixCodec::new();
-        // Message without proper 8= prefix (needs at least 20 bytes)
-        let mut buf = BytesMut::from(&b"9=FIX.4.4\x019=5\x0135=0\x0110=000\x01"[..]);
+    fn test_decode_body_length_pointing_at_non_trailer_is_invalid_trailer() {
+        // BodyLength says 3 where the body is 5 bytes, so the trailer offsets
+        // land inside the body. This must be a framing error on both paths:
+        // with validation off it used to mis-frame silently, with it on it used
+        // to surface as a misleading ChecksumMismatch.
+        for validate in [true, false] {
+            let mut codec = FixCodec::new().with_checksum_validation(validate);
+            let mut buf = BytesMut::from(&b"8=FIX.4.4\x019=3\x0135=0\x0110=000\x01"[..]);
+            let total = buf.len();
 
-        let result = codec.decode(&mut buf);
-        assert!(matches!(result, Err(CodecError::InvalidBeginString)));
+            let result = codec.decode(&mut buf);
+            assert!(
+                matches!(result, Err(CodecError::InvalidTrailer { .. })),
+                "validate_checksum={validate} must report a framing error, got {result:?}"
+            );
+            // BodyLength is not corroborated by anything here, so its declared
+            // length is NOT used to bound the discard. The codec resyncs to the
+            // next `<SOH>8` instead; there is none, so everything but a
+            // trailing SOH goes.
+            assert!(
+                buf.len() < total,
+                "validate_checksum={validate} must make progress"
+            );
+            assert!(
+                buf.len() <= 1,
+                "validate_checksum={validate} resync should leave at most a trailing SOH, left {}",
+                buf.len()
+            );
+        }
     }
 
     #[test]
-    fn test_codec_decode_checksum_mismatch() {
+    fn test_decode_invalid_trailer_does_not_discard_the_frames_that_follow() {
+        // A 21-byte hostile header declares a 222-byte body. Consuming the
+        // declared frame would swallow every well-formed frame that merely
+        // follows it -- at the default 1 MiB ceiling, tens of thousands of
+        // them, reported as a single error. BodyLength is not corroborated by
+        // any trailer here, so it must not bound the discard.
+        let good = b"8=FIX.4.4\x019=15\x0135=0\x0149=A\x0156=B\x0110=171\x01";
+        let mut raw = Vec::from(&b"8=FIX.4.4\x019=222\x0135=0\x01"[..]);
+        let hostile_len = raw.len();
+        for _ in 0..6 {
+            raw.extend_from_slice(good);
+        }
+        // The declared frame ends two bytes past the last good frame, so the
+        // buffer must hold it in full for the trailer check to run at all.
+        let padding: &[u8] = b"\x01\x01\x01\x01\x01\x01\x01";
+        raw.extend_from_slice(padding);
+        let mut buf = BytesMut::from(&raw[..]);
+
+        let mut codec = FixCodec::new();
+        let result = codec.decode(&mut buf);
+        assert!(
+            matches!(result, Err(CodecError::InvalidTrailer { .. })),
+            "expected a trailer error, got {result:?}"
+        );
+        // Only the hostile header is discarded: the good frames survive. Under
+        // the previous policy this single error consumed 245 of 250 bytes.
+        assert_eq!(buf.len(), raw.len() - hostile_len);
+
+        for index in 0..6 {
+            match codec.decode(&mut buf) {
+                Ok(Some(frame)) => assert_eq!(&frame[..], &good[..]),
+                other => panic!("frame {index} must survive the resync, got {other:?}"),
+            }
+        }
+        assert_eq!(buf.len(), padding.len());
+    }
+
+    #[test]
+    fn test_decode_missing_final_soh_is_invalid_trailer() {
+        let mut codec = FixCodec::new();
+        // Trailer terminated by 'X' instead of SOH.
+        let mut buf = BytesMut::from(&b"8=FIX.4.4\x019=5\x0135=0\x0110=000X"[..]);
+
+        assert!(matches!(
+            codec.decode(&mut buf),
+            Err(CodecError::InvalidTrailer { .. })
+        ));
+    }
+
+    #[test]
+    fn test_decode_malformed_checksum_digits_is_invalid_checksum_format() {
+        // "10=0x0" has the right shape but is not a decimal value. It used to
+        // be reported as InvalidBodyLength.
+        for validate in [true, false] {
+            let mut codec = FixCodec::new().with_checksum_validation(validate);
+            let mut buf = BytesMut::from(&b"8=FIX.4.4\x019=5\x0135=0\x0110=0x0\x01"[..]);
+
+            assert_eq!(
+                codec.decode(&mut buf).err(),
+                Some(CodecError::InvalidChecksumFormat),
+                "validate_checksum={validate}"
+            );
+            assert!(buf.is_empty(), "the declared frame must be consumed");
+        }
+    }
+
+    #[test]
+    fn test_decode_out_of_range_checksum_is_invalid_checksum_format() {
+        let mut codec = FixCodec::new();
+        // 999 does not fit in a u8 checksum.
+        let mut buf = BytesMut::from(&b"8=FIX.4.4\x019=5\x0135=0\x0110=999\x01"[..]);
+
+        assert_eq!(
+            codec.decode(&mut buf).err(),
+            Some(CodecError::InvalidChecksumFormat)
+        );
+    }
+
+    #[test]
+    fn test_decode_checksum_mismatch_consumes_the_declared_frame() {
         let mut codec = FixCodec::new();
         let mut buf = BytesMut::from(&b"8=FIX.4.4\x019=5\x0135=0\x0110=000\x01"[..]);
 
-        let result = codec.decode(&mut buf);
-        assert!(matches!(result, Err(CodecError::ChecksumMismatch { .. })));
+        assert!(matches!(
+            codec.decode(&mut buf),
+            Err(CodecError::ChecksumMismatch { .. })
+        ));
+        assert!(buf.is_empty());
     }
 
     #[test]
-    fn test_codec_decode_no_checksum_validation() {
+    fn test_decode_checksum_mismatch_keeps_the_next_frame_aligned() {
+        let mut codec = FixCodec::new();
+        let good = make_fix_message("35=0\x0149=A\x01");
+        let mut buf = BytesMut::from(&b"8=FIX.4.4\x019=5\x0135=0\x0110=000\x01"[..]);
+        buf.extend_from_slice(&good);
+
+        assert!(matches!(
+            codec.decode(&mut buf),
+            Err(CodecError::ChecksumMismatch { .. })
+        ));
+        let frame = decode_frame(&mut codec, &mut buf);
+        assert_eq!(&frame[..], &good[..]);
+    }
+
+    #[test]
+    fn test_decode_no_checksum_validation_accepts_a_wrong_checksum() {
         let mut codec = FixCodec::new().with_checksum_validation(false);
         let mut buf = BytesMut::from(&b"8=FIX.4.4\x019=5\x0135=0\x0110=000\x01"[..]);
 
-        let result = codec.decode(&mut buf).unwrap();
-        assert!(result.is_some());
+        let frame = decode_frame(&mut codec, &mut buf);
+        assert_eq!(frame.len(), 26);
     }
 
     #[test]
-    fn test_codec_encode() {
+    fn test_decode_invalid_begin_string_resyncs_to_the_next_frame() {
+        let mut codec = FixCodec::new();
+        let garbage: &[u8] = b"9=FIX.4.4\x0135=0\x0110=000\x01";
+        let good = make_fix_message("35=0\x0149=A\x0156=B\x01");
+        let mut buf = BytesMut::from(garbage);
+        buf.extend_from_slice(&good);
+        let total = buf.len();
+
+        assert_eq!(
+            codec.decode(&mut buf).err(),
+            Some(CodecError::InvalidBeginString)
+        );
+        // The first "<SOH>8" pair is the SOH ending "10=000" plus the '8' of the
+        // following frame, so exactly the garbage is discarded.
+        assert_eq!(total - buf.len(), garbage.len());
+
+        let frame = decode_frame(&mut codec, &mut buf);
+        assert_eq!(&frame[..], &good[..]);
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn test_decode_invalid_begin_string_without_a_candidate_discards_all_but_a_trailing_soh() {
+        let mut codec = FixCodec::new();
+        let mut buf = BytesMut::from(&b"garbage without any candidate start\x01"[..]);
+
+        assert_eq!(
+            codec.decode(&mut buf).err(),
+            Some(CodecError::InvalidBeginString)
+        );
+        // Only the trailing SOH survives: its '8' partner may still arrive.
+        assert_eq!(&buf[..], &[SOH]);
+    }
+
+    #[test]
+    fn test_decode_invalid_begin_string_with_no_soh_discards_everything() {
+        let mut codec = FixCodec::new();
+        let mut buf = BytesMut::from(&b"garbage without any delimiter at all"[..]);
+
+        assert_eq!(
+            codec.decode(&mut buf).err(),
+            Some(CodecError::InvalidBeginString)
+        );
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn test_resync_offset_skips_non_candidate_soh_pairs() {
+        // The first SOH is followed by '3', not '8'; the second one starts a
+        // candidate frame.
+        let input: &[u8] = b"junk\x0135=0\x018=FIX.4.4\x01";
+        let offset = resync_offset(input);
+        assert_eq!(input.get(offset..offset + 2), Some(&b"8="[..]));
+    }
+
+    #[test]
+    fn test_parse_body_length_rejects_hostile_values() {
+        assert_eq!(parse_body_length(b"0"), Some(0));
+        assert_eq!(parse_body_length(b"512"), Some(512));
+        assert_eq!(parse_body_length(b""), None);
+        assert_eq!(parse_body_length(b"-1"), None);
+        assert_eq!(parse_body_length(b"1a"), None);
+        assert_eq!(parse_body_length(b" 12"), None);
+        assert_eq!(parse_body_length(b"99999999999999999999"), None);
+    }
+
+    #[test]
+    fn test_encode_slice_appends_the_frame() {
         let mut codec = FixCodec::new();
         let msg = b"8=FIX.4.4\x019=5\x0135=0\x0110=123\x01";
         let mut dst = BytesMut::new();
 
-        codec.encode(&msg[..], &mut dst).unwrap();
+        assert!(matches!(codec.encode(&msg[..], &mut dst), Ok(())));
         assert_eq!(&dst[..], msg);
+    }
+
+    #[test]
+    fn test_encode_slice_over_the_ceiling_is_message_too_large() {
+        let mut codec = FixCodec::new().with_max_message_size(16);
+        let msg = [b'X'; 17];
+        let mut dst = BytesMut::new();
+
+        assert_eq!(
+            codec.encode(&msg[..], &mut dst).err(),
+            Some(CodecError::MessageTooLarge {
+                size: 17,
+                max_size: 16
+            })
+        );
+        assert!(dst.is_empty(), "a rejected frame must not be written");
+    }
+
+    #[test]
+    fn test_encode_bytes_mut_appends_the_frame() {
+        let mut codec = FixCodec::new();
+        let msg = BytesMut::from(&b"8=FIX.4.4\x019=5\x0135=0\x0110=123\x01"[..]);
+        let mut dst = BytesMut::new();
+
+        assert!(matches!(codec.encode(msg.clone(), &mut dst), Ok(())));
+        assert_eq!(&dst[..], &msg[..]);
+    }
+
+    #[test]
+    fn test_encode_bytes_mut_over_the_ceiling_is_message_too_large() {
+        let mut codec = FixCodec::new().with_max_message_size(16);
+        let msg = BytesMut::from(&vec![b'X'; 17][..]);
+        let mut dst = BytesMut::new();
+
+        assert_eq!(
+            codec.encode(msg, &mut dst).err(),
+            Some(CodecError::MessageTooLarge {
+                size: 17,
+                max_size: 16
+            })
+        );
+        assert!(dst.is_empty());
+    }
+
+    #[test]
+    fn test_encode_at_the_ceiling_is_accepted() {
+        let mut codec = FixCodec::new().with_max_message_size(16);
+        let msg = [b'X'; 16];
+        let mut dst = BytesMut::new();
+
+        assert!(matches!(codec.encode(&msg[..], &mut dst), Ok(())));
+        assert_eq!(dst.len(), 16);
     }
 }


### PR DESCRIPTION
## Summary

Fixes the seven framing defects in `FixCodec` found by the 2026-07-21 workspace audit. The codec is the engine's untrusted-input boundary — every byte it sees is chosen by the counterparty — and it was accepting mis-framed input, buffering without bound, and reporting the wrong error for a malformed trailer.

Closes #8.

## Stack

- **Base branch:** `stack/1-7-tagvalue-decoder` (PR #23)
- **Stack:** #7 (#23) → **#8 (this PR)** → #9 (engine session conformance)
- `Stacked on:` #23. Merge bottom-up: #23 first, then this one.

The diff shown against `main` is cumulative and includes #23's commits — **review it against the base branch**, where it is just `ironfix-transport/src/codec.rs` plus a documentation addition.

## What was wrong

**1. A peer could grow the read buffer without bound (remote OOM).** The `max_message_size` ceiling was applied only *after* BodyLength parsed, and every header-phase miss returned `Ok(None)` — "send me more". A counterparty transmitting `8=` followed by endless non-SOH bytes therefore grew the `Framed` read buffer indefinitely, and forced a fresh `memchr` scan of the whole buffer on every poll.

The header region is now parsed inside a 64-byte window and every header-phase "need more data" is gated on both ceilings. 64 bytes is well above any legal header — `8=` plus the longest BeginString in the family (`FIXT.1.1`) plus SOH is 12 bytes, and `9=` plus a 10-digit BodyLength plus SOH is 13 more — so the cap can only reject garbage.

**2. The trailer was never verified.** `total_length` was computed purely from the declared BodyLength, and nothing checked that the bytes it pointed at actually were `<SOH>10=NNN<SOH>`. With checksum validation off, a wrong BodyLength silently mis-framed the stream; with it on, the same input surfaced as a misleading `ChecksumMismatch`.

The trailer is now verified **unconditionally** — the body's terminating SOH, the literal `10=`, three digits, and the final SOH. This mirrors the call made in #23 for the tag=value decoder: `with_checksum_validation` governs whether the CheckSum *value* is compared, never whether the field must exist.

**3. Malformed checksum digits reported `InvalidBodyLength`.** An unrelated variant, actively misleading when diagnosing a live session. Now `InvalidChecksumFormat`.

**4. No error path consumed bytes, so nothing could resynchronize.** Every error left `src` untouched, so a caller that tried to keep reading re-parsed the same garbage forever. `doc/fix_operations.md` was silent on garbled messages, so per `CLAUDE.md` the policy had to be decided explicitly rather than invented in code — it is now written down (see below) and implemented.

**5. `CodecError::Incomplete` was dead.** Never constructed; need-more-data is `Ok(None)`, the correct tokio-util idiom. Now `#[deprecated]` with a note, removal queued for the next breaking release.

**6. Both `Encoder` impls were unchecked passthroughs.** Identical `reserve`+`put_slice` bodies with no size check, so the codec would transmit a frame it would refuse to receive; the `BytesMut` impl took ownership only to copy. The `BytesMut` impl now delegates to the slice impl, and both enforce the ceiling.

**7. The codec's core job was untested.** Nothing fed a split buffer's remainder, decoded two concatenated messages, or covered `MissingBodyLength` and malformed checksum digits — which is exactly why defect 3 went unnoticed.

## Garbled-message policy

`doc/fix_operations.md` gains a "Garbled Messages and Transport Resynchronization" subsection stating the FIX convention (a garbled message is ignored; no Reject, no ResendRequest, and the inbound MsgSeqNum is **not** incremented) and the codec's contract:

| `CodecError` | Bytes consumed |
|---|---|
| `InvalidBeginString` | up to and including the `<SOH>` of the next `<SOH>8` pair, so the buffer restarts at the `8` |
| `InvalidTrailer` | the same resync — BodyLength is not corroborated, so its declared length is not trusted to size the discard |
| `InvalidChecksumFormat`, `ChecksumMismatch` | the whole declared frame — the trailer literal is where BodyLength said, so the boundary is corroborated |
| `MissingBodyLength`, `InvalidBodyLength`, `HeaderTooLong`, `MessageTooLarge`, `Io` | none — no frame boundary can be inferred |

The split between the middle two rows came out of adversarial review and is the important part. An earlier draft consumed the declared frame on *any* trailer or checksum failure, reasoning that the declared boundary "keeps the stream aligned". When the trailer is missing, that reasoning is exactly backwards: nothing corroborates BodyLength, so trusting it to size the discard hands the attacker a lever. A 21-byte header declaring a 222-byte body was shown to consume 245 of 250 bytes — destroying six well-formed frames that merely followed it and reporting the loss as one error. At the default 1 MiB ceiling the same trick swallows ~28,000 frames. A regression test now pins that those frames survive.

Recovery is documented as **best-effort, not lossless**: the anchor is `<SOH>8` rather than a bare `8=`, because `8=` occurs inside ordinary tags (`18=`, `58=`, …) and a bare scan would resynchronise onto the middle of a field. The cost is that a well-formed frame arriving immediately after garbage is normally discarded with it, unless the garbage ends on an SOH.

**Stated as a non-implementation, not glossed over.** Two gaps, both written into the doc:

- The MsgSeqNum half of the convention belongs to the session layer and is *not* implemented — the codec has no session state.
- The resync is **not reachable from the engine as built**, and not merely because `Initiator` treats codec errors as fatal: `tokio_util::Framed` terminates its stream after *any* decoder error (it latches an error flag and returns `None` on the next poll), so the well-formed frame the resync just aligned onto is discarded with the stream. No way of writing the caller changes that. Honouring the convention from the engine would need either the codec to report garbling as `Ok(None)` with internal skip state — itself a framing-semantics change — or the engine to drive `Decoder::decode` by hand instead of using `Framed`. The policy is therefore observable only by a caller that drives the codec directly, which is how it is tested.

An earlier draft of this PR claimed the resync made a future convention-honouring engine possible "without changing framing semantics". Review disproved that empirically against tokio-util 0.7.18; the claim is gone rather than softened.

## Public API changes (semver)

The workspace is already at 0.4.0 (bumped in #23), which covers all of this. Note that a plain `cargo semver-checks` run against the 0.3.1 baseline reports "no semver update required" only because 0.3.1 → 0.4.0 is *already* a major bump under Cargo's 0.x rules, so every lint is skipped; forcing the comparison with `--release-type minor` correctly reports `semver requires new major version` for the `#[non_exhaustive]` on `CodecError`.

Breaking:
- `#[non_exhaustive]` on `CodecError` — future variants stop being breaking
- three new variants: `HeaderTooLong { max_header_len }`, `InvalidTrailer { offset }`, `InvalidChecksumFormat`
- `CodecError::Incomplete` is `#[deprecated]`

Additive / behavioural:
- `FixCodec::new` is now `const fn`
- both `Encoder` impls can now return `MessageTooLarge`; previously they were infallible in practice
- `decode` now consumes bytes on the resync-eligible error paths (a semantic change no tool can see — nothing in the workspace observes it, per the `Framed` behaviour described above)

Two behaviour changes worth calling out for reviewers, neither visible to `cargo-semver-checks`:

- **With `validate_checksum = false`, input that previously decoded now errors** — specifically a frame whose BodyLength lies about the layout, or whose tag-10 digits are malformed. That is the point of the change, but it only affects callers who deliberately disabled checksum comparison; the default is `true`.
- **Encoding is now fallible in practice.** `framed.send(...)` in the engine can return `MessageTooLarge` for an outbound frame above `SessionConfig::max_message_size` (1 MiB default), which the reactor maps to a session teardown. Previously the oversized frame was transmitted and the peer had to deal with it.

## Adversarial review

Beyond the architectural review, this codec was attacked directly: the source was copied into a standalone harness and driven through `Decoder::decode` with hostile corpora. The results are evidence rather than argument, so they are worth recording:

- **No panic.** `advance()` was instrumented across 12M decode drives and 5.46M real `advance` calls; the maximum of `n - src.len()` was **0**, i.e. `n <= src.len()` held every time. A separate sweep under `catch_unwind` over declared BodyLength 0..600 × body 0..8 × both validation settings × two ceilings produced zero panics, as did a 3.2M-drive fuzz in the debug profile with overflow checks on.
- **No accepted-but-wrong frame.** An oracle re-derived the framing independently for every accepted frame (starts `8=`, SOH at `len-8`, `10=` at `len-7`, three digits ≤ 255, BodyLength consistent, checksum re-checked when enabled). Against mutated and trailer-planted inputs: **1,713,640 accepted frames, 0 contract violations.**
- **No unbounded buffering.** Drip-fed one byte at a time, the peak buffer at any `Ok(None)` was 63 bytes with no header, and bounded by the declared frame otherwise. A 60,000-stream invariant fuzzer found no violation.
- **No livelock** reachable from the engine, because `Framed` fuses after an error.

One thing the attack confirmed as *correct* rather than broken: a lying BodyLength that lands on a planted `<SOH>10=NNN<SOH>` with a matching checksum **is** accepted, leaving the rest as garbage. That is spec-correct — BodyLength is authoritative in FIX, and what the attacker sent is a genuinely well-formed short message.

## Tests

Workspace goes from 188 to **215 passing tests**; `codec.rs` from 8 to 35. New coverage includes:

- byte-by-byte feed reassembling one message; a split buffer's remainder completing it; chunk boundaries inside `9=` and inside the trailer
- two back-to-back messages in one buffer, and two messages whose *combined* size exceeds the ceiling still decoding individually
- a SOH-free buffer over the ceiling returning `MessageTooLarge`, and a SOH-free header never answering "read more"
- BodyLength that is empty, non-numeric, signed, overflowing, or too large — each asserting its exact variant
- a BodyLength pointing at non-trailer bytes, and a missing final SOH, both `InvalidTrailer`
- malformed and out-of-range checksum digits as `InvalidChecksumFormat`
- checksum mismatch consuming the declared frame and leaving the *next* frame correctly aligned
- resync: to the next candidate frame, with no candidate, and with no SOH at all
- a hostile header declaring a large body does **not** discard the well-formed frames that follow it
- encode at, over, and under the ceiling, through both `Encoder` impls

## Verification

```
cargo test --workspace                                    # 215 passed, 0 failed
cargo clippy --all-targets --all-features -- -D warnings  # clean
cargo fmt --all --check                                   # clean
cargo build --release --workspace                         # clean
make doc                                                  # clean (clippy -W missing-docs)
```

No performance claim is made — this repo still has no benchmark harness.
