### PR TITLE
fix(engine): make inbound session handling conform to the FIX spec

### DIFF
--- a/doc/fix_operations.md
+++ b/doc/fix_operations.md
@@ -52,6 +52,50 @@ These messages are required for establishing and maintaining FIX sessions.
 4. Respond with Logon message
 5. Begin heartbeat monitoring
 
+**What IronFix implements today (initiator side)**
+
+`ironfix-engine::Initiator` validates the Logon acknowledgement in this order,
+and stops at the first failure:
+
+1. **MsgType.** A Logout or Reject is a rejected Logon; anything else is an
+   unexpected message.
+2. **Identity.** Inbound `SenderCompID` (49) must equal the configured
+   `target_comp_id` and inbound `TargetCompID` (56) the configured
+   `sender_comp_id`; when `sender_sub_id` / `target_sub_id` are configured,
+   inbound `TargetSubID` (57) and `SenderSubID` (50) are checked the same way.
+   A mismatch produces a session Reject with reason 9 (CompID problem) followed
+   by a Logout, and the handshake fails. This is checked before any callback
+   runs and before sequence state moves, so a cross-wired connection can never
+   establish a session.
+3. **`from_admin`.** A rejection sends a Logout and fails the handshake.
+4. **`HeartBtInt` (108).** The interval confirmed by the counterparty wins.
+   Note the counterparty therefore controls this value, and `108=0` — legal
+   FIX for "do not send heartbeats" — is not handled correctly today; see the
+   Phase 1 checklist entry for Heartbeat / Test Request.
+5. **`ResetSeqNumFlag` (141).** `141=Y` on the ack must arrive under
+   `MsgSeqNum = 1` — the reset and the number carrying it have to describe the
+   same stream — and a peer that sends any other number fails the handshake
+   rather than having one half of the contradiction guessed for it. It is
+   honored **before** MsgSeqNum is validated — otherwise the ack's
+   `34=1` reads as fatally too low against continuity-seeded counters. The
+   inbound counter is reset to 1. The outbound counter is set to 2, not 1.
+   That is an interpretive choice, not a derivation: it is exact when
+   `reset_on_logon` was set (the Logon on the wire really was message 1 of the
+   reset stream, and rewinding would re-emit a number the peer has seen), but
+   with continuity-seeded counters the Logon went out under its seeded number
+   and nothing numbered 1 was ever sent. QuickFIX/J's two halves disagree here
+   — its initiator would set 1, its acceptor 2 — and IronFix matches the
+   acceptor. The mismatch self-heals: the peer sees a gap at 2, requests a
+   resend of 1, and receives a GapFill that resynchronises it.
+6. **`MsgSeqNum` (34).** Too low fails the handshake; a gap completes the
+   handshake and immediately issues a ResendRequest.
+
+The same identity check (step 2) runs on every inbound frame once the session
+is established; there a mismatch produces the Reject and Logout and then tears
+the session down.
+
+Outbound `ResetSeqNumFlag` is driven by `SessionConfig::reset_on_logon`.
+
 ---
 
 ### Logout (MsgType = 5)
@@ -151,6 +195,40 @@ These messages are required for establishing and maintaining FIX sessions.
 3. Use SequenceReset-GapFill for admin messages
 4. Maintain original SendingTime with OrigSendingTime
 
+**What IronFix implements today**
+
+`ironfix-engine` has **no message store dependency**, so mandate items 1, 2 and
+4 above are **not implemented**: the engine cannot replay a single stored
+message. What it does is answer the whole requested range with one
+SequenceReset-GapFill (item 3, generalized to every message type):
+
+- `BeginSeqNo` (7) absent or unparseable → session Reject, reason 1 (required
+  tag missing), `RefTagID` = 7. There is deliberately **no** default value;
+  defaulting a missing BeginSeqNo to 1 silently answers a request the
+  counterparty never made.
+- `EndSeqNo` (16) absent or unparseable → session Reject, reason 1,
+  `RefTagID` = 16.
+- `BeginSeqNo` = 0, or at or beyond our next outbound sequence number → session
+  Reject, reason 5 (value incorrect), `RefTagID` = 7. We cannot resend what we
+  have not sent.
+- `EndSeqNo` below `BeginSeqNo` (and not 0) → session Reject, reason 5,
+  `RefTagID` = 16.
+- Otherwise the reply is `SequenceReset`-GapFill with `MsgSeqNum` = BeginSeqNo
+  and `NewSeqNo` = min(EndSeqNo + 1, next outbound sequence), or the next
+  outbound sequence when `EndSeqNo` = 0 (infinity). A bounded request therefore
+  never advances the counterparty past what it asked for.
+
+The GapFill carries `PossDupFlag` (43) = Y and `OrigSendingTime` (122). Absent
+a store there is no recorded original sending time, so 122 is stamped with the
+same value as `SendingTime` (52), which is the FIX handling for an unavailable
+OrigSendingTime. A GapFill's "original" messages are administrative filler
+rather than replayed traffic, so no information is lost by this.
+
+Consequence for consumers: **application messages are never replayed.** A
+counterparty that requests a resend of business traffic receives a gap fill,
+not the traffic. Real replay requires wiring a `MessageStore` into the engine,
+which is separate, tracked work.
+
 ---
 
 ### Reject (MsgType = 3)
@@ -190,6 +268,22 @@ These messages are required for establishing and maintaining FIX sessions.
 | 11 | Invalid MsgType |
 | 99 | Other |
 
+**Reason codes IronFix emits today**
+
+| Code | Emitted when |
+|---|---|
+| 1 | `SequenceReset` without `NewSeqNo` (36); `ResendRequest` without `BeginSeqNo` (7) or `EndSeqNo` (16) |
+| 5 | `SequenceReset` whose `NewSeqNo` would rewind or fails to advance; `ResendRequest` whose range is outside what we have sent |
+| 9 | Inbound `SenderCompID`/`TargetCompID` (and `SenderSubID`/`TargetSubID` when configured) do not match the session configuration |
+| any | Whatever an `Application::from_admin` / `from_app` implementation returns in its `RejectReason` |
+
+**Reason 10 (SendingTime accuracy) is not implemented.** `SendingTime` (52) is
+never compared against the local clock. Doing so requires a tolerance window,
+and a tolerance is a policy decision — it needs its own typed
+`SessionConfig` knob with a defensible default and a documented unit and range,
+not a guessed constant. Until that decision is made, a message with a wildly
+skewed `SendingTime` is accepted. This is a known, deliberate omission.
+
 ---
 
 ### Sequence Reset (MsgType = 4)
@@ -212,6 +306,37 @@ These messages are required for establishing and maintaining FIX sessions.
 **Server Behavior**:
 - **Gap Fill Mode**: Skip sequence numbers for admin messages during resend
 - **Reset Mode**: Force sequence number reset (use with caution)
+
+**What IronFix implements today**
+
+The two modes are **not** interchangeable, and `GapFillFlag` (123) is what
+selects between them. A Gap Fill is an ordinary sequenced message: it occupies
+its own `MsgSeqNum` and is validated like any other inbound message. **Reset
+mode is the only mode allowed to ignore `MsgSeqNum`.** Applying a gapped Gap
+Fill as though it were a Reset jumps the inbound expectation past messages that
+were never received and will now never be requested — a silent, permanent loss
+of (potentially) Execution Reports.
+
+**Not bounded:** `NewSeqNo` is accepted at any magnitude, so a peer can jump the
+inbound expectation arbitrarily far ahead — up to `u64::MAX`, after which the
+next message exhausts the counter and the session is torn down with a typed
+error. There is no principled ceiling in the specification to check against, and
+the failure mode is a clean teardown rather than silent corruption, so no
+arbitrary limit is invented here.
+
+`ironfix-engine` handles an inbound `SequenceReset` as follows:
+
+| Condition | Behavior |
+|---|---|
+| `from_admin` rejects the message | session Reject with the application's reason; `NewSeqNo` not applied |
+| `NewSeqNo` (36) absent or unparseable | session Reject, reason 1, `RefTagID` = 36; MsgSeqNum is **not** validated and **not** consumed, matching QuickFIX/J, which excludes SequenceReset from its increment-on-reject rule. For a GapFill this leaves the peer's next in-order message looking gapped, so expect a ResendRequest to follow |
+| `123=Y`, MsgSeqNum gapped | ResendRequest for the missing range; `NewSeqNo` **not** applied |
+| `123=Y`, MsgSeqNum too low with `PossDupFlag` = Y | dropped as an already-applied duplicate |
+| `123=Y`, MsgSeqNum too low without `PossDupFlag` | Logout and disconnect, as for any other too-low message |
+| `123=Y`, MsgSeqNum in sequence, `NewSeqNo` ≤ MsgSeqNum | session Reject, reason 5, `RefTagID` = 36; the fill message itself is consumed so the session does not deadlock on that number |
+| `123=Y`, MsgSeqNum in sequence, `NewSeqNo` > MsgSeqNum | applied: inbound expectation becomes `NewSeqNo` |
+| `123=N` or 123 absent (Reset mode), `NewSeqNo` < expected | session Reject, reason 5, `RefTagID` = 36; not applied |
+| `123=N` or 123 absent (Reset mode), `NewSeqNo` ≥ expected | applied regardless of MsgSeqNum. An outstanding ResendRequest is only cleared when the reset actually advances the expectation; a reset landing on the number already expected changes nothing, and clearing for it would let a peer replay it to trigger a fresh ResendRequest every round |
 
 ---
 
@@ -705,10 +830,20 @@ Rationale for the two policies:
 
 ### Phase 1: Core Session Layer (Required)
 - [x] Logon / Logout
-- [x] Heartbeat / Test Request
+- [ ] Heartbeat / Test Request — **partial**: the interval is negotiated and
+  heartbeats, TestRequests and the silent-peer timeout all work at the
+  configured interval, but two cases in `ironfix-session::HeartbeatManager` are
+  wrong. `HeartBtInt = 0` (legal FIX, meaning "do not send heartbeats") is
+  taken literally as a zero-length interval, so the session floods the peer and
+  then times itself out; and a pending TestRequest is cleared only by a
+  Heartbeat echoing the matching `TestReqID`, so a peer that answers without
+  tag 112 — or whose Heartbeat is reordered behind application traffic — is
+  disconnected despite being demonstrably alive.
 - [x] Reject
 - [x] Sequence Reset
-- [x] Resend Request
+- [ ] Resend Request — **partial**: inbound requests are validated and answered
+  with a correctly bounded SequenceReset-GapFill, but the engine has no message
+  store, so no message is ever actually replayed. See "Resend Request" above.
 
 ### Phase 2: Order Entry (High Priority)
 - [ ] New Order Single
@@ -753,6 +888,38 @@ Rationale for the two policies:
 - DefaultApplVerID (tag 1137) in Logon
 - ApplVerID (tag 1128) in application messages
 - Enhanced market data support
+
+**What IronFix implements today.** A session configured with a 5.0 version
+string is carried as a FIXT.1.1 session on the wire: `BeginString` (8) is
+always `FIXT.1.1` and the application version travels in 1137 / 1128. Putting
+`FIX.5.0` in tag 8 is rejected outright by conforming acceptors, so the
+configured string is a *session* version, not a literal BeginString.
+
+| `SessionConfig::begin_string` | Tag 8 | 1137 (Logon) / 1128 (app messages) |
+|---|---|---|
+| `FIX.4.0` … `FIX.4.4` | verbatim | not sent |
+| `FIX.5.0` | `FIXT.1.1` | `7` |
+| `FIX.5.0SP1` | `FIXT.1.1` | `8` |
+| `FIX.5.0SP2` | `FIXT.1.1` | `9` |
+| `FIXT.1.1` | — | session refused |
+| anything else | — | session refused |
+
+`FIXT.1.1` on its own names the transport version and no application version,
+so the engine cannot supply `DefaultApplVerID` (1137) — a **required** field of
+the FIXT.1.1 Logon. Rather than send a Logon missing a required field, or
+default the application version to a guess, `Initiator::connect` refuses the
+session with `EngineError::UnsupportedVersion` before dialling; configure
+`FIX.5.0`, `FIX.5.0SP1` or `FIX.5.0SP2` instead. An unrecognised version string
+is refused the same way, rather than being passed through onto the wire.
+
+This table is duplicated from `ironfix_dictionary::schema::Version`, because
+`ironfix-engine` does not and must not depend on `ironfix-dictionary`. The two
+can drift apart and no test can cross-check them without taking that
+dependency; unifying them into `ironfix-core` is follow-up work.
+
+**Not implemented for 5.0:** no application-version-driven validation of any
+kind. The `ApplVerID` values are stamped, not enforced, and the engine never
+consults a dictionary.
 
 ---
 

--- a/doc/fix_operations.md
+++ b/doc/fix_operations.md
@@ -197,10 +197,12 @@ Outbound `ResetSeqNumFlag` is driven by `SessionConfig::reset_on_logon`.
 
 **What IronFix implements today**
 
-`ironfix-engine` has **no message store dependency**, so mandate items 1, 2 and
-4 above are **not implemented**: the engine cannot replay a single stored
-message. What it does is answer the whole requested range with one
-SequenceReset-GapFill (item 3, generalized to every message type):
+`ironfix-engine` **does not use a message store for replay**: although it
+declares `ironfix-store` in its `Cargo.toml`, no store is wired into the session
+path, so mandate items 1, 2 and 4 above are **not implemented** and the engine
+cannot replay a single stored message. What it does is answer the whole
+requested range with one SequenceReset-GapFill (item 3, generalized to every
+message type):
 
 - `BeginSeqNo` (7) absent or unparseable → session Reject, reason 1 (required
   tag missing), `RefTagID` = 7. There is deliberately **no** default value;
@@ -228,6 +230,20 @@ Consequence for consumers: **application messages are never replayed.** A
 counterparty that requests a resend of business traffic receives a gap fill,
 not the traffic. Real replay requires wiring a `MessageStore` into the engine,
 which is separate, tracked work.
+
+**Outbound `EndSeqNo` sentinel — a version caveat.** When the engine detects an
+inbound gap it requests retransmission with `EndSeqNo` (16) = 0, the open-ended
+"to infinity" sentinel. That `16=0` convention was introduced in FIX 4.2; FIX
+4.0 and 4.1 instead use `999999` for an open-ended request and read `16=0` as an
+empty range. IronFix emits `16=0` for **every** configured version — the
+sentinel is not selected by `BeginString` — so an open-ended resend request sent
+to a strict FIX 4.0/4.1 counterparty is not framed the way that version expects.
+This is recorded here as a **known limitation** rather than fixed with a
+version-aware sentinel; selecting the sentinel by `BeginString` is small,
+isolated follow-up work. (The inbound direction is unaffected in practice: a
+`16=999999` request from such a peer resolves to the same range as `16=0`,
+because the GapFill's `NewSeqNo` is capped at our next outbound sequence
+regardless.)
 
 ---
 
@@ -274,6 +290,7 @@ which is separate, tracked work.
 |---|---|
 | 1 | `SequenceReset` without `NewSeqNo` (36); `ResendRequest` without `BeginSeqNo` (7) or `EndSeqNo` (16) |
 | 5 | `SequenceReset` whose `NewSeqNo` would rewind or fails to advance; `ResendRequest` whose range is outside what we have sent |
+| 6 | `SequenceReset` with a malformed `GapFillFlag` (123) that is present but neither `Y` nor `N` |
 | 9 | Inbound `SenderCompID`/`TargetCompID` (and `SenderSubID`/`TargetSubID` when configured) do not match the session configuration |
 | any | Whatever an `Application::from_admin` / `from_app` implementation returns in its `RejectReason` |
 
@@ -328,11 +345,12 @@ arbitrary limit is invented here.
 
 | Condition | Behavior |
 |---|---|
-| `from_admin` rejects the message | session Reject with the application's reason; `NewSeqNo` not applied |
-| `NewSeqNo` (36) absent or unparseable | session Reject, reason 1, `RefTagID` = 36; MsgSeqNum is **not** validated and **not** consumed, matching QuickFIX/J, which excludes SequenceReset from its increment-on-reject rule. For a GapFill this leaves the peer's next in-order message looking gapped, so expect a ResendRequest to follow |
-| `123=Y`, MsgSeqNum gapped | ResendRequest for the missing range; `NewSeqNo` **not** applied |
-| `123=Y`, MsgSeqNum too low with `PossDupFlag` = Y | dropped as an already-applied duplicate |
+| `123` present but neither `Y` nor `N` (malformed GapFillFlag) | session Reject, reason 6 (incorrect data format), `RefTagID` = 123; the mode is not guessed from an uninterpretable field. An **absent** 123 stays Reset mode |
+| `123=Y`, MsgSeqNum gapped | ResendRequest for the missing range; `NewSeqNo` **not** applied. Classified **before** `from_admin`, so a rejecting application cannot suppress the required ResendRequest |
+| `123=Y`, MsgSeqNum too low with `PossDupFlag` = Y | dropped as an already-applied duplicate, **without** reaching `from_admin` |
 | `123=Y`, MsgSeqNum too low without `PossDupFlag` | Logout and disconnect, as for any other too-low message |
+| `from_admin` rejects an in-sequence fill or a Reset | session Reject with the application's reason; `NewSeqNo` not applied. An in-sequence GapFill still **consumes** its own MsgSeqNum — a rejected fill left unconsumed would wedge the inbound stream — while a Reset consumes nothing |
+| `NewSeqNo` (36) absent or unparseable | session Reject, reason 1, `RefTagID` = 36. An in-sequence GapFill (`123=Y`) still **consumes** its own MsgSeqNum, since it occupies that number even though its NewSeqNo is unusable; Reset mode (`123=N` or absent) consumes nothing. A gapped or too-low fill never reaches this branch — it is classified first (rows above) |
 | `123=Y`, MsgSeqNum in sequence, `NewSeqNo` ≤ MsgSeqNum | session Reject, reason 5, `RefTagID` = 36; the fill message itself is consumed so the session does not deadlock on that number |
 | `123=Y`, MsgSeqNum in sequence, `NewSeqNo` > MsgSeqNum | applied: inbound expectation becomes `NewSeqNo` |
 | `123=N` or 123 absent (Reset mode), `NewSeqNo` < expected | session Reject, reason 5, `RefTagID` = 36; not applied |

--- a/ironfix-engine/src/error.rs
+++ b/ironfix-engine/src/error.rs
@@ -67,6 +67,21 @@ pub enum EngineError {
         detail: String,
     },
 
+    /// The Logon acknowledgement carried a `BeginString` (8) that does not
+    /// match the configured session version.
+    ///
+    /// For a FIX 5.0 / FIXT.1.1 session the configured transport
+    /// `BeginString` is `FIXT.1.1`, so an ack tagged `FIX.5.0*` — or any
+    /// other version — is not this session's acknowledgement and aborts the
+    /// handshake.
+    #[error("begin string mismatch: expected {expected}, received {received}")]
+    BeginStringMismatch {
+        /// The configured transport `BeginString`.
+        expected: String,
+        /// The `BeginString` the counterparty sent on the Logon ack.
+        received: String,
+    },
+
     /// The configured `BeginString` cannot be framed conformantly.
     ///
     /// An unknown version, or `FIXT.1.1` on its own — which names the

--- a/ironfix-engine/src/error.rs
+++ b/ironfix-engine/src/error.rs
@@ -7,11 +7,13 @@
 //! Engine error types.
 
 use ironfix_core::error::DecodeError;
+use ironfix_session::sequence::SequenceExhausted;
 use ironfix_transport::CodecError;
 use std::time::Duration;
 
 /// Errors produced by the engine transport layer.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum EngineError {
     /// Underlying I/O failure.
     #[error("io error: {0}")]
@@ -51,6 +53,32 @@ pub enum EngineError {
     /// A sequence number violation that is fatal for the session.
     #[error("sequence error: {0}")]
     Sequence(String),
+
+    /// A sequence counter reached `u64::MAX`. No further messages can be
+    /// numbered until the session performs a sequence reset.
+    #[error(transparent)]
+    SequenceExhausted(#[from] SequenceExhausted),
+
+    /// The counterparty's identity fields (49/56, and 50/57 when
+    /// configured) did not match the session configuration.
+    #[error("identity mismatch: {detail}")]
+    IdentityMismatch {
+        /// Which field mismatched, with the expected and received values.
+        detail: String,
+    },
+
+    /// The configured `BeginString` cannot be framed conformantly.
+    ///
+    /// An unknown version, or `FIXT.1.1` on its own — which names the
+    /// transport version but no application version for the required
+    /// `DefaultApplVerID` (1137).
+    #[error("unsupported FIX version {version}: {detail}")]
+    UnsupportedVersion {
+        /// The configured version string.
+        version: String,
+        /// Why it cannot be framed.
+        detail: String,
+    },
 
     /// The connection is closed; no more messages can be sent.
     #[error("connection closed")]

--- a/ironfix-engine/src/initiator.rs
+++ b/ironfix-engine/src/initiator.rs
@@ -29,8 +29,9 @@
 //! `GapFillFlag` (123) = Y is an ordinary sequenced message and is validated
 //! against its own `MsgSeqNum`, while Reset mode alone may ignore it; an
 //! inbound `ResendRequest` is answered with a `SequenceReset`-GapFill bounded
-//! by `EndSeqNo`. **The engine has no message store, so no message is ever
-//! actually replayed** — a resend request is always answered with a gap fill.
+//! by `EndSeqNo`. **The engine does not use a message store for replay, so no
+//! message is ever actually replayed** — a resend request is always answered
+//! with a gap fill.
 //!
 //! All sequence arithmetic goes through the checked
 //! [`SequenceManager::try_allocate_sender_seq`] /
@@ -315,6 +316,31 @@ impl<A: Application + 'static> Initiator<A> {
                     let msg_type = other.as_str().to_string();
                     let _ = session.on_logon_reject();
                     return Err(EngineError::UnexpectedMessage { msg_type });
+                }
+            }
+
+            // BeginString before anything else the ack claims: an
+            // acknowledgement in a different FIX dialect than this session was
+            // configured for is not our acknowledgement, no matter what its
+            // CompIDs or MsgSeqNum say. The configured transport BeginString is
+            // the value used for outbound framing -- FIXT.1.1 for a 5.0
+            // session -- so that, not FIX.5.0*, is what a conforming ack
+            // carries. A mismatch aborts the handshake with a typed error
+            // rather than taking the session Active under the wrong protocol
+            // version.
+            match raw.begin_string() {
+                Ok(begin_string) if begin_string == version.begin_string => {}
+                Ok(begin_string) => {
+                    let received = begin_string.to_string();
+                    let _ = session.on_logon_reject();
+                    return Err(EngineError::BeginStringMismatch {
+                        expected: version.begin_string.to_string(),
+                        received,
+                    });
+                }
+                Err(err) => {
+                    let _ = session.on_logon_reject();
+                    return Err(err.into());
                 }
             }
 
@@ -827,15 +853,6 @@ impl<A: Application> Reactor<A> {
         closed(detail, false)
     }
 
-    /// Handles an inbound SequenceReset (35=4).
-    ///
-    /// `GapFillFlag` (123) selects the mode (`doc/fix_operations.md`,
-    /// "Sequence Reset"): `123=Y` is a Gap Fill, which is an ordinary
-    /// sequenced message and is validated against MsgSeqNum like any other;
-    /// `123=N` or an absent 123 is a Reset, the only mode allowed to ignore
-    /// MsgSeqNum. Treating a Gap Fill as a Reset would let a gapped fill
-    /// jump the target expectation past messages that were never received
-    /// and will now never be requested.
     /// Consumes the MsgSeqNum of a `SequenceReset` that is being rejected.
     ///
     /// A Gap Fill participates in normal sequencing: it occupies the number it
@@ -854,6 +871,24 @@ impl<A: Application> Reactor<A> {
             .map(|_| ())
     }
 
+    /// Handles an inbound SequenceReset (35=4).
+    ///
+    /// `GapFillFlag` (123) selects the mode (`doc/fix_operations.md`,
+    /// "Sequence Reset"): `123=Y` is a Gap Fill, which is an ordinary
+    /// sequenced message and is validated against MsgSeqNum like any other;
+    /// `123=N` or an absent 123 is a Reset, the only mode allowed to ignore
+    /// MsgSeqNum. A present-but-malformed 123 (neither `Y` nor `N`) is a
+    /// data-format error, rejected with reason 6 rather than silently taken as
+    /// a Reset. Treating a Gap Fill as a Reset would let a gapped fill jump the
+    /// target expectation past messages that were never received and will now
+    /// never be requested.
+    ///
+    /// A Gap Fill's own MsgSeqNum is classified (gap / too-low duplicate / in
+    /// sequence) **before** the `from_admin` callback runs, exactly as every
+    /// other inbound message is sequence-checked before it reaches the
+    /// application: a gapped fill must produce a ResendRequest even if the
+    /// application would reject it, and a too-low duplicate must be dropped
+    /// without the callback ever seeing it.
     async fn on_sequence_reset(
         &mut self,
         framed: &mut FixFramed,
@@ -861,8 +896,61 @@ impl<A: Application> Reactor<A> {
         raw: &RawMessage<'_>,
         seq: u64,
     ) -> Result<Phase, SessionClosed> {
-        let gap_fill = raw.get_field_str(123) == Some("Y");
+        // Only Y and N are valid GapFillFlag Booleans. An absent 123 is Reset
+        // mode per spec, but a present-but-malformed value is rejected with
+        // reason 6 (incorrect data format) rather than guessing a mode from an
+        // uninterpretable field. Reset mode's target jump is defined behaviour,
+        // so a malformed value gains no extra power by being read as a Reset --
+        // it is simply not a value we are entitled to interpret.
+        let gap_fill = match raw.get_field_str(123) {
+            Some("Y") => true,
+            Some("N") | None => false,
+            Some(other) => {
+                let reason = RejectReason::new(
+                    6,
+                    format!("GapFillFlag (123) must be Y or N, got '{other}'"),
+                )
+                .with_ref_tag(123);
+                return self
+                    .send_session_reject(
+                        framed,
+                        phase,
+                        seq,
+                        MsgType::SequenceReset.as_str(),
+                        &reason,
+                    )
+                    .await;
+            }
+        };
 
+        // Classify a Gap Fill's MsgSeqNum before the application sees it. A
+        // gapped fill cannot be trusted to describe the missing range, so it
+        // triggers a ResendRequest -- never a Reject the application asked for
+        // -- and a too-low duplicate is dropped without reaching from_admin.
+        // Reset mode carries no meaningful MsgSeqNum and is not classified.
+        if gap_fill {
+            match self.runtime.sequences.validate_incoming(seq) {
+                SequenceResult::Gap { expected, .. } => {
+                    // The fill is itself gapped: it cannot be trusted to
+                    // describe the missing range, so NewSeqNo is not applied
+                    // and the range is requested instead.
+                    return self.request_resend(framed, phase, expected).await;
+                }
+                SequenceResult::TooLow { expected, received } => {
+                    if raw.get_field_str(43) == Some("Y") {
+                        // Duplicate delivery of an already-applied fill.
+                        return Ok(phase);
+                    }
+                    return Err(self
+                        .close_on_too_low(framed, phase, expected, received)
+                        .await);
+                }
+                SequenceResult::Ok => {}
+            }
+        }
+
+        // The fill is in sequence (or this is Reset mode): the application may
+        // now inspect it.
         if let Err(reason) = self.application.from_admin(raw, &self.session_id).await {
             // An in-sequence GapFill occupies its own MsgSeqNum. Rejecting it
             // without consuming that number leaves the inbound expectation
@@ -892,26 +980,8 @@ impl<A: Application> Reactor<A> {
         };
 
         if gap_fill {
-            match self.runtime.sequences.validate_incoming(seq) {
-                SequenceResult::Gap { expected, .. } => {
-                    // The fill is itself gapped: it cannot be trusted to
-                    // describe the missing range, so NewSeqNo is not applied
-                    // and the range is requested instead.
-                    return self.request_resend(framed, phase, expected).await;
-                }
-                SequenceResult::TooLow { expected, received } => {
-                    if raw.get_field_str(43) == Some("Y") {
-                        // Duplicate delivery of an already-applied fill.
-                        return Ok(phase);
-                    }
-                    return Err(self
-                        .close_on_too_low(framed, phase, expected, received)
-                        .await);
-                }
-                SequenceResult::Ok => {}
-            }
-
-            // A Gap Fill must advance past the number it occupies itself.
+            // The fill was classified as in sequence above; a Gap Fill must
+            // advance past the number it occupies itself.
             if new_seq <= seq {
                 // The fill was in sequence, so consume it: repeating the
                 // same number would deadlock the session on this message.

--- a/ironfix-engine/src/initiator.rs
+++ b/ironfix-engine/src/initiator.rs
@@ -17,6 +17,26 @@
 //! Reconnection is deliberately out of scope: the consumer owns supervision
 //! and backoff, and calls [`Initiator::connect`] again for a new session.
 //!
+//! # Inbound conformance
+//!
+//! Every inbound frame is checked in this order: decode, `MsgSeqNum` (34)
+//! presence, counterparty identity (49/56, plus 50/57 when configured), then
+//! heartbeat bookkeeping, then sequence validation. Identity comes before the
+//! heartbeat clock deliberately — traffic from the wrong counterparty must not
+//! keep the session alive, reach the [`Application`], or move sequence state.
+//!
+//! Sequence recovery follows `doc/fix_operations.md`: a `SequenceReset` with
+//! `GapFillFlag` (123) = Y is an ordinary sequenced message and is validated
+//! against its own `MsgSeqNum`, while Reset mode alone may ignore it; an
+//! inbound `ResendRequest` is answered with a `SequenceReset`-GapFill bounded
+//! by `EndSeqNo`. **The engine has no message store, so no message is ever
+//! actually replayed** — a resend request is always answered with a gap fill.
+//!
+//! All sequence arithmetic goes through the checked
+//! [`SequenceManager::try_allocate_sender_seq`] /
+//! [`SequenceManager::try_increment_target_seq`]; an exhausted counter tears
+//! the session down rather than wrapping.
+//!
 //! # Example
 //!
 //! ```no_run
@@ -46,15 +66,15 @@
 //! # }
 //! ```
 
-use crate::application::{Application, NoOpApplication, SessionId};
+use crate::application::{Application, NoOpApplication, RejectReason, SessionId};
 use crate::connection::{Command, Connection, SessionRuntime};
 use crate::error::EngineError;
-use crate::wire::{self, MessageFactory};
+use crate::wire::{self, MessageFactory, PeerIdentity, UnsupportedVersion, WireVersion};
 use bytes::BytesMut;
 use futures_util::{SinkExt, StreamExt};
-use ironfix_core::message::MsgType;
+use ironfix_core::message::{MsgType, RawMessage};
 use ironfix_session::heartbeat::generate_test_req_id;
-use ironfix_session::sequence::SequenceResult;
+use ironfix_session::sequence::{SequenceExhausted, SequenceResult};
 use ironfix_session::{
     Active, Disconnected, HeartbeatManager, LogoutPending, SequenceManager, Session, SessionConfig,
 };
@@ -88,8 +108,9 @@ pub struct Initiator<A: Application = NoOpApplication> {
     application: Arc<A>,
     /// Session identifier derived from the configuration.
     session_id: SessionId,
-    /// Interned BeginString for the encoder.
-    begin_string: &'static str,
+    /// Wire representation (BeginString + ApplVerID) of the configured
+    /// FIX version.
+    version: Result<WireVersion, UnsupportedVersion>,
     /// TCP connect timeout.
     connect_timeout: Duration,
     /// Initial (sender, target) sequence numbers for session continuity.
@@ -117,13 +138,13 @@ impl<A: Application + 'static> Initiator<A> {
         if let Some(sub) = &config.target_sub_id {
             session_id = session_id.with_target_sub_id(sub.clone());
         }
-        let begin_string = wire::static_begin_string(&config.begin_string);
+        let version = wire::wire_version(&config.begin_string);
 
         Self {
             config,
             application,
             session_id,
-            begin_string,
+            version,
             connect_timeout: Duration::from_secs(30),
             initial_sequences: None,
             outbound_capacity: DEFAULT_OUTBOUND_CAPACITY,
@@ -182,8 +203,27 @@ impl<A: Application + 'static> Initiator<A> {
     ///
     /// # Errors
     /// Returns an [`EngineError`] if the dial, framing, or Logon handshake
-    /// fails.
+    /// fails. Beyond timeouts and transport failures that includes
+    /// [`EngineError::IdentityMismatch`], when the ack's CompIDs do not match
+    /// the configured session, and [`EngineError::SequenceExhausted`], when a
+    /// sequence counter has reached `u64::MAX` and the session must be reset
+    /// before it can number another message. A `BeginString` this engine
+    /// cannot frame conformantly is refused up front with
+    /// [`EngineError::UnsupportedVersion`], before the socket is dialled.
     pub async fn connect(&self, addr: impl ToSocketAddrs) -> Result<Connection, EngineError> {
+        // Refuse before dialling: an unsupported version cannot produce a
+        // conforming Logon, and guessing one would put a fabricated version on
+        // the wire.
+        let version = match &self.version {
+            Ok(version) => *version,
+            Err(err) => {
+                return Err(EngineError::UnsupportedVersion {
+                    version: err.version.clone(),
+                    detail: err.detail.clone(),
+                });
+            }
+        };
+
         let session_id = self.session_id.clone();
         self.application.on_create(&session_id).await;
 
@@ -218,10 +258,17 @@ impl<A: Application + 'static> Initiator<A> {
             sequences,
             heartbeat: Mutex::new(HeartbeatManager::new(self.config.heartbeat_interval)),
         });
-        let factory = MessageFactory::new(&self.config, self.begin_string);
+        let factory = MessageFactory::new(&self.config, version);
+        let identity = PeerIdentity::new(&self.config);
 
         // Typestate: Connecting -> LogonSent.
-        let seq = runtime.sequences.allocate_sender_seq().value();
+        let seq = match runtime.sequences.try_allocate_sender_seq() {
+            Ok(seq) => seq.value(),
+            Err(err) => {
+                let _ = session.disconnect();
+                return Err(err.into());
+            }
+        };
         let logon = factory.logon(
             seq,
             self.config.heartbeat_interval_secs(),
@@ -271,9 +318,44 @@ impl<A: Application + 'static> Initiator<A> {
                 }
             }
 
+            let ack_seq: u64 = raw.get_field_as(34)?;
+
+            // Identity before anything else: a cross-wired acceptor must not
+            // be allowed to establish a session or move sequence state.
+            if let Err(mismatch) = identity.validate(&raw) {
+                let detail = mismatch.to_string();
+                let reason = RejectReason::new(9, detail.clone()).with_ref_tag(mismatch.tag);
+                if let Ok(out_seq) = runtime.sequences.try_allocate_sender_seq() {
+                    let reject = factory.session_reject(
+                        out_seq.value(),
+                        ack_seq,
+                        MsgType::Logon.as_str(),
+                        &reason,
+                    );
+                    let _ = framed.send(reject).await;
+                }
+                if let Ok(out_seq) = runtime.sequences.try_allocate_sender_seq() {
+                    let _ = framed
+                        .send(factory.logout(out_seq.value(), Some(&detail)))
+                        .await;
+                }
+                let _ = session.on_logon_reject();
+                return Err(EngineError::IdentityMismatch { detail });
+            }
+
             if let Err(reason) = self.application.from_admin(&raw, &session_id).await {
-                let seq = runtime.sequences.allocate_sender_seq().value();
-                let _ = framed.send(factory.logout(seq, Some(&reason.text))).await;
+                match runtime.sequences.try_allocate_sender_seq() {
+                    Ok(seq) => {
+                        let _ = framed
+                            .send(factory.logout(seq.value(), Some(&reason.text)))
+                            .await;
+                    }
+                    Err(err) => tracing::warn!(
+                        session = %session_id,
+                        error = %err,
+                        "cannot send Logout after from_admin rejection"
+                    ),
+                }
                 let _ = session.on_logon_reject();
                 return Err(EngineError::LogonRejected {
                     reason: reason.text,
@@ -296,9 +378,41 @@ impl<A: Application + 'static> Initiator<A> {
                 }
             }
 
-            let ack_seq: u64 = raw.get_field_as(34)?;
+            // ResetSeqNumFlag (141) on the ack is a counterparty-driven
+            // reset and must be honored before MsgSeqNum is validated,
+            // otherwise the ack's 34=1 reads as fatally too low against
+            // continuity-seeded counters.
+            if raw.get_field_str(141) == Some("Y") {
+                // FIX requires MsgSeqNum = 1 on a Logon carrying
+                // ResetSeqNumFlag = Y: the reset and the number it arrives
+                // under have to agree. A peer that declares a reset and then
+                // numbers the message anything else is describing two
+                // different streams, so the handshake fails rather than
+                // guessing which half to believe.
+                if ack_seq != 1 {
+                    let _ = session.on_logon_reject();
+                    return Err(EngineError::Sequence(format!(
+                        "Logon ack set ResetSeqNumFlag=Y but carried MsgSeqNum {ack_seq}, not 1"
+                    )));
+                }
+                tracing::info!(
+                    session = %session_id,
+                    "counterparty set ResetSeqNumFlag on the Logon ack: resetting sequence numbers"
+                );
+                runtime.sequences.set_target_seq(1);
+                // The Logon already on the wire is message 1 of the reset
+                // outbound stream; rewinding the sender counter to 1 would
+                // re-emit a MsgSeqNum the counterparty has already seen.
+                runtime.sequences.set_sender_seq(2);
+            }
+
             match runtime.sequences.validate_incoming(ack_seq) {
-                SequenceResult::Ok => runtime.sequences.increment_target_seq(),
+                SequenceResult::Ok => {
+                    if let Err(err) = runtime.sequences.try_increment_target_seq() {
+                        let _ = session.on_logon_reject();
+                        return Err(err.into());
+                    }
+                }
                 SequenceResult::TooLow { expected, received } => {
                     let _ = session.on_logon_reject();
                     return Err(EngineError::Sequence(format!(
@@ -316,7 +430,7 @@ impl<A: Application + 'static> Initiator<A> {
 
         // A gap in the Logon ack means we missed messages: request a resend.
         if let Some(expected) = pending_resend {
-            let seq = runtime.sequences.allocate_sender_seq().value();
+            let seq = runtime.sequences.try_allocate_sender_seq()?.value();
             let frame = factory.resend_request(seq, expected, 0);
             if let Ok(mut owned) = wire::owned_from_frame(&frame) {
                 self.application.to_admin(&mut owned, &session_id).await;
@@ -330,6 +444,7 @@ impl<A: Application + 'static> Initiator<A> {
 
         let reactor = Reactor {
             factory,
+            identity,
             runtime: Arc::clone(&runtime),
             config: self.config.clone(),
             application: Arc::clone(&self.application),
@@ -349,8 +464,17 @@ impl<A: Application + 'static> Initiator<A> {
 }
 
 /// Locks the shared heartbeat manager.
+///
+/// A poisoned lock means a previous holder panicked. The heartbeat state is
+/// plain timestamps with no invariant a panic could leave half-applied, so
+/// the guard is recovered rather than propagated: the release profile is
+/// `panic = "abort"`, and taking the consumer's process down over a
+/// heartbeat timestamp is never the right trade.
 fn lock_heartbeat(runtime: &SessionRuntime) -> std::sync::MutexGuard<'_, HeartbeatManager> {
-    runtime.heartbeat.lock().expect("heartbeat lock poisoned")
+    runtime
+        .heartbeat
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 /// Runtime session phase, wrapping the typestate session so the reactor can
@@ -391,10 +515,21 @@ fn teardown(phase: Phase) {
     }
 }
 
+/// Tears the session down because a sequence counter is exhausted.
+///
+/// A wrapped MsgSeqNum corrupts a live session, so exhaustion is a terminal
+/// condition rather than something to paper over.
+fn exhausted(phase: Phase, err: SequenceExhausted) -> SessionClosed {
+    teardown(phase);
+    closed(err.to_string(), false)
+}
+
 /// Reactor state shared across event handlers.
 struct Reactor<A: Application> {
     /// Outbound frame factory.
     factory: MessageFactory,
+    /// Identity every inbound message must carry.
+    identity: PeerIdentity,
     /// Shared session runtime (sequences + heartbeat).
     runtime: Arc<SessionRuntime>,
     /// Session configuration.
@@ -424,7 +559,12 @@ async fn run_reactor<A: Application + 'static>(
     tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
     let outcome = loop {
-        let current = phase.take().expect("session phase present");
+        // The phase is put back by every handler that does not close the
+        // session, so it is always present here. Treating its absence as a
+        // close keeps the reactor panic-free rather than relying on that.
+        let Some(current) = phase.take() else {
+            break closed("internal error: session phase lost", false);
+        };
         let result = tokio::select! {
             inbound = framed.next() => match inbound {
                 Some(Ok(frame)) => ctx.on_frame(&mut framed, current, frame).await,
@@ -496,7 +636,10 @@ impl<A: Application> Reactor<A> {
                     );
                     return Ok(phase);
                 }
-                let seq = self.runtime.sequences.allocate_sender_seq().value();
+                let seq = match self.runtime.sequences.try_allocate_sender_seq() {
+                    Ok(seq) => seq.value(),
+                    Err(err) => return Err(exhausted(phase, err)),
+                };
                 let frame = self.factory.application_message(seq, &message);
                 if let Ok(mut owned) = wire::owned_from_frame(&frame) {
                     self.application.to_app(&mut owned, &self.session_id).await;
@@ -511,7 +654,13 @@ impl<A: Application> Reactor<A> {
             Command::Logout => match phase {
                 Phase::LogoutPending(_) => Ok(phase),
                 Phase::Active(session) => {
-                    let seq = self.runtime.sequences.allocate_sender_seq().value();
+                    let seq = match self.runtime.sequences.try_allocate_sender_seq() {
+                        Ok(seq) => seq.value(),
+                        Err(err) => {
+                            let _ = session.disconnect();
+                            return Err(closed(err.to_string(), false));
+                        }
+                    };
                     let frame = self.factory.logout(seq, None);
                     if let Err(err) = self.send_admin(framed, frame).await {
                         let _ = session.disconnect();
@@ -556,7 +705,10 @@ impl<A: Application> Reactor<A> {
         }
         if send_test_request {
             let test_req_id = generate_test_req_id();
-            let seq = self.runtime.sequences.allocate_sender_seq().value();
+            let seq = match self.runtime.sequences.try_allocate_sender_seq() {
+                Ok(seq) => seq.value(),
+                Err(err) => return Err(exhausted(phase, err)),
+            };
             let frame = self.factory.test_request(seq, &test_req_id);
             if let Err(err) = self.send_admin(framed, frame).await {
                 teardown(phase);
@@ -564,7 +716,10 @@ impl<A: Application> Reactor<A> {
             }
             lock_heartbeat(&self.runtime).on_test_request_sent(test_req_id);
         } else if send_heartbeat {
-            let seq = self.runtime.sequences.allocate_sender_seq().value();
+            let seq = match self.runtime.sequences.try_allocate_sender_seq() {
+                Ok(seq) => seq.value(),
+                Err(err) => return Err(exhausted(phase, err)),
+            };
             let frame = self.factory.heartbeat(seq, None);
             if let Err(err) = self.send_admin(framed, frame).await {
                 teardown(phase);
@@ -574,8 +729,314 @@ impl<A: Application> Reactor<A> {
         Ok(phase)
     }
 
-    /// Handles one inbound frame: sequence validation, admin processing,
-    /// and application callback dispatch.
+    /// Sends a session-level Reject (35=3) and keeps the session running.
+    async fn send_session_reject(
+        &mut self,
+        framed: &mut FixFramed,
+        phase: Phase,
+        ref_seq: u64,
+        ref_msg_type: &str,
+        reason: &RejectReason,
+    ) -> Result<Phase, SessionClosed> {
+        let out_seq = match self.runtime.sequences.try_allocate_sender_seq() {
+            Ok(seq) => seq.value(),
+            Err(err) => return Err(exhausted(phase, err)),
+        };
+        let frame = self
+            .factory
+            .session_reject(out_seq, ref_seq, ref_msg_type, reason);
+        if let Err(err) = self.send_admin(framed, frame).await {
+            teardown(phase);
+            return Err(closed(format!("send failed: {err}"), false));
+        }
+        Ok(phase)
+    }
+
+    /// Requests retransmission from `expected` onwards, unless the same
+    /// range is already outstanding.
+    async fn request_resend(
+        &mut self,
+        framed: &mut FixFramed,
+        phase: Phase,
+        expected: u64,
+    ) -> Result<Phase, SessionClosed> {
+        if self.pending_resend == Some(expected) {
+            return Ok(phase);
+        }
+        let out_seq = match self.runtime.sequences.try_allocate_sender_seq() {
+            Ok(seq) => seq.value(),
+            Err(err) => return Err(exhausted(phase, err)),
+        };
+        let frame = self.factory.resend_request(out_seq, expected, 0);
+        if let Err(err) = self.send_admin(framed, frame).await {
+            teardown(phase);
+            return Err(closed(format!("send failed: {err}"), false));
+        }
+        self.pending_resend = Some(expected);
+        Ok(phase)
+    }
+
+    /// Terminates the session on an unrecoverable MsgSeqNum-too-low: a
+    /// message below the expected number that is not flagged as a possible
+    /// duplicate means the streams have diverged.
+    async fn close_on_too_low(
+        &mut self,
+        framed: &mut FixFramed,
+        phase: Phase,
+        expected: u64,
+        received: u64,
+    ) -> SessionClosed {
+        let reason = format!("MsgSeqNum too low: expected {expected}, received {received}");
+        if let Ok(out_seq) = self.runtime.sequences.try_allocate_sender_seq() {
+            let frame = self.factory.logout(out_seq.value(), Some(&reason));
+            let _ = self.send_admin(framed, frame).await;
+        }
+        teardown(phase);
+        closed(reason, false)
+    }
+
+    /// Rejects an inbound message whose identity fields do not match the
+    /// configured counterparty, then logs out and tears the session down.
+    ///
+    /// A cross-wired connection must not be allowed to advance sequence
+    /// state or reach the application. The Reject carries
+    /// `SessionRejectReason` 9, "CompID problem".
+    async fn close_on_identity_mismatch(
+        &mut self,
+        framed: &mut FixFramed,
+        phase: Phase,
+        ref_seq: u64,
+        ref_msg_type: &str,
+        mismatch: wire::IdentityMismatch,
+    ) -> SessionClosed {
+        let detail = mismatch.to_string();
+        tracing::warn!(session = %self.session_id, detail = %detail, "inbound identity mismatch");
+
+        let reason = RejectReason::new(9, detail.clone()).with_ref_tag(mismatch.tag);
+        if let Ok(out_seq) = self.runtime.sequences.try_allocate_sender_seq() {
+            let frame =
+                self.factory
+                    .session_reject(out_seq.value(), ref_seq, ref_msg_type, &reason);
+            let _ = self.send_admin(framed, frame).await;
+        }
+        if let Ok(out_seq) = self.runtime.sequences.try_allocate_sender_seq() {
+            let frame = self.factory.logout(out_seq.value(), Some(&detail));
+            let _ = self.send_admin(framed, frame).await;
+        }
+        teardown(phase);
+        closed(detail, false)
+    }
+
+    /// Handles an inbound SequenceReset (35=4).
+    ///
+    /// `GapFillFlag` (123) selects the mode (`doc/fix_operations.md`,
+    /// "Sequence Reset"): `123=Y` is a Gap Fill, which is an ordinary
+    /// sequenced message and is validated against MsgSeqNum like any other;
+    /// `123=N` or an absent 123 is a Reset, the only mode allowed to ignore
+    /// MsgSeqNum. Treating a Gap Fill as a Reset would let a gapped fill
+    /// jump the target expectation past messages that were never received
+    /// and will now never be requested.
+    /// Consumes the MsgSeqNum of a `SequenceReset` that is being rejected.
+    ///
+    /// A Gap Fill participates in normal sequencing: it occupies the number it
+    /// carries. If it is rejected without that number being consumed, the
+    /// inbound expectation never moves past it and the session silently drops
+    /// everything that follows. A Reset-mode message does not participate in
+    /// sequencing, so nothing is consumed for it, and neither is anything
+    /// consumed for a fill that was not in sequence to begin with.
+    fn consume_if_in_sequence(&self, gap_fill: bool, seq: u64) -> Result<(), SequenceExhausted> {
+        if !gap_fill || !self.runtime.sequences.validate_incoming(seq).is_ok() {
+            return Ok(());
+        }
+        self.runtime
+            .sequences
+            .try_increment_target_seq()
+            .map(|_| ())
+    }
+
+    async fn on_sequence_reset(
+        &mut self,
+        framed: &mut FixFramed,
+        phase: Phase,
+        raw: &RawMessage<'_>,
+        seq: u64,
+    ) -> Result<Phase, SessionClosed> {
+        let gap_fill = raw.get_field_str(123) == Some("Y");
+
+        if let Err(reason) = self.application.from_admin(raw, &self.session_id).await {
+            // An in-sequence GapFill occupies its own MsgSeqNum. Rejecting it
+            // without consuming that number leaves the inbound expectation
+            // parked on it forever: every later message then looks gapped, is
+            // deduplicated against the outstanding ResendRequest and dropped,
+            // and the session goes on reporting itself healthy while it
+            // silently discards traffic.
+            if let Err(err) = self.consume_if_in_sequence(gap_fill, seq) {
+                return Err(exhausted(phase, err));
+            }
+            return self
+                .send_session_reject(framed, phase, seq, MsgType::SequenceReset.as_str(), &reason)
+                .await;
+        }
+
+        let Some(new_seq) = raw.get_field_str(36).and_then(|s| s.parse::<u64>().ok()) else {
+            let reason = RejectReason::new(1, "SequenceReset without a valid NewSeqNo (36)")
+                .with_ref_tag(36);
+            // Same hazard as the rejection path above: the fill still occupies
+            // its sequence number even though its NewSeqNo is unusable.
+            if let Err(err) = self.consume_if_in_sequence(gap_fill, seq) {
+                return Err(exhausted(phase, err));
+            }
+            return self
+                .send_session_reject(framed, phase, seq, MsgType::SequenceReset.as_str(), &reason)
+                .await;
+        };
+
+        if gap_fill {
+            match self.runtime.sequences.validate_incoming(seq) {
+                SequenceResult::Gap { expected, .. } => {
+                    // The fill is itself gapped: it cannot be trusted to
+                    // describe the missing range, so NewSeqNo is not applied
+                    // and the range is requested instead.
+                    return self.request_resend(framed, phase, expected).await;
+                }
+                SequenceResult::TooLow { expected, received } => {
+                    if raw.get_field_str(43) == Some("Y") {
+                        // Duplicate delivery of an already-applied fill.
+                        return Ok(phase);
+                    }
+                    return Err(self
+                        .close_on_too_low(framed, phase, expected, received)
+                        .await);
+                }
+                SequenceResult::Ok => {}
+            }
+
+            // A Gap Fill must advance past the number it occupies itself.
+            if new_seq <= seq {
+                // The fill was in sequence, so consume it: repeating the
+                // same number would deadlock the session on this message.
+                if let Err(err) = self.runtime.sequences.try_increment_target_seq() {
+                    return Err(exhausted(phase, err));
+                }
+                let reason = RejectReason::new(
+                    5,
+                    format!("GapFill NewSeqNo {new_seq} does not advance past MsgSeqNum {seq}"),
+                )
+                .with_ref_tag(36);
+                return self
+                    .send_session_reject(
+                        framed,
+                        phase,
+                        seq,
+                        MsgType::SequenceReset.as_str(),
+                        &reason,
+                    )
+                    .await;
+            }
+        } else {
+            let expected = self.runtime.sequences.next_target_seq().value();
+            if new_seq < expected {
+                let reason = RejectReason::new(
+                    5,
+                    format!("SequenceReset NewSeqNo {new_seq} is below the expected {expected}"),
+                )
+                .with_ref_tag(36);
+                return self
+                    .send_session_reject(
+                        framed,
+                        phase,
+                        seq,
+                        MsgType::SequenceReset.as_str(),
+                        &reason,
+                    )
+                    .await;
+            }
+        }
+
+        let expected_before = self.runtime.sequences.next_target_seq().value();
+        self.runtime.sequences.set_target_seq(new_seq);
+        // Only a reset that actually advances the expectation resolves an
+        // outstanding ResendRequest. A reset landing on the number we already
+        // expect changes nothing, and clearing the marker for it would let a
+        // peer replay it to make the engine emit a fresh ResendRequest every
+        // round -- sequence amplification with no progress.
+        if new_seq > expected_before {
+            self.pending_resend = None;
+        }
+        Ok(phase)
+    }
+
+    /// Answers an inbound ResendRequest (35=2).
+    ///
+    /// The engine has no message store, so it cannot replay the requested
+    /// messages: it answers the whole requested range with a single
+    /// SequenceReset-GapFill. The reply is bounded by `EndSeqNo` (16) so the
+    /// counterparty is never advanced past what it asked for, and `16=0`
+    /// means "up to infinity" (`doc/fix_operations.md`, "Resend Request").
+    async fn on_resend_request(
+        &mut self,
+        framed: &mut FixFramed,
+        phase: Phase,
+        raw: &RawMessage<'_>,
+        seq: u64,
+    ) -> Result<Phase, SessionClosed> {
+        let ref_msg_type = MsgType::ResendRequest.as_str();
+
+        let Some(begin_seq) = raw.get_field_str(7).and_then(|s| s.parse::<u64>().ok()) else {
+            let reason = RejectReason::new(1, "ResendRequest without a valid BeginSeqNo (7)")
+                .with_ref_tag(7);
+            return self
+                .send_session_reject(framed, phase, seq, ref_msg_type, &reason)
+                .await;
+        };
+        let Some(end_seq) = raw.get_field_str(16).and_then(|s| s.parse::<u64>().ok()) else {
+            let reason = RejectReason::new(1, "ResendRequest without a valid EndSeqNo (16)")
+                .with_ref_tag(16);
+            return self
+                .send_session_reject(framed, phase, seq, ref_msg_type, &reason)
+                .await;
+        };
+
+        let next_sender = self.runtime.sequences.next_sender_seq().value();
+        if begin_seq == 0 || begin_seq >= next_sender {
+            let reason = RejectReason::new(
+                5,
+                format!("ResendRequest BeginSeqNo {begin_seq} is outside the sent range 1..{next_sender}"),
+            )
+            .with_ref_tag(7);
+            return self
+                .send_session_reject(framed, phase, seq, ref_msg_type, &reason)
+                .await;
+        }
+        if end_seq != 0 && end_seq < begin_seq {
+            let reason = RejectReason::new(
+                5,
+                format!("ResendRequest EndSeqNo {end_seq} is below BeginSeqNo {begin_seq}"),
+            )
+            .with_ref_tag(16);
+            return self
+                .send_session_reject(framed, phase, seq, ref_msg_type, &reason)
+                .await;
+        }
+
+        // The fill covers begin_seq..new_seq, never beyond EndSeqNo + 1 and
+        // never beyond what we have actually sent.
+        let new_seq = match end_seq {
+            0 => next_sender,
+            _ => end_seq
+                .checked_add(1)
+                .map_or(next_sender, |bound| bound.min(next_sender)),
+        };
+        let frame = self.factory.sequence_reset_gap_fill(begin_seq, new_seq);
+        if let Err(err) = self.send_admin(framed, frame).await {
+            teardown(phase);
+            return Err(closed(format!("send failed: {err}"), false));
+        }
+        Ok(phase)
+    }
+
+    /// Handles one inbound frame: identity validation, sequence validation,
+    /// admin processing, and application callback dispatch.
     async fn on_frame(
         &mut self,
         framed: &mut FixFramed,
@@ -590,9 +1051,6 @@ impl<A: Application> Reactor<A> {
             }
         };
         let msg_type = raw.msg_type().clone();
-        let test_req_id = raw.get_field_str(112);
-        lock_heartbeat(&self.runtime)
-            .on_message_received(msg_type == MsgType::Heartbeat, test_req_id);
 
         let Some(seq) = raw.get_field_str(34).and_then(|s| s.parse::<u64>().ok()) else {
             tracing::warn!(
@@ -603,36 +1061,32 @@ impl<A: Application> Reactor<A> {
             return Ok(phase);
         };
 
-        // SequenceReset (including GapFill) jumps the target expectation
-        // regardless of its own MsgSeqNum.
+        // Identity before session state: foreign traffic must not advance
+        // sequence numbers, reach the application, or keep the heartbeat
+        // clock alive.
+        if let Err(mismatch) = self.identity.validate(&raw) {
+            return Err(self
+                .close_on_identity_mismatch(framed, phase, seq, msg_type.as_str(), mismatch)
+                .await);
+        }
+
+        // The frame is well-formed, sequenced, and from the configured
+        // counterparty: it proves the peer is alive. A sequence gap is a
+        // recoverable condition, not evidence of a dead peer, so gapped
+        // frames still count here.
+        let test_req_id = raw.get_field_str(112);
+        lock_heartbeat(&self.runtime)
+            .on_message_received(msg_type == MsgType::Heartbeat, test_req_id);
+
         if msg_type == MsgType::SequenceReset {
-            let _ = self.application.from_admin(&raw, &self.session_id).await;
-            match raw.get_field_str(36).and_then(|s| s.parse::<u64>().ok()) {
-                Some(new_seq) => {
-                    let expected = self.runtime.sequences.next_target_seq().value();
-                    if new_seq >= expected {
-                        self.runtime.sequences.set_target_seq(new_seq);
-                        self.pending_resend = None;
-                    } else {
-                        tracing::warn!(
-                            session = %self.session_id,
-                            new_seq,
-                            expected,
-                            "ignoring SequenceReset that would decrease the target sequence"
-                        );
-                    }
-                }
-                None => tracing::warn!(
-                    session = %self.session_id,
-                    "ignoring SequenceReset without valid NewSeqNo (36)"
-                ),
-            }
-            return Ok(phase);
+            return self.on_sequence_reset(framed, phase, &raw, seq).await;
         }
 
         match self.runtime.sequences.validate_incoming(seq) {
             SequenceResult::Ok => {
-                self.runtime.sequences.increment_target_seq();
+                if let Err(err) = self.runtime.sequences.try_increment_target_seq() {
+                    return Err(exhausted(phase, err));
+                }
                 self.pending_resend = None;
             }
             SequenceResult::TooLow { expected, received } => {
@@ -640,118 +1094,101 @@ impl<A: Application> Reactor<A> {
                     // Duplicate delivery of an already-processed message.
                     return Ok(phase);
                 }
-                let reason = format!("MsgSeqNum too low: expected {expected}, received {received}");
-                let out_seq = self.runtime.sequences.allocate_sender_seq().value();
-                let frame = self.factory.logout(out_seq, Some(&reason));
-                let _ = self.send_admin(framed, frame).await;
-                teardown(phase);
-                return Err(closed(reason, false));
+                return Err(self
+                    .close_on_too_low(framed, phase, expected, received)
+                    .await);
             }
             SequenceResult::Gap { expected, .. } => {
-                if self.pending_resend != Some(expected) {
-                    let out_seq = self.runtime.sequences.allocate_sender_seq().value();
-                    let frame = self.factory.resend_request(out_seq, expected, 0);
-                    if let Err(err) = self.send_admin(framed, frame).await {
-                        teardown(phase);
-                        return Err(closed(format!("send failed: {err}"), false));
-                    }
-                    self.pending_resend = Some(expected);
-                }
+                let phase = self.request_resend(framed, phase, expected).await?;
                 if msg_type.is_app() {
                     // Application messages inside a gap will be resent in
                     // order; admin messages are still processed below
                     // (without advancing the target sequence).
                     return Ok(phase);
                 }
+                return self.dispatch(framed, phase, &raw, &msg_type, seq).await;
             }
         }
 
-        if msg_type.is_admin() {
-            if let Err(reason) = self.application.from_admin(&raw, &self.session_id).await {
-                let out_seq = self.runtime.sequences.allocate_sender_seq().value();
-                let frame = self
-                    .factory
-                    .session_reject(out_seq, seq, msg_type.as_str(), &reason);
+        self.dispatch(framed, phase, &raw, &msg_type, seq).await
+    }
+
+    /// Runs the application callback and the admin reply for a message whose
+    /// sequence number has already been validated.
+    async fn dispatch(
+        &mut self,
+        framed: &mut FixFramed,
+        phase: Phase,
+        raw: &RawMessage<'_>,
+        msg_type: &MsgType,
+        seq: u64,
+    ) -> Result<Phase, SessionClosed> {
+        if !msg_type.is_admin() {
+            if let Err(reason) = self.application.from_app(raw, &self.session_id).await {
+                return self
+                    .send_session_reject(framed, phase, seq, msg_type.as_str(), &reason)
+                    .await;
+            }
+            return Ok(phase);
+        }
+
+        if let Err(reason) = self.application.from_admin(raw, &self.session_id).await {
+            return self
+                .send_session_reject(framed, phase, seq, msg_type.as_str(), &reason)
+                .await;
+        }
+
+        match msg_type {
+            MsgType::Heartbeat => Ok(phase),
+            MsgType::TestRequest => {
+                let out_seq = match self.runtime.sequences.try_allocate_sender_seq() {
+                    Ok(out_seq) => out_seq.value(),
+                    Err(err) => return Err(exhausted(phase, err)),
+                };
+                let frame = self.factory.heartbeat(out_seq, raw.get_field_str(112));
                 if let Err(err) = self.send_admin(framed, frame).await {
                     teardown(phase);
                     return Err(closed(format!("send failed: {err}"), false));
                 }
-                return Ok(phase);
+                Ok(phase)
             }
-            match msg_type {
-                MsgType::Heartbeat => Ok(phase),
-                MsgType::TestRequest => {
-                    let out_seq = self.runtime.sequences.allocate_sender_seq().value();
-                    let frame = self.factory.heartbeat(out_seq, test_req_id);
-                    if let Err(err) = self.send_admin(framed, frame).await {
-                        teardown(phase);
-                        return Err(closed(format!("send failed: {err}"), false));
-                    }
-                    Ok(phase)
+            MsgType::ResendRequest => self.on_resend_request(framed, phase, raw, seq).await,
+            MsgType::Logon => {
+                tracing::warn!(
+                    session = %self.session_id,
+                    "ignoring unexpected Logon on established session"
+                );
+                Ok(phase)
+            }
+            MsgType::Reject => {
+                tracing::warn!(
+                    session = %self.session_id,
+                    text = raw.get_field_str(58).unwrap_or(""),
+                    "session-level Reject received"
+                );
+                Ok(phase)
+            }
+            MsgType::Logout => match phase {
+                Phase::LogoutPending(session) => {
+                    // Typestate: LogoutPending -> Disconnected.
+                    let _ = session.on_logout_ack();
+                    Err(closed("logout complete", true))
                 }
-                MsgType::ResendRequest => {
-                    // Answer with a GapFill jumping to our next sender
-                    // sequence; message-by-message replay from a store is a
-                    // consumer/session-layer concern.
-                    let begin_seq = raw
-                        .get_field_str(7)
-                        .and_then(|s| s.parse::<u64>().ok())
-                        .unwrap_or(1);
-                    let new_seq = self.runtime.sequences.next_sender_seq().value();
-                    let frame = self.factory.sequence_reset_gap_fill(begin_seq, new_seq);
-                    if let Err(err) = self.send_admin(framed, frame).await {
-                        teardown(phase);
-                        return Err(closed(format!("send failed: {err}"), false));
-                    }
-                    Ok(phase)
-                }
-                MsgType::Logon => {
-                    tracing::warn!(
-                        session = %self.session_id,
-                        "ignoring unexpected Logon on established session"
-                    );
-                    Ok(phase)
-                }
-                MsgType::Reject => {
-                    tracing::warn!(
-                        session = %self.session_id,
-                        text = raw.get_field_str(58).unwrap_or(""),
-                        "session-level Reject received"
-                    );
-                    Ok(phase)
-                }
-                MsgType::Logout => match phase {
-                    Phase::LogoutPending(session) => {
-                        // Typestate: LogoutPending -> Disconnected.
-                        let _ = session.on_logout_ack();
-                        Err(closed("logout complete", true))
-                    }
-                    Phase::Active(session) => {
-                        let out_seq = self.runtime.sequences.allocate_sender_seq().value();
-                        let frame = self.factory.logout(out_seq, None);
+                Phase::Active(session) => {
+                    if let Ok(out_seq) = self.runtime.sequences.try_allocate_sender_seq() {
+                        let frame = self.factory.logout(out_seq.value(), None);
                         let _ = self.send_admin(framed, frame).await;
-                        let _ = session.disconnect();
-                        let text = raw
-                            .get_field_str(58)
-                            .unwrap_or("logout initiated by counterparty");
-                        Err(closed(format!("logout by counterparty: {text}"), true))
                     }
-                },
-                // All admin types are matched above.
-                _ => Ok(phase),
-            }
-        } else {
-            if let Err(reason) = self.application.from_app(&raw, &self.session_id).await {
-                let out_seq = self.runtime.sequences.allocate_sender_seq().value();
-                let frame = self
-                    .factory
-                    .session_reject(out_seq, seq, msg_type.as_str(), &reason);
-                if let Err(err) = self.send_admin(framed, frame).await {
-                    teardown(phase);
-                    return Err(closed(format!("send failed: {err}"), false));
+                    let _ = session.disconnect();
+                    let text = raw
+                        .get_field_str(58)
+                        .unwrap_or("logout initiated by counterparty");
+                    Err(closed(format!("logout by counterparty: {text}"), true))
                 }
-            }
-            Ok(phase)
+            },
+            // SequenceReset is handled before dispatch; every other admin
+            // type is matched above.
+            _ => Ok(phase),
         }
     }
 }

--- a/ironfix-engine/src/wire.rs
+++ b/ironfix-engine/src/wire.rs
@@ -20,23 +20,188 @@ use ironfix_core::types::Timestamp;
 use ironfix_session::SessionConfig;
 use ironfix_tagvalue::{Decoder, Encoder};
 
-/// Returns a `'static` copy of a FIX BeginString.
+/// How a configured FIX version is carried on the wire.
+///
+/// FIX 5.0 and later split the transport version from the application
+/// version: the frame is always a FIXT.1.1 frame (`BeginString` = FIXT.1.1)
+/// and the application version travels in `DefaultApplVerID` (1137) on the
+/// Logon and `ApplVerID` (1128) on application messages
+/// (`doc/fix_operations.md`, "FIX 5.0 / FIXT.1.1"). Putting `FIX.5.0*` in
+/// tag 8 is rejected outright by conforming acceptors.
+///
+/// `ironfix_dictionary::schema::Version` encodes exactly the same mapping in
+/// its `begin_string` / `appl_ver_id` methods, but `ironfix-engine` must not
+/// depend on `ironfix-dictionary` (a hard DAG invariant, see `CLAUDE.md`), so
+/// the mapping is duplicated here in a small spec-derived table. Unifying the
+/// two belongs in `ironfix-core`, which both crates already depend on; that is
+/// follow-up work.
+///
+/// The cost of that duplication is that the two tables can drift apart and no
+/// test can cross-check them without taking the forbidden dependency. Both are
+/// derived from the same fixed clause of the specification and neither changes
+/// unless a new FIX version ships, so the exposure is small — but it is the
+/// reason unifying them is worth doing rather than a permanent arrangement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct WireVersion {
+    /// Value stamped into `BeginString` (8).
+    pub(crate) begin_string: &'static str,
+    /// Application version for `DefaultApplVerID` (1137) and `ApplVerID`
+    /// (1128), or `None` for a pre-5.0 session that has neither.
+    pub(crate) appl_ver_id: Option<&'static str>,
+}
+
+/// A configured `BeginString` the engine cannot frame conformantly.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("unsupported FIX version {version}: {detail}")]
+pub(crate) struct UnsupportedVersion {
+    /// The configured version string.
+    pub(crate) version: String,
+    /// Why it cannot be framed.
+    pub(crate) detail: String,
+}
+
+/// Resolves the configured version string to its on-the-wire representation.
 ///
 /// Well-known versions map to interned constants; anything else is leaked
 /// once (bounded: once per `Initiator`), because the tag-value `Encoder`
-/// requires a `&'static str` BeginString.
-pub(crate) fn static_begin_string(value: &str) -> &'static str {
-    match value {
-        "FIX.4.0" => "FIX.4.0",
-        "FIX.4.1" => "FIX.4.1",
-        "FIX.4.2" => "FIX.4.2",
-        "FIX.4.3" => "FIX.4.3",
-        "FIX.4.4" => "FIX.4.4",
-        "FIX.5.0" => "FIX.5.0",
-        "FIX.5.0SP1" => "FIX.5.0SP1",
-        "FIX.5.0SP2" => "FIX.5.0SP2",
-        "FIXT.1.1" => "FIXT.1.1",
-        other => Box::leak(other.to_owned().into_boxed_str()),
+/// requires a `&'static str` BeginString. An unrecognized version is passed
+/// through verbatim with no application version, which is the only honest
+/// answer available without a dictionary.
+///
+/// A session configured as `FIXT.1.1` gets no `ApplVerID`: FIXT.1.1 names the
+/// transport version only and does not identify an application version.
+/// Configure `FIX.5.0`, `FIX.5.0SP1` or `FIX.5.0SP2` to have 1137 and 1128
+/// stamped.
+pub(crate) fn wire_version(value: &str) -> Result<WireVersion, UnsupportedVersion> {
+    let (begin_string, appl_ver_id) = match value {
+        "FIX.4.0" => ("FIX.4.0", None),
+        "FIX.4.1" => ("FIX.4.1", None),
+        "FIX.4.2" => ("FIX.4.2", None),
+        "FIX.4.3" => ("FIX.4.3", None),
+        "FIX.4.4" => ("FIX.4.4", None),
+        "FIX.5.0" => ("FIXT.1.1", Some("7")),
+        "FIX.5.0SP1" => ("FIXT.1.1", Some("8")),
+        "FIX.5.0SP2" => ("FIXT.1.1", Some("9")),
+        // FIXT.1.1 names the transport version only. A FIXT Logon must carry
+        // DefaultApplVerID (1137), which is required, and nothing here can
+        // supply it: the application version is exactly what this string
+        // failed to state. Defaulting it would put a guessed version on the
+        // wire, so the session is refused instead.
+        "FIXT.1.1" => {
+            return Err(UnsupportedVersion {
+                version: value.to_owned(),
+                detail: "FIXT.1.1 names only the transport version and carries no application \
+                         version for DefaultApplVerID (1137), which a FIXT Logon requires; \
+                         configure FIX.5.0, FIX.5.0SP1 or FIX.5.0SP2 instead"
+                    .to_owned(),
+            });
+        }
+        other => {
+            return Err(UnsupportedVersion {
+                version: other.to_owned(),
+                detail: "not a FIX version this engine can frame; supported values are FIX.4.0 \
+                         through FIX.4.4 and FIX.5.0, FIX.5.0SP1, FIX.5.0SP2"
+                    .to_owned(),
+            });
+        }
+    };
+    Ok(WireVersion {
+        begin_string,
+        appl_ver_id,
+    })
+}
+
+/// A mismatch between an inbound message's identity fields and the
+/// configured counterparty.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct IdentityMismatch {
+    /// The offending tag (49, 56, 50 or 57).
+    pub(crate) tag: u32,
+    /// The value the configuration requires.
+    pub(crate) expected: String,
+    /// The value the counterparty sent, empty when the tag was absent.
+    pub(crate) received: String,
+}
+
+impl std::fmt::Display for IdentityMismatch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "CompID problem: tag {} expected '{}', received '{}'",
+            self.tag, self.expected, self.received
+        )
+    }
+}
+
+/// The identity every inbound message must carry, derived from the session
+/// configuration with sender and target reversed.
+///
+/// A cross-wired connection that is never checked advances sequence state
+/// against the wrong counterparty and delivers another session's traffic to
+/// the application, so this is validated before anything else touches
+/// session state. A mismatch is `SessionRejectReason` 9, "CompID problem"
+/// (`doc/fix_operations.md`, "Session Reject Reasons").
+#[derive(Debug, Clone)]
+pub(crate) struct PeerIdentity {
+    /// Required inbound `SenderCompID` (49) — our configured target.
+    sender_comp_id: String,
+    /// Required inbound `TargetCompID` (56) — our configured sender.
+    target_comp_id: String,
+    /// Required inbound `SenderSubID` (50), when configured.
+    sender_sub_id: Option<String>,
+    /// Required inbound `TargetSubID` (57), when configured.
+    target_sub_id: Option<String>,
+}
+
+impl PeerIdentity {
+    /// Builds the expected inbound identity from the session configuration.
+    #[must_use]
+    pub(crate) fn new(config: &SessionConfig) -> Self {
+        Self {
+            sender_comp_id: config.target_comp_id.as_str().to_string(),
+            target_comp_id: config.sender_comp_id.as_str().to_string(),
+            sender_sub_id: config.target_sub_id.clone(),
+            target_sub_id: config.sender_sub_id.clone(),
+        }
+    }
+
+    /// Checks an inbound message's identity fields.
+    ///
+    /// Sub IDs are only checked when configured; an unconfigured sub ID
+    /// places no requirement on the counterparty.
+    /// # Positional caveat
+    ///
+    /// Field lookup is by tag over the whole decoded message, not by position,
+    /// so CompIDs appearing anywhere in the frame satisfy the check. A message
+    /// that omits them from the standard header but carries them in the body is
+    /// therefore accepted. Enforcing header position needs positional
+    /// information the decoder does not currently retain; the practical impact
+    /// is small, since a peer able to place the tags in the body can equally
+    /// place them in the header.
+    pub(crate) fn validate(&self, raw: &RawMessage<'_>) -> Result<(), IdentityMismatch> {
+        check_field(raw, 49, &self.sender_comp_id)?;
+        check_field(raw, 56, &self.target_comp_id)?;
+        if let Some(expected) = &self.sender_sub_id {
+            check_field(raw, 50, expected)?;
+        }
+        if let Some(expected) = &self.target_sub_id {
+            check_field(raw, 57, expected)?;
+        }
+        Ok(())
+    }
+}
+
+/// Compares one inbound identity field against its required value.
+fn check_field(raw: &RawMessage<'_>, tag: u32, expected: &str) -> Result<(), IdentityMismatch> {
+    let received = raw.get_field_str(tag).unwrap_or_default();
+    if received == expected {
+        Ok(())
+    } else {
+        Err(IdentityMismatch {
+            tag,
+            expected: expected.to_string(),
+            received: received.to_string(),
+        })
     }
 }
 
@@ -58,7 +223,7 @@ pub(crate) fn owned_from_frame(frame: &[u8]) -> Result<OwnedMessage, DecodeError
 /// Builds outbound frames with the session header stamped.
 #[derive(Debug)]
 pub(crate) struct MessageFactory {
-    begin_string: &'static str,
+    version: WireVersion,
     sender_comp_id: String,
     target_comp_id: String,
     sender_sub_id: Option<String>,
@@ -67,9 +232,10 @@ pub(crate) struct MessageFactory {
 
 impl MessageFactory {
     /// Creates a factory from the session configuration.
-    pub(crate) fn new(config: &SessionConfig, begin_string: &'static str) -> Self {
+    #[must_use]
+    pub(crate) fn new(config: &SessionConfig, version: WireVersion) -> Self {
         Self {
-            begin_string,
+            version,
             sender_comp_id: config.sender_comp_id.as_str().to_string(),
             target_comp_id: config.target_comp_id.as_str().to_string(),
             sender_sub_id: config.sender_sub_id.clone(),
@@ -78,10 +244,33 @@ impl MessageFactory {
     }
 
     /// Starts an encoder with the standard header:
-    /// 35, 49, 56, [50], [57], 34, [43], 52.
-    fn header(&self, msg_type: &str, seq: u64, poss_dup: bool) -> Encoder {
-        let mut encoder = Encoder::new(self.begin_string);
+    /// 35, [1128], 49, 56, [50], [57], 34, [43], 52, [122].
+    ///
+    /// `poss_dup` stamps both `PossDupFlag` (43) and `OrigSendingTime` (122):
+    /// FIX requires 122 on every message carrying 43=Y, and
+    /// `doc/fix_operations.md` mandates it for resends. The engine has no
+    /// message store, so the original sending time of the replaced messages
+    /// is not recoverable; per the spec's handling of an unavailable
+    /// OrigSendingTime the current time is used, which is also what a
+    /// SequenceReset-GapFill (whose "original" messages are administrative
+    /// filler, not replayed traffic) needs.
+    ///
+    /// `appl_ver_id` stamps `ApplVerID` (1128) immediately after MsgType,
+    /// its position in the FIXT.1.1 standard header. It is passed only for
+    /// application messages; session-level messages are versioned by the
+    /// FIXT.1.1 BeginString itself.
+    fn header(
+        &self,
+        msg_type: &str,
+        seq: u64,
+        poss_dup: bool,
+        appl_ver_id: Option<&str>,
+    ) -> Encoder {
+        let mut encoder = Encoder::new(self.version.begin_string);
         encoder.put_str(35, msg_type);
+        if let Some(appl_ver_id) = appl_ver_id {
+            encoder.put_str(1128, appl_ver_id);
+        }
         encoder.put_str(49, &self.sender_comp_id);
         encoder.put_str(56, &self.target_comp_id);
         if let Some(sub) = &self.sender_sub_id {
@@ -94,17 +283,25 @@ impl MessageFactory {
         if poss_dup {
             encoder.put_bool(43, true);
         }
-        encoder.put_str(52, Timestamp::now().format_millis().as_str());
+        let sending_time = Timestamp::now().format_millis();
+        encoder.put_str(52, sending_time.as_str());
+        if poss_dup {
+            encoder.put_str(122, sending_time.as_str());
+        }
         encoder
     }
 
-    /// Builds a Logon (35=A) with EncryptMethod=0 and HeartBtInt.
+    /// Builds a Logon (35=A) with EncryptMethod=0, HeartBtInt and, for a
+    /// FIXT.1.1 session, DefaultApplVerID (1137).
     pub(crate) fn logon(&self, seq: u64, heartbeat_secs: u64, reset_seq: bool) -> BytesMut {
-        let mut encoder = self.header("A", seq, false);
+        let mut encoder = self.header("A", seq, false, None);
         encoder.put_uint(98, 0);
         encoder.put_uint(108, heartbeat_secs);
         if reset_seq {
             encoder.put_bool(141, true);
+        }
+        if let Some(appl_ver_id) = self.version.appl_ver_id {
+            encoder.put_str(1137, appl_ver_id);
         }
         encoder.finish()
     }
@@ -112,7 +309,7 @@ impl MessageFactory {
     /// Builds a Heartbeat (35=0), echoing TestReqID (112) when replying to
     /// a TestRequest.
     pub(crate) fn heartbeat(&self, seq: u64, test_req_id: Option<&str>) -> BytesMut {
-        let mut encoder = self.header("0", seq, false);
+        let mut encoder = self.header("0", seq, false, None);
         if let Some(id) = test_req_id {
             encoder.put_str(112, id);
         }
@@ -121,14 +318,14 @@ impl MessageFactory {
 
     /// Builds a TestRequest (35=1) with TestReqID (112).
     pub(crate) fn test_request(&self, seq: u64, test_req_id: &str) -> BytesMut {
-        let mut encoder = self.header("1", seq, false);
+        let mut encoder = self.header("1", seq, false, None);
         encoder.put_str(112, test_req_id);
         encoder.finish()
     }
 
     /// Builds a Logout (35=5) with optional Text (58).
     pub(crate) fn logout(&self, seq: u64, text: Option<&str>) -> BytesMut {
-        let mut encoder = self.header("5", seq, false);
+        let mut encoder = self.header("5", seq, false, None);
         if let Some(text) = text {
             encoder.put_str(58, text);
         }
@@ -138,7 +335,7 @@ impl MessageFactory {
     /// Builds a ResendRequest (35=2) for `begin_seq..end_seq`
     /// (`end_seq` = 0 means "up to infinity").
     pub(crate) fn resend_request(&self, seq: u64, begin_seq: u64, end_seq: u64) -> BytesMut {
-        let mut encoder = self.header("2", seq, false);
+        let mut encoder = self.header("2", seq, false, None);
         encoder.put_uint(7, begin_seq);
         encoder.put_uint(16, end_seq);
         encoder.finish()
@@ -146,9 +343,10 @@ impl MessageFactory {
 
     /// Builds a SequenceReset-GapFill (35=4, 123=Y) that answers a
     /// ResendRequest by jumping the counterparty's expectation to `new_seq`.
-    /// Stamped with the gap's begin sequence and PossDupFlag (43=Y).
+    /// Stamped with the gap's begin sequence, PossDupFlag (43=Y) and
+    /// OrigSendingTime (122).
     pub(crate) fn sequence_reset_gap_fill(&self, seq: u64, new_seq: u64) -> BytesMut {
-        let mut encoder = self.header("4", seq, true);
+        let mut encoder = self.header("4", seq, true, None);
         encoder.put_bool(123, true);
         encoder.put_uint(36, new_seq);
         encoder.finish()
@@ -162,7 +360,7 @@ impl MessageFactory {
         ref_msg_type: &str,
         reason: &RejectReason,
     ) -> BytesMut {
-        let mut encoder = self.header("3", seq, false);
+        let mut encoder = self.header("3", seq, false, None);
         encoder.put_uint(45, ref_seq);
         if let Some(ref_tag) = reason.ref_tag {
             encoder.put_uint(371, u64::from(ref_tag));
@@ -175,9 +373,15 @@ impl MessageFactory {
         encoder.finish()
     }
 
-    /// Builds an application message from an [`OutboundMessage`].
+    /// Builds an application message from an [`OutboundMessage`], stamping
+    /// ApplVerID (1128) for a FIXT.1.1 session.
     pub(crate) fn application_message(&self, seq: u64, message: &OutboundMessage) -> BytesMut {
-        let mut encoder = self.header(message.msg_type().as_str(), seq, false);
+        let mut encoder = self.header(
+            message.msg_type().as_str(),
+            seq,
+            false,
+            self.version.appl_ver_id,
+        );
         for (tag, value) in message.fields() {
             encoder.put_raw(*tag, value);
         }
@@ -191,19 +395,39 @@ mod tests {
     use ironfix_core::message::MsgType;
     use ironfix_core::types::CompId;
 
+    fn config_for(begin_string: &str) -> SessionConfig {
+        let Some(sender) = CompId::new("CLIENT") else {
+            unreachable!("CLIENT is a valid CompId")
+        };
+        let Some(target) = CompId::new("VENUE") else {
+            unreachable!("VENUE is a valid CompId")
+        };
+        SessionConfig::new(sender, target, begin_string)
+    }
+
+    fn factory_for(begin_string: &str) -> MessageFactory {
+        let config = config_for(begin_string);
+        match wire_version(&config.begin_string) {
+            Ok(version) => MessageFactory::new(&config, version),
+            Err(err) => panic!("test fixture uses an unsupported version: {err}"),
+        }
+    }
+
     fn factory() -> MessageFactory {
-        let config = SessionConfig::new(
-            CompId::new("CLIENT").unwrap(),
-            CompId::new("VENUE").unwrap(),
-            "FIX.4.4",
-        );
-        MessageFactory::new(&config, static_begin_string(&config.begin_string))
+        factory_for("FIX.4.4")
+    }
+
+    fn decode(frame: &[u8]) -> RawMessage<'_> {
+        match decode_frame(frame) {
+            Ok(raw) => raw,
+            Err(err) => unreachable!("factory frame must decode: {err}"),
+        }
     }
 
     #[test]
     fn test_logon_frame_roundtrip() {
         let frame = factory().logon(1, 30, true);
-        let raw = decode_frame(&frame).unwrap();
+        let raw = decode(&frame);
         assert_eq!(raw.msg_type(), &MsgType::Logon);
         assert_eq!(raw.get_field_str(49), Some("CLIENT"));
         assert_eq!(raw.get_field_str(56), Some("VENUE"));
@@ -211,17 +435,31 @@ mod tests {
         assert_eq!(raw.get_field_str(98), Some("0"));
         assert_eq!(raw.get_field_str(108), Some("30"));
         assert_eq!(raw.get_field_str(141), Some("Y"));
+        // Pre-5.0 session: no application version fields.
+        assert_eq!(raw.get_field_str(1137), None);
     }
 
     #[test]
-    fn test_gap_fill_frame() {
+    fn test_gap_fill_frame_carries_orig_sending_time() {
         let frame = factory().sequence_reset_gap_fill(3, 10);
-        let raw = decode_frame(&frame).unwrap();
+        let raw = decode(&frame);
         assert_eq!(raw.msg_type(), &MsgType::SequenceReset);
         assert_eq!(raw.get_field_str(34), Some("3"));
         assert_eq!(raw.get_field_str(43), Some("Y"));
         assert_eq!(raw.get_field_str(123), Some("Y"));
         assert_eq!(raw.get_field_str(36), Some("10"));
+        // Every frame carrying PossDupFlag must carry OrigSendingTime, and
+        // absent a store it equals SendingTime.
+        assert_eq!(raw.get_field_str(122), raw.get_field_str(52));
+        assert!(raw.get_field_str(122).is_some());
+    }
+
+    #[test]
+    fn test_non_poss_dup_frame_omits_orig_sending_time() {
+        let frame = factory().heartbeat(4, None);
+        let raw = decode(&frame);
+        assert_eq!(raw.get_field_str(43), None);
+        assert_eq!(raw.get_field_str(122), None);
     }
 
     #[test]
@@ -230,16 +468,149 @@ mod tests {
         message.push_str(11, "ORDER-1").push_char(54, '1');
 
         let frame = factory().application_message(7, &message);
-        let raw = decode_frame(&frame).unwrap();
+        let raw = decode(&frame);
         assert_eq!(raw.msg_type(), &MsgType::NewOrderSingle);
         assert_eq!(raw.get_field_str(34), Some("7"));
         assert_eq!(raw.get_field_str(11), Some("ORDER-1"));
         assert_eq!(raw.get_field_str(54), Some("1"));
+        assert_eq!(raw.get_field_str(1128), None);
     }
 
     #[test]
-    fn test_static_begin_string_interned() {
-        assert_eq!(static_begin_string("FIX.4.4"), "FIX.4.4");
-        assert_eq!(static_begin_string("FIX.9.9"), "FIX.9.9");
+    fn test_wire_version_pre_fixt_passthrough() {
+        assert_eq!(
+            wire_version("FIX.4.4"),
+            Ok(WireVersion {
+                begin_string: "FIX.4.4",
+                appl_ver_id: None,
+            })
+        );
+    }
+
+    #[test]
+    fn test_wire_version_unknown_is_typed_error() {
+        // An unsupported version must degrade to an explicit typed error, never
+        // travel onto the wire as a fabricated BeginString.
+        match wire_version("FIX.9.9") {
+            Err(err) => assert_eq!(err.version, "FIX.9.9"),
+            Ok(version) => panic!("FIX.9.9 must not be framed, got {version:?}"),
+        }
+    }
+
+    #[test]
+    fn test_wire_version_bare_fixt_is_rejected_for_missing_appl_ver_id() {
+        // FIXT.1.1 names only the transport version. Its Logon requires
+        // DefaultApplVerID (1137) and nothing here can supply it, so the
+        // session is refused rather than sent without a required field.
+        match wire_version("FIXT.1.1") {
+            Err(err) => {
+                assert_eq!(err.version, "FIXT.1.1");
+                assert!(
+                    err.detail.contains("1137"),
+                    "the reason should name the missing field, got {}",
+                    err.detail
+                );
+            }
+            Ok(version) => panic!("bare FIXT.1.1 must be refused, got {version:?}"),
+        }
+    }
+
+    #[test]
+    fn test_wire_version_fix50_maps_to_fixt() {
+        assert_eq!(
+            wire_version("FIX.5.0"),
+            Ok(WireVersion {
+                begin_string: "FIXT.1.1",
+                appl_ver_id: Some("7"),
+            })
+        );
+        assert_eq!(
+            wire_version("FIX.5.0SP1"),
+            Ok(WireVersion {
+                begin_string: "FIXT.1.1",
+                appl_ver_id: Some("8"),
+            })
+        );
+        assert_eq!(
+            wire_version("FIX.5.0SP2"),
+            Ok(WireVersion {
+                begin_string: "FIXT.1.1",
+                appl_ver_id: Some("9"),
+            })
+        );
+    }
+
+    #[test]
+    fn test_fix50sp2_logon_carries_fixt_begin_string_and_default_appl_ver_id() {
+        let frame = factory_for("FIX.5.0SP2").logon(1, 30, false);
+        let raw = decode(&frame);
+        assert_eq!(raw.begin_string(), Ok("FIXT.1.1"));
+        assert_eq!(raw.get_field_str(1137), Some("9"));
+    }
+
+    #[test]
+    fn test_fix50sp2_application_message_carries_appl_ver_id() {
+        let mut message = OutboundMessage::new(MsgType::NewOrderSingle);
+        message.push_str(11, "ORDER-1");
+
+        let frame = factory_for("FIX.5.0SP2").application_message(2, &message);
+        let raw = decode(&frame);
+        assert_eq!(raw.begin_string(), Ok("FIXT.1.1"));
+        assert_eq!(raw.get_field_str(1128), Some("9"));
+    }
+
+    #[test]
+    fn test_peer_identity_accepts_reversed_comp_ids() {
+        let identity = PeerIdentity::new(&config_for("FIX.4.4"));
+        let mut encoder = Encoder::new("FIX.4.4");
+        encoder.put_str(35, "0");
+        encoder.put_str(49, "VENUE");
+        encoder.put_str(56, "CLIENT");
+        encoder.put_uint(34, 1);
+        let frame = encoder.finish();
+
+        assert_eq!(identity.validate(&decode(&frame)), Ok(()));
+    }
+
+    #[test]
+    fn test_peer_identity_rejects_wrong_sender_comp_id() {
+        let identity = PeerIdentity::new(&config_for("FIX.4.4"));
+        let mut encoder = Encoder::new("FIX.4.4");
+        encoder.put_str(35, "0");
+        encoder.put_str(49, "OTHER");
+        encoder.put_str(56, "CLIENT");
+        encoder.put_uint(34, 1);
+        let frame = encoder.finish();
+
+        assert_eq!(
+            identity.validate(&decode(&frame)),
+            Err(IdentityMismatch {
+                tag: 49,
+                expected: "VENUE".to_string(),
+                received: "OTHER".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn test_peer_identity_rejects_missing_sub_id_when_configured() {
+        let config = config_for("FIX.4.4").with_sender_sub_id("DESK");
+        let identity = PeerIdentity::new(&config);
+        let mut encoder = Encoder::new("FIX.4.4");
+        encoder.put_str(35, "0");
+        encoder.put_str(49, "VENUE");
+        encoder.put_str(56, "CLIENT");
+        encoder.put_uint(34, 1);
+        let frame = encoder.finish();
+
+        // Our SenderSubID is the peer's TargetSubID (57).
+        assert_eq!(
+            identity.validate(&decode(&frame)),
+            Err(IdentityMismatch {
+                tag: 57,
+                expected: "DESK".to_string(),
+                received: String::new(),
+            })
+        );
     }
 }

--- a/ironfix-engine/tests/initiator_tests.rs
+++ b/ironfix-engine/tests/initiator_tests.rs
@@ -1693,3 +1693,209 @@ async fn test_with_initial_sequences_seeds_counters() {
         "acceptor task",
     );
 }
+
+// ---------------------------------------------------------------------------
+// SequenceReset classification runs before the application callback
+// ---------------------------------------------------------------------------
+
+/// A GapFill whose own MsgSeqNum is gapped must trigger a ResendRequest even
+/// when the application would reject it: sequence classification runs before
+/// `from_admin`, so the rejection cannot turn the required ResendRequest into a
+/// session Reject.
+#[tokio::test]
+async fn test_gapped_gap_fill_rejected_by_app_requests_resend_not_reject() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+        // Expecting 2, but the GapFill claims 34=7 and jumps to 20.
+        ok(
+            framed
+                .send(venue_msg("4", 7, &[(123, "Y"), (36, "20")]))
+                .await,
+            "send gapped gap fill",
+        );
+
+        // The reply must be a ResendRequest (35=2), never a session Reject.
+        let reply = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&reply), "2");
+        assert_eq!(field(&reply, 7).as_deref(), Some("2"));
+        assert_eq!(field(&reply, 16).as_deref(), Some("0"));
+    });
+
+    // rejecting_admin makes from_admin reject every non-Logon admin message: if
+    // it were reached for the gapped fill the reply would be a 35=3 Reject.
+    let (app, _app_rx) = RecordingApp::rejecting_admin();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+    // NewSeqNo must NOT have been applied.
+    assert_eq!(connection.next_target_seq(), 2);
+}
+
+/// A too-low GapFill flagged PossDup is an already-applied duplicate: it is
+/// dropped before `from_admin` runs. With a from_admin that rejects every admin
+/// message, the discriminator is that NO session Reject comes back for the
+/// duplicate -- the callback was never reached.
+#[tokio::test]
+async fn test_too_low_duplicate_gap_fill_dropped_without_from_admin() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+
+        // Advance the client's target past 2 with an in-order report at 34=2.
+        ok(
+            framed
+                .send(venue_msg(
+                    "8",
+                    2,
+                    &[(37, "EX-1"), (17, "E-1"), (150, "0"), (39, "0")],
+                ))
+                .await,
+            "send report at 2",
+        );
+        // Too-low GapFill (34=2) flagged PossDup: an already-applied duplicate.
+        ok(
+            framed
+                .send(venue_msg("4", 2, &[(123, "Y"), (43, "Y"), (36, "3")]))
+                .await,
+            "send too-low duplicate gap fill",
+        );
+        // The next in-order report at 34=3 proves the session survived and the
+        // duplicate consumed nothing.
+        ok(
+            framed
+                .send(venue_msg(
+                    "8",
+                    3,
+                    &[(37, "EX-2"), (17, "E-2"), (150, "0"), (39, "0")],
+                ))
+                .await,
+            "send report at 3",
+        );
+
+        // No session Reject may come back for the dropped duplicate.
+        assert!(
+            timeout(Duration::from_millis(300), framed.next())
+                .await
+                .is_err(),
+            "a too-low duplicate must be dropped, not rejected via from_admin"
+        );
+    });
+
+    let (app, mut app_rx) = RecordingApp::rejecting_admin();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    // Both reports (application messages) are delivered; the duplicate GapFill
+    // is not.
+    for expected in ["8", "8"] {
+        let received = some(
+            ok(
+                timeout(Duration::from_secs(5), app_rx.recv()).await,
+                "app message within 5s",
+            ),
+            "app channel must stay open",
+        );
+        assert_eq!(received, expected);
+    }
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+    // Target advanced 2 -> 3 -> 4; the duplicate at 2 consumed nothing.
+    assert_eq!(connection.next_target_seq(), 4);
+}
+
+/// A GapFillFlag (123) that is present but neither Y nor N is a data-format
+/// error: session Reject with reason 6 and RefTagID 123, not a silent Reset.
+#[tokio::test]
+async fn test_sequence_reset_malformed_gap_fill_flag_is_rejected() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+        ok(
+            framed
+                .send(venue_msg("4", 2, &[(123, "X"), (36, "10")]))
+                .await,
+            "send malformed gap fill flag",
+        );
+
+        let reject = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&reject), "3");
+        assert_eq!(field(&reject, 45).as_deref(), Some("2"));
+        assert_eq!(field(&reject, 372).as_deref(), Some("4"));
+        assert_eq!(field(&reject, 373).as_deref(), Some("6"));
+        assert_eq!(field(&reject, 371).as_deref(), Some("123"));
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+    // The malformed reset was rejected without touching sequence state.
+    assert_eq!(connection.next_target_seq(), 2);
+}
+
+// ---------------------------------------------------------------------------
+// Logon ack BeginString validation
+// ---------------------------------------------------------------------------
+
+/// A Logon ack whose BeginString differs from the configured session version
+/// aborts the handshake: an ack in a different FIX dialect is not this
+/// session's acknowledgement, whatever its CompIDs say.
+#[tokio::test]
+async fn test_logon_ack_wrong_begin_string_fails_handshake() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_framed(listener).await;
+        let _logon = next_frame(&mut framed).await;
+        // The client is configured FIX.4.4; ack with FIX.4.2.
+        let mut encoder = Encoder::new("FIX.4.2");
+        encoder.put_str(35, "A");
+        encoder.put_str(49, "VENUE");
+        encoder.put_str(56, "CLIENT");
+        encoder.put_uint(34, 1);
+        encoder.put_str(52, Timestamp::now().format_millis().as_str());
+        encoder.put_str(98, "0");
+        encoder.put_str(108, "30");
+        ok(
+            framed.send(encoder.finish()).await,
+            "send wrong-version logon ack",
+        );
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+
+    match initiator.connect(addr).await {
+        Err(EngineError::BeginStringMismatch { expected, received }) => {
+            assert_eq!(expected, "FIX.4.4");
+            assert_eq!(received, "FIX.4.2");
+        }
+        other => panic!("expected BeginStringMismatch, got {other:?}"),
+    }
+
+    ok(acceptor.await, "acceptor task");
+}

--- a/ironfix-engine/tests/initiator_tests.rs
+++ b/ironfix-engine/tests/initiator_tests.rs
@@ -5,7 +5,8 @@
 ******************************************************************************/
 
 //! Integration tests for the `Initiator`: dial, Logon handshake, message
-//! exchange, heartbeats, and close observation against a stub acceptor.
+//! exchange, heartbeats, sequence recovery, and teardown against a stub
+//! acceptor.
 
 use async_trait::async_trait;
 use bytes::BytesMut;
@@ -16,6 +17,7 @@ use ironfix_core::types::{CompId, Timestamp};
 use ironfix_engine::application::{Application, RejectReason, SessionId};
 use ironfix_engine::{EngineError, Initiator, OutboundMessage};
 use ironfix_session::SessionConfig;
+use ironfix_session::sequence::SequenceCounter;
 use ironfix_tagvalue::{Decoder, Encoder};
 use ironfix_transport::FixCodec;
 use std::sync::{Arc, Mutex};
@@ -25,12 +27,48 @@ use tokio::sync::mpsc;
 use tokio::time::timeout;
 use tokio_util::codec::Framed;
 
+/// Fails the test with context instead of `.unwrap()` / `.expect()`.
+#[track_caller]
+fn ok<T, E: std::fmt::Debug>(result: Result<T, E>, what: &str) -> T {
+    match result {
+        Ok(value) => value,
+        Err(err) => panic!("{what}: {err:?}"),
+    }
+}
+
+/// Fails the test with context instead of `.unwrap()` / `.expect()`.
+#[track_caller]
+fn some<T>(value: Option<T>, what: &str) -> T {
+    match value {
+        Some(value) => value,
+        None => panic!("{what}"),
+    }
+}
+
+/// Builds a CompID for the test fixtures.
+#[track_caller]
+fn comp_id(value: &str) -> CompId {
+    some(CompId::new(value), "test CompId must be valid")
+}
+
 /// Stub-acceptor side frame builder (VENUE -> CLIENT).
 fn venue_msg(msg_type: &str, seq: u64, extra: &[(u32, &str)]) -> BytesMut {
+    venue_msg_from("VENUE", "CLIENT", msg_type, seq, extra)
+}
+
+/// Stub-acceptor side frame builder with explicit CompIDs, for identity
+/// validation tests.
+fn venue_msg_from(
+    sender: &str,
+    target: &str,
+    msg_type: &str,
+    seq: u64,
+    extra: &[(u32, &str)],
+) -> BytesMut {
     let mut encoder = Encoder::new("FIX.4.4");
     encoder.put_str(35, msg_type);
-    encoder.put_str(49, "VENUE");
-    encoder.put_str(56, "CLIENT");
+    encoder.put_str(49, sender);
+    encoder.put_str(56, target);
     encoder.put_uint(34, seq);
     encoder.put_str(52, Timestamp::now().format_millis().as_str());
     for (tag, value) in extra {
@@ -42,34 +80,59 @@ fn venue_msg(msg_type: &str, seq: u64, extra: &[(u32, &str)]) -> BytesMut {
 /// Extracts a field from a framed message.
 fn field(frame: &[u8], tag: u32) -> Option<String> {
     let mut decoder = Decoder::new(frame);
-    let raw = decoder.decode().expect("frame decodes");
-    raw.get_field_str(tag).map(str::to_string)
+    match decoder.decode() {
+        Ok(raw) => raw.get_field_str(tag).map(str::to_string),
+        Err(_) => None,
+    }
 }
 
+#[track_caller]
 fn msg_type_of(frame: &[u8]) -> String {
-    field(frame, 35).expect("35 present")
+    some(field(frame, 35), "frame must carry MsgType (35)")
 }
 
 fn client_config(heartbeat: Duration) -> SessionConfig {
-    SessionConfig::new(
-        CompId::new("CLIENT").unwrap(),
-        CompId::new("VENUE").unwrap(),
-        "FIX.4.4",
-    )
-    .with_heartbeat_interval(heartbeat)
+    SessionConfig::new(comp_id("CLIENT"), comp_id("VENUE"), "FIX.4.4")
+        .with_heartbeat_interval(heartbeat)
 }
 
 async fn accept_framed(listener: TcpListener) -> Framed<TcpStream, FixCodec> {
-    let (socket, _) = listener.accept().await.expect("accept");
+    let (socket, _) = ok(listener.accept().await, "acceptor must accept");
     Framed::new(socket, FixCodec::new())
 }
 
 async fn next_frame(framed: &mut Framed<TcpStream, FixCodec>) -> BytesMut {
-    timeout(Duration::from_secs(5), framed.next())
-        .await
-        .expect("frame within 5s")
-        .expect("stream open")
-        .expect("frame ok")
+    let polled = ok(
+        timeout(Duration::from_secs(5), framed.next()).await,
+        "frame must arrive within 5s",
+    );
+    let frame = some(polled, "stream must stay open");
+    ok(frame, "frame must decode")
+}
+
+/// Drives the stub acceptor through the Logon handshake and returns the
+/// framed socket, positioned just after the ack.
+async fn accept_logon(listener: TcpListener) -> Framed<TcpStream, FixCodec> {
+    let mut framed = accept_framed(listener).await;
+    let logon = next_frame(&mut framed).await;
+    assert_eq!(msg_type_of(&logon), "A");
+    ok(
+        framed
+            .send(venue_msg("A", 1, &[(98, "0"), (108, "30")]))
+            .await,
+        "acceptor must send the Logon ack",
+    );
+    framed
+}
+
+/// Binds an ephemeral loopback listener.
+async fn bind_listener() -> (TcpListener, std::net::SocketAddr) {
+    let listener = ok(
+        TcpListener::bind("127.0.0.1:0").await,
+        "listener must bind to loopback",
+    );
+    let addr = ok(listener.local_addr(), "listener must report its address");
+    (listener, addr)
 }
 
 /// Records session events and received app messages.
@@ -78,27 +141,51 @@ struct RecordingApp {
     events: Mutex<Vec<String>>,
     app_rx_tx: mpsc::UnboundedSender<String>,
     reject_app: bool,
+    reject_admin: bool,
 }
 
 impl RecordingApp {
-    fn new(reject_app: bool) -> (Arc<Self>, mpsc::UnboundedReceiver<String>) {
+    fn build(reject_app: bool, reject_admin: bool) -> (Arc<Self>, mpsc::UnboundedReceiver<String>) {
         let (tx, rx) = mpsc::unbounded_channel();
         (
             Arc::new(Self {
                 events: Mutex::new(Vec::new()),
                 app_rx_tx: tx,
                 reject_app,
+                reject_admin,
             }),
             rx,
         )
     }
 
-    fn record(&self, event: &str) {
-        self.events.lock().unwrap().push(event.to_string());
+    fn new() -> (Arc<Self>, mpsc::UnboundedReceiver<String>) {
+        Self::build(false, false)
     }
 
+    fn rejecting_app() -> (Arc<Self>, mpsc::UnboundedReceiver<String>) {
+        Self::build(true, false)
+    }
+
+    /// Rejects every admin message except the Logon, so the handshake still
+    /// completes and the reactor path can be exercised.
+    fn rejecting_admin() -> (Arc<Self>, mpsc::UnboundedReceiver<String>) {
+        Self::build(false, true)
+    }
+
+    #[track_caller]
+    fn record(&self, event: &str) {
+        match self.events.lock() {
+            Ok(mut events) => events.push(event.to_string()),
+            Err(_) => panic!("event lock poisoned"),
+        }
+    }
+
+    #[track_caller]
     fn events(&self) -> Vec<String> {
-        self.events.lock().unwrap().clone()
+        match self.events.lock() {
+            Ok(events) => events.clone(),
+            Err(_) => panic!("event lock poisoned"),
+        }
     }
 }
 
@@ -125,9 +212,12 @@ impl Application for RecordingApp {
 
     async fn from_admin(
         &self,
-        _message: &RawMessage<'_>,
+        message: &RawMessage<'_>,
         _session_id: &SessionId,
     ) -> Result<(), RejectReason> {
+        if self.reject_admin && message.msg_type() != &MsgType::Logon {
+            return Err(RejectReason::new(99, "admin rejected by test app"));
+        }
         Ok(())
     }
 
@@ -156,8 +246,7 @@ impl Application for RecordingApp {
 /// acceptor), app message in, graceful logout, wait_closed.
 #[tokio::test]
 async fn test_logon_exchange_and_logout() {
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
+    let (listener, addr) = bind_listener().await;
 
     let acceptor = tokio::spawn(async move {
         let mut framed = accept_framed(listener).await;
@@ -168,39 +257,43 @@ async fn test_logon_exchange_and_logout() {
         assert_eq!(field(&logon, 56).as_deref(), Some("VENUE"));
         assert_eq!(field(&logon, 34).as_deref(), Some("1"));
         assert_eq!(field(&logon, 108).as_deref(), Some("30"));
-        framed
-            .send(venue_msg("A", 1, &[(98, "0"), (108, "30")]))
-            .await
-            .unwrap();
+        ok(
+            framed
+                .send(venue_msg("A", 1, &[(98, "0"), (108, "30")]))
+                .await,
+            "send logon ack",
+        );
 
         let order = next_frame(&mut framed).await;
         assert_eq!(msg_type_of(&order), "D");
         assert_eq!(field(&order, 34).as_deref(), Some("2"));
         assert_eq!(field(&order, 11).as_deref(), Some("ORDER-1"));
-        framed
-            .send(venue_msg(
-                "8",
-                2,
-                &[
-                    (37, "EX-1"),
-                    (11, "ORDER-1"),
-                    (17, "E-1"),
-                    (150, "0"),
-                    (39, "0"),
-                ],
-            ))
-            .await
-            .unwrap();
+        ok(
+            framed
+                .send(venue_msg(
+                    "8",
+                    2,
+                    &[
+                        (37, "EX-1"),
+                        (11, "ORDER-1"),
+                        (17, "E-1"),
+                        (150, "0"),
+                        (39, "0"),
+                    ],
+                ))
+                .await,
+            "send execution report",
+        );
 
         let logout = next_frame(&mut framed).await;
         assert_eq!(msg_type_of(&logout), "5");
         assert_eq!(field(&logout, 34).as_deref(), Some("3"));
-        framed.send(venue_msg("5", 3, &[])).await.unwrap();
+        ok(framed.send(venue_msg("5", 3, &[])).await, "send logout ack");
     });
 
-    let (app, mut app_rx) = RecordingApp::new(false);
+    let (app, mut app_rx) = RecordingApp::new();
     let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
-    let connection = initiator.connect(addr).await.expect("connect");
+    let connection = ok(initiator.connect(addr).await, "connect");
 
     assert_eq!(connection.session_id().to_string(), "FIX.4.4:CLIENT->VENUE");
     assert!(app.events().contains(&"logon".to_string()));
@@ -212,18 +305,22 @@ async fn test_logon_exchange_and_logout() {
         .push_str(55, "EUR/USD")
         .push_char(54, '1')
         .push_uint(38, 100);
-    connection.send(order).await.expect("send");
+    ok(connection.send(order).await, "send order");
 
-    let received = timeout(Duration::from_secs(5), app_rx.recv())
-        .await
-        .expect("app message within 5s")
-        .expect("channel open");
+    let received = some(
+        ok(
+            timeout(Duration::from_secs(5), app_rx.recv()).await,
+            "app message within 5s",
+        ),
+        "app channel must stay open",
+    );
     assert_eq!(received, "8");
 
-    connection.logout().await.expect("logout");
-    timeout(Duration::from_secs(5), connection.wait_closed())
-        .await
-        .expect("closed within 5s");
+    ok(connection.logout().await, "logout");
+    ok(
+        timeout(Duration::from_secs(5), connection.wait_closed()).await,
+        "closed within 5s",
+    );
 
     assert!(connection.is_closed());
     assert!(
@@ -236,78 +333,149 @@ async fn test_logon_exchange_and_logout() {
     assert_eq!(events.first().map(String::as_str), Some("create"));
     assert!(events.contains(&"logout".to_string()));
 
-    acceptor.await.unwrap();
+    ok(acceptor.await, "acceptor task");
 }
 
 /// Transport drop after logon fires wait_closed and on_logout.
 #[tokio::test]
 async fn test_transport_drop_fires_wait_closed() {
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
+    let (listener, addr) = bind_listener().await;
 
     let acceptor = tokio::spawn(async move {
-        let mut framed = accept_framed(listener).await;
-        let logon = next_frame(&mut framed).await;
-        assert_eq!(msg_type_of(&logon), "A");
-        framed
-            .send(venue_msg("A", 1, &[(98, "0"), (108, "30")]))
-            .await
-            .unwrap();
+        let _framed = accept_logon(listener).await;
         // Drop the connection without a Logout.
     });
 
-    let (app, _app_rx) = RecordingApp::new(false);
+    let (app, _app_rx) = RecordingApp::new();
     let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
-    let connection = initiator.connect(addr).await.expect("connect");
+    let connection = ok(initiator.connect(addr).await, "connect");
 
-    timeout(Duration::from_secs(5), connection.wait_closed())
-        .await
-        .expect("closed within 5s");
+    ok(
+        timeout(Duration::from_secs(5), connection.wait_closed()).await,
+        "closed within 5s",
+    );
     assert!(connection.is_closed());
     assert!(app.events().contains(&"logout".to_string()));
 
-    acceptor.await.unwrap();
+    ok(acceptor.await, "acceptor task");
 }
 
 /// Counterparty-initiated logout is acknowledged and closes the session.
 #[tokio::test]
 async fn test_counterparty_logout() {
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
+    let (listener, addr) = bind_listener().await;
 
     let acceptor = tokio::spawn(async move {
-        let mut framed = accept_framed(listener).await;
-        let _logon = next_frame(&mut framed).await;
-        framed
-            .send(venue_msg("A", 1, &[(98, "0"), (108, "30")]))
-            .await
-            .unwrap();
-        framed
-            .send(venue_msg("5", 2, &[(58, "session ended")]))
-            .await
-            .unwrap();
-        // Expect the Logout acknowledgement.
+        let mut framed = accept_logon(listener).await;
+        ok(
+            framed
+                .send(venue_msg("5", 2, &[(58, "session ended")]))
+                .await,
+            "send logout",
+        );
         let reply = next_frame(&mut framed).await;
         assert_eq!(msg_type_of(&reply), "5");
     });
 
-    let (app, _app_rx) = RecordingApp::new(false);
+    let (app, _app_rx) = RecordingApp::new();
     let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
-    let connection = initiator.connect(addr).await.expect("connect");
+    let connection = ok(initiator.connect(addr).await, "connect");
 
-    timeout(Duration::from_secs(5), connection.wait_closed())
-        .await
-        .expect("closed within 5s");
+    ok(
+        timeout(Duration::from_secs(5), connection.wait_closed()).await,
+        "closed within 5s",
+    );
     assert!(app.events().contains(&"logout".to_string()));
 
-    acceptor.await.unwrap();
+    ok(acceptor.await, "acceptor task");
 }
 
 /// No Logon ack within the logon timeout -> LogonTimeout.
 #[tokio::test]
+async fn test_rejected_in_sequence_gap_fill_still_consumes_its_sequence_number() {
+    // A Gap Fill occupies the number it carries. If the application rejects it
+    // and the engine does not consume that number, the inbound expectation
+    // parks on it forever: every later message looks gapped, is deduplicated
+    // against the outstanding ResendRequest and dropped, and the session goes
+    // on reporting itself healthy while silently discarding traffic.
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+
+        // In-sequence Gap Fill (34=2) that the application will reject.
+        ok(
+            framed
+                .send(venue_msg("4", 2, &[(123, "Y"), (36, "3")]))
+                .await,
+            "send gap fill",
+        );
+
+        // The Reject is expected and correct.
+        let reject = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&reject), "3");
+        assert_eq!(field(&reject, 45).as_deref(), Some("2"));
+
+        // Sequence 2 must now be consumed, so a strictly in-order report at 3
+        // is accepted rather than treated as a gap.
+        ok(
+            framed
+                .send(venue_msg("8", 3, &[(11, "AFTER-REJECT")]))
+                .await,
+            "send report",
+        );
+    });
+
+    let (app, mut app_rx) = RecordingApp::rejecting_admin();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+    let _connection = ok(initiator.connect(addr).await, "connect");
+
+    // Delivery is the proof: a wedged session would have deduplicated this
+    // message against the outstanding ResendRequest and dropped it silently.
+    match timeout(Duration::from_secs(5), app_rx.recv()).await {
+        Ok(Some(msg_type)) => assert_eq!(msg_type, "8"),
+        other => panic!("the report after a rejected fill must be delivered, got {other:?}"),
+    }
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+}
+
+#[tokio::test]
+async fn test_exhausted_sender_counter_fails_the_logon() {
+    // Seeding the sender counter at u64::MAX makes the very first allocation
+    // -- the Logon's own MsgSeqNum -- fail, so the session must refuse to open
+    // with a typed error instead of wrapping the counter round to zero.
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_framed(listener).await;
+        // The client must never get far enough to send anything.
+        let _ = timeout(Duration::from_millis(500), framed.next()).await;
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app))
+        .with_initial_sequences(u64::MAX, 1);
+
+    match initiator.connect(addr).await {
+        Err(EngineError::SequenceExhausted(err)) => {
+            assert_eq!(err.counter, SequenceCounter::Sender);
+        }
+        other => panic!("expected SequenceExhausted, got {other:?}"),
+    }
+
+    acceptor.abort();
+}
+
+#[tokio::test]
 async fn test_logon_timeout() {
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
+    let (listener, addr) = bind_listener().await;
 
     let acceptor = tokio::spawn(async move {
         let mut framed = accept_framed(listener).await;
@@ -316,16 +484,15 @@ async fn test_logon_timeout() {
         let _ = timeout(Duration::from_secs(5), framed.next()).await;
     });
 
-    let (app, _app_rx) = RecordingApp::new(false);
+    let (app, _app_rx) = RecordingApp::new();
     let config =
         client_config(Duration::from_secs(30)).with_logon_timeout(Duration::from_millis(300));
     let initiator = Initiator::new(config, Arc::clone(&app));
 
-    let err = initiator
-        .connect(addr)
-        .await
-        .expect_err("logon must time out");
-    assert!(matches!(err, EngineError::LogonTimeout(_)), "got {err:?}");
+    match initiator.connect(addr).await {
+        Err(EngineError::LogonTimeout(_)) => {}
+        other => panic!("expected LogonTimeout, got {other:?}"),
+    }
 
     acceptor.abort();
 }
@@ -333,46 +500,44 @@ async fn test_logon_timeout() {
 /// Logout instead of Logon ack -> LogonRejected with the counterparty text.
 #[tokio::test]
 async fn test_logon_rejected() {
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
+    let (listener, addr) = bind_listener().await;
 
     let acceptor = tokio::spawn(async move {
         let mut framed = accept_framed(listener).await;
         let _logon = next_frame(&mut framed).await;
-        framed
-            .send(venue_msg("5", 1, &[(58, "bad credentials")]))
-            .await
-            .unwrap();
+        ok(
+            framed
+                .send(venue_msg("5", 1, &[(58, "bad credentials")]))
+                .await,
+            "send rejection",
+        );
     });
 
-    let (app, _app_rx) = RecordingApp::new(false);
+    let (app, _app_rx) = RecordingApp::new();
     let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
 
-    let err = initiator
-        .connect(addr)
-        .await
-        .expect_err("logon must be rejected");
-    match err {
-        EngineError::LogonRejected { reason } => assert_eq!(reason, "bad credentials"),
+    match initiator.connect(addr).await {
+        Err(EngineError::LogonRejected { reason }) => assert_eq!(reason, "bad credentials"),
         other => panic!("expected LogonRejected, got {other:?}"),
     }
 
-    acceptor.await.unwrap();
+    ok(acceptor.await, "acceptor task");
 }
 
 /// Idle session: the initiator emits heartbeats at the configured interval.
 #[tokio::test]
 async fn test_heartbeat_emitted_when_idle() {
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
+    let (listener, addr) = bind_listener().await;
 
     let acceptor = tokio::spawn(async move {
         let mut framed = accept_framed(listener).await;
         let _logon = next_frame(&mut framed).await;
-        framed
-            .send(venue_msg("A", 1, &[(98, "0"), (108, "1")]))
-            .await
-            .unwrap();
+        ok(
+            framed
+                .send(venue_msg("A", 1, &[(98, "0"), (108, "1")]))
+                .await,
+            "send logon ack",
+        );
 
         // Keep the client's inbound side alive so it does not TestRequest.
         let heartbeat = next_frame(&mut framed).await;
@@ -380,33 +545,30 @@ async fn test_heartbeat_emitted_when_idle() {
         assert_eq!(field(&heartbeat, 34).as_deref(), Some("2"));
     });
 
-    let (app, _app_rx) = RecordingApp::new(false);
+    let (app, _app_rx) = RecordingApp::new();
     let initiator = Initiator::new(client_config(Duration::from_secs(1)), Arc::clone(&app));
-    let _connection = initiator.connect(addr).await.expect("connect");
+    let _connection = ok(initiator.connect(addr).await, "connect");
 
-    timeout(Duration::from_secs(5), acceptor)
-        .await
-        .expect("acceptor done within 5s")
-        .unwrap();
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
 }
 
 /// Inbound TestRequest is answered with a Heartbeat echoing TestReqID (112).
 #[tokio::test]
 async fn test_test_request_answered() {
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
+    let (listener, addr) = bind_listener().await;
 
     let acceptor = tokio::spawn(async move {
-        let mut framed = accept_framed(listener).await;
-        let _logon = next_frame(&mut framed).await;
-        framed
-            .send(venue_msg("A", 1, &[(98, "0"), (108, "30")]))
-            .await
-            .unwrap();
-        framed
-            .send(venue_msg("1", 2, &[(112, "PING-42")]))
-            .await
-            .unwrap();
+        let mut framed = accept_logon(listener).await;
+        ok(
+            framed.send(venue_msg("1", 2, &[(112, "PING-42")])).await,
+            "send test request",
+        );
 
         let reply = next_frame(&mut framed).await;
         assert_eq!(msg_type_of(&reply), "0");
@@ -414,30 +576,34 @@ async fn test_test_request_answered() {
         assert_eq!(field(&reply, 34).as_deref(), Some("2"));
     });
 
-    let (app, _app_rx) = RecordingApp::new(false);
+    let (app, _app_rx) = RecordingApp::new();
     let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
-    let _connection = initiator.connect(addr).await.expect("connect");
+    let _connection = ok(initiator.connect(addr).await, "connect");
 
-    timeout(Duration::from_secs(5), acceptor)
-        .await
-        .expect("acceptor done within 5s")
-        .unwrap();
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
 }
 
 /// A silent counterparty triggers TestRequest, then heartbeat timeout: the
 /// session closes and the handle observes is_timed_out().
 #[tokio::test]
 async fn test_heartbeat_timeout_closes_session() {
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
+    let (listener, addr) = bind_listener().await;
 
     let acceptor = tokio::spawn(async move {
         let mut framed = accept_framed(listener).await;
         let _logon = next_frame(&mut framed).await;
-        framed
-            .send(venue_msg("A", 1, &[(98, "0"), (108, "1")]))
-            .await
-            .unwrap();
+        ok(
+            framed
+                .send(venue_msg("A", 1, &[(98, "0"), (108, "1")]))
+                .await,
+            "send logon ack",
+        );
 
         // Read and ignore everything: never answer the TestRequest.
         let mut saw_test_request = false;
@@ -449,45 +615,44 @@ async fn test_heartbeat_timeout_closes_session() {
         saw_test_request
     });
 
-    let (app, _app_rx) = RecordingApp::new(false);
+    let (app, _app_rx) = RecordingApp::new();
     let initiator = Initiator::new(client_config(Duration::from_secs(1)), Arc::clone(&app));
-    let connection = initiator.connect(addr).await.expect("connect");
+    let connection = ok(initiator.connect(addr).await, "connect");
 
     // TestRequest due at interval + 1s grace; timeout one interval later.
-    timeout(Duration::from_secs(8), connection.wait_closed())
-        .await
-        .expect("closed within 8s");
+    ok(
+        timeout(Duration::from_secs(8), connection.wait_closed()).await,
+        "closed within 8s",
+    );
     assert!(connection.is_timed_out());
     assert!(app.events().contains(&"logout".to_string()));
 
-    let saw_test_request = acceptor.await.unwrap();
-    assert!(saw_test_request, "acceptor should have seen a TestRequest");
+    assert!(
+        ok(acceptor.await, "acceptor task"),
+        "acceptor should have seen a TestRequest"
+    );
 }
 
 /// A sequence gap triggers a ResendRequest and the gapped app message is not
 /// delivered to the application.
 #[tokio::test]
 async fn test_sequence_gap_triggers_resend_request() {
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
+    let (listener, addr) = bind_listener().await;
 
     let acceptor = tokio::spawn(async move {
-        let mut framed = accept_framed(listener).await;
-        let _logon = next_frame(&mut framed).await;
-        framed
-            .send(venue_msg("A", 1, &[(98, "0"), (108, "30")]))
-            .await
-            .unwrap();
+        let mut framed = accept_logon(listener).await;
 
         // Jump from seq 2 to seq 5: gap of 2..=4.
-        framed
-            .send(venue_msg(
-                "8",
-                5,
-                &[(37, "EX-9"), (17, "E-9"), (150, "0"), (39, "0")],
-            ))
-            .await
-            .unwrap();
+        ok(
+            framed
+                .send(venue_msg(
+                    "8",
+                    5,
+                    &[(37, "EX-9"), (17, "E-9"), (150, "0"), (39, "0")],
+                ))
+                .await,
+            "send gapped report",
+        );
 
         let resend = next_frame(&mut framed).await;
         assert_eq!(msg_type_of(&resend), "2");
@@ -495,14 +660,17 @@ async fn test_sequence_gap_triggers_resend_request() {
         assert_eq!(field(&resend, 16).as_deref(), Some("0"));
     });
 
-    let (app, mut app_rx) = RecordingApp::new(false);
+    let (app, mut app_rx) = RecordingApp::new();
     let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
-    let _connection = initiator.connect(addr).await.expect("connect");
+    let _connection = ok(initiator.connect(addr).await, "connect");
 
-    timeout(Duration::from_secs(5), acceptor)
-        .await
-        .expect("acceptor done within 5s")
-        .unwrap();
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
 
     // The gapped ExecutionReport must not reach the application.
     assert!(
@@ -516,24 +684,20 @@ async fn test_sequence_gap_triggers_resend_request() {
 /// from_app rejection produces a session-level Reject (35=3).
 #[tokio::test]
 async fn test_from_app_reject_sends_session_reject() {
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
+    let (listener, addr) = bind_listener().await;
 
     let acceptor = tokio::spawn(async move {
-        let mut framed = accept_framed(listener).await;
-        let _logon = next_frame(&mut framed).await;
-        framed
-            .send(venue_msg("A", 1, &[(98, "0"), (108, "30")]))
-            .await
-            .unwrap();
-        framed
-            .send(venue_msg(
-                "8",
-                2,
-                &[(37, "EX-1"), (17, "E-1"), (150, "0"), (39, "0")],
-            ))
-            .await
-            .unwrap();
+        let mut framed = accept_logon(listener).await;
+        ok(
+            framed
+                .send(venue_msg(
+                    "8",
+                    2,
+                    &[(37, "EX-1"), (17, "E-1"), (150, "0"), (39, "0")],
+                ))
+                .await,
+            "send report",
+        );
 
         let reject = next_frame(&mut framed).await;
         assert_eq!(msg_type_of(&reject), "3");
@@ -543,30 +707,60 @@ async fn test_from_app_reject_sends_session_reject() {
         assert_eq!(field(&reject, 58).as_deref(), Some("rejected by test app"));
     });
 
-    let (app, _app_rx) = RecordingApp::new(true);
+    let (app, _app_rx) = RecordingApp::rejecting_app();
     let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
-    let _connection = initiator.connect(addr).await.expect("connect");
+    let _connection = ok(initiator.connect(addr).await, "connect");
 
-    timeout(Duration::from_secs(5), acceptor)
-        .await
-        .expect("acceptor done within 5s")
-        .unwrap();
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+}
+
+/// from_admin rejection produces a session-level Reject instead of the
+/// normal admin reply.
+#[tokio::test]
+async fn test_from_admin_reject_sends_session_reject() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+        ok(
+            framed.send(venue_msg("1", 2, &[(112, "PING-1")])).await,
+            "send test request",
+        );
+
+        let reject = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&reject), "3");
+        assert_eq!(field(&reject, 45).as_deref(), Some("2"));
+        assert_eq!(field(&reject, 372).as_deref(), Some("1"));
+        assert_eq!(field(&reject, 373).as_deref(), Some("99"));
+    });
+
+    let (app, _app_rx) = RecordingApp::rejecting_admin();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+    let _connection = ok(initiator.connect(addr).await, "connect");
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
 }
 
 /// Sequence state survives across messages within a session and is visible
 /// on the handle.
 #[tokio::test]
 async fn test_sequence_state_within_session() {
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
+    let (listener, addr) = bind_listener().await;
 
     let acceptor = tokio::spawn(async move {
-        let mut framed = accept_framed(listener).await;
-        let _logon = next_frame(&mut framed).await;
-        framed
-            .send(venue_msg("A", 1, &[(98, "0"), (108, "30")]))
-            .await
-            .unwrap();
+        let mut framed = accept_logon(listener).await;
 
         for expected_seq in 2..=4u64 {
             let frame = next_frame(&mut framed).await;
@@ -575,21 +769,927 @@ async fn test_sequence_state_within_session() {
         }
     });
 
-    let (app, _app_rx) = RecordingApp::new(false);
+    let (app, _app_rx) = RecordingApp::new();
     let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
-    let connection = initiator.connect(addr).await.expect("connect");
+    let connection = ok(initiator.connect(addr).await, "connect");
 
     for i in 0..3 {
         let mut order = OutboundMessage::new(MsgType::NewOrderSingle);
         order.push_str(11, &format!("ORDER-{i}"));
-        connection.send(order).await.expect("send");
+        ok(connection.send(order).await, "send order");
     }
 
-    timeout(Duration::from_secs(5), acceptor)
-        .await
-        .expect("acceptor done within 5s")
-        .unwrap();
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
 
     assert_eq!(connection.next_sender_seq(), 5);
     assert_eq!(connection.next_target_seq(), 2);
+}
+
+// ---------------------------------------------------------------------------
+// Inbound SequenceReset (35=4)
+// ---------------------------------------------------------------------------
+
+/// A GapFill whose own MsgSeqNum is in sequence advances the target
+/// expectation to NewSeqNo, and the next message at that number is
+/// delivered.
+#[tokio::test]
+async fn test_sequence_reset_gap_fill_in_sequence_advances_target() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+        // In-sequence GapFill: 34=2 while expecting 2, filling 2..=4.
+        ok(
+            framed
+                .send(venue_msg("4", 2, &[(123, "Y"), (36, "5")]))
+                .await,
+            "send gap fill",
+        );
+        ok(
+            framed
+                .send(venue_msg(
+                    "8",
+                    5,
+                    &[(37, "EX-5"), (17, "E-5"), (150, "0"), (39, "0")],
+                ))
+                .await,
+            "send report at the filled sequence",
+        );
+        // No ResendRequest may come back.
+        assert!(
+            timeout(Duration::from_millis(300), framed.next())
+                .await
+                .is_err(),
+            "an in-sequence GapFill must not trigger a ResendRequest"
+        );
+    });
+
+    let (app, mut app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    let received = some(
+        ok(
+            timeout(Duration::from_secs(5), app_rx.recv()).await,
+            "app message within 5s",
+        ),
+        "app channel must stay open",
+    );
+    assert_eq!(received, "8");
+    assert_eq!(connection.next_target_seq(), 6);
+
+    ok(acceptor.await, "acceptor task");
+}
+
+/// A GapFill that is itself gapped must not be applied: the missing range is
+/// requested and the target expectation stays put. This is the branch that
+/// used to silently skip real messages.
+#[tokio::test]
+async fn test_sequence_reset_gap_fill_with_gap_requests_resend() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+        // Expecting 2, but the GapFill claims 34=7 and jumps to 20.
+        ok(
+            framed
+                .send(venue_msg("4", 7, &[(123, "Y"), (36, "20")]))
+                .await,
+            "send gapped gap fill",
+        );
+
+        let resend = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&resend), "2");
+        assert_eq!(field(&resend, 7).as_deref(), Some("2"));
+        assert_eq!(field(&resend, 16).as_deref(), Some("0"));
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+
+    // NewSeqNo must NOT have been applied.
+    assert_eq!(connection.next_target_seq(), 2);
+}
+
+/// Reset mode (no GapFillFlag) is the only mode allowed to ignore its own
+/// MsgSeqNum.
+#[tokio::test]
+async fn test_sequence_reset_reset_mode_ignores_msg_seq_num() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+        // Reset mode with a meaningless MsgSeqNum: 36 is applied anyway.
+        ok(
+            framed.send(venue_msg("4", 99, &[(36, "10")])).await,
+            "send sequence reset",
+        );
+        ok(
+            framed
+                .send(venue_msg(
+                    "8",
+                    10,
+                    &[(37, "EX-10"), (17, "E-10"), (150, "0"), (39, "0")],
+                ))
+                .await,
+            "send report at the reset sequence",
+        );
+    });
+
+    let (app, mut app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    let received = some(
+        ok(
+            timeout(Duration::from_secs(5), app_rx.recv()).await,
+            "app message within 5s",
+        ),
+        "app channel must stay open",
+    );
+    assert_eq!(received, "8");
+    assert_eq!(connection.next_target_seq(), 11);
+
+    ok(acceptor.await, "acceptor task");
+}
+
+/// A NewSeqNo below the expected sequence is a session Reject with
+/// SessionRejectReason 5, not a warning.
+#[tokio::test]
+async fn test_sequence_reset_backward_new_seq_no_is_rejected() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+        // Expecting 2; a Reset to 1 would rewind the inbound stream.
+        ok(
+            framed.send(venue_msg("4", 2, &[(36, "1")])).await,
+            "send backward reset",
+        );
+
+        let reject = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&reject), "3");
+        assert_eq!(field(&reject, 45).as_deref(), Some("2"));
+        assert_eq!(field(&reject, 372).as_deref(), Some("4"));
+        assert_eq!(field(&reject, 373).as_deref(), Some("5"));
+        assert_eq!(field(&reject, 371).as_deref(), Some("36"));
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+    assert_eq!(connection.next_target_seq(), 2);
+}
+
+/// A GapFill whose NewSeqNo does not advance past its own MsgSeqNum is
+/// rejected with reason 5, and the fill message itself is consumed so the
+/// session does not deadlock on that number.
+#[tokio::test]
+async fn test_sequence_reset_gap_fill_without_advance_is_rejected() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+        ok(
+            framed
+                .send(venue_msg("4", 2, &[(123, "Y"), (36, "2")]))
+                .await,
+            "send non-advancing gap fill",
+        );
+
+        let reject = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&reject), "3");
+        assert_eq!(field(&reject, 373).as_deref(), Some("5"));
+        assert_eq!(field(&reject, 371).as_deref(), Some("36"));
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+    assert_eq!(connection.next_target_seq(), 3);
+}
+
+/// A SequenceReset without NewSeqNo is rejected with reason 1 (required tag
+/// missing) rather than silently ignored.
+#[tokio::test]
+async fn test_sequence_reset_without_new_seq_no_is_rejected() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+        ok(
+            framed.send(venue_msg("4", 2, &[(123, "Y")])).await,
+            "send gap fill without NewSeqNo",
+        );
+
+        let reject = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&reject), "3");
+        assert_eq!(field(&reject, 373).as_deref(), Some("1"));
+        assert_eq!(field(&reject, 371).as_deref(), Some("36"));
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+    let _connection = ok(initiator.connect(addr).await, "connect");
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Inbound ResendRequest (35=2)
+// ---------------------------------------------------------------------------
+
+/// A bounded ResendRequest is answered with a GapFill bounded by EndSeqNo+1,
+/// carrying PossDupFlag and OrigSendingTime.
+#[tokio::test]
+async fn test_resend_request_answered_with_bounded_gap_fill() {
+    let (listener, addr) = bind_listener().await;
+    // Lets the client hold its next order back until the gap fill is on the
+    // wire, so the sequence assertion below is not racing the reactor.
+    let (fill_seen_tx, fill_seen_rx) = tokio::sync::oneshot::channel::<()>();
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+
+        // Drain three orders so the client's next sender sequence is 5.
+        for expected_seq in 2..=4u64 {
+            let frame = next_frame(&mut framed).await;
+            assert_eq!(field(&frame, 34), Some(expected_seq.to_string()));
+        }
+
+        ok(
+            framed.send(venue_msg("2", 2, &[(7, "2"), (16, "3")])).await,
+            "send bounded resend request",
+        );
+
+        let fill = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&fill), "4");
+        assert_eq!(field(&fill, 123).as_deref(), Some("Y"));
+        assert_eq!(field(&fill, 34).as_deref(), Some("2"));
+        // Bounded by EndSeqNo + 1, not by our next sender sequence (5).
+        assert_eq!(field(&fill, 36).as_deref(), Some("4"));
+        assert_eq!(field(&fill, 43).as_deref(), Some("Y"));
+        assert_eq!(field(&fill, 122), field(&fill, 52));
+        assert!(field(&fill, 122).is_some(), "PossDup requires 122");
+
+        let _ = fill_seen_tx.send(());
+
+        // The crux of "the fill occupies the range it replaces": it carries
+        // BeginSeqNo as its own MsgSeqNum and allocates nothing, so the next
+        // real message still goes out at 5. Had a sender number been consumed
+        // for the fill this would be 6, and the counterparty would see a
+        // permanent off-by-one.
+        let next = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&next), "D");
+        assert_eq!(field(&next, 34).as_deref(), Some("5"));
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    for i in 0..3 {
+        let mut order = OutboundMessage::new(MsgType::NewOrderSingle);
+        order.push_str(11, &format!("ORDER-{i}"));
+        ok(connection.send(order).await, "send order");
+    }
+
+    ok(
+        timeout(Duration::from_secs(5), fill_seen_rx).await,
+        "gap fill observed within 5s",
+    )
+    .ok();
+    let mut order = OutboundMessage::new(MsgType::NewOrderSingle);
+    order.push_str(11, "ORDER-AFTER-FILL");
+    ok(connection.send(order).await, "send order after fill");
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+}
+
+/// EndSeqNo = 0 means infinity: the fill runs up to our next sender
+/// sequence.
+#[tokio::test]
+async fn test_resend_request_unbounded_gap_fill_reaches_next_sender_seq() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+
+        for expected_seq in 2..=4u64 {
+            let frame = next_frame(&mut framed).await;
+            assert_eq!(field(&frame, 34), Some(expected_seq.to_string()));
+        }
+
+        ok(
+            framed.send(venue_msg("2", 2, &[(7, "2"), (16, "0")])).await,
+            "send unbounded resend request",
+        );
+
+        let fill = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&fill), "4");
+        assert_eq!(field(&fill, 34).as_deref(), Some("2"));
+        assert_eq!(field(&fill, 36).as_deref(), Some("5"));
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    for i in 0..3 {
+        let mut order = OutboundMessage::new(MsgType::NewOrderSingle);
+        order.push_str(11, &format!("ORDER-{i}"));
+        ok(connection.send(order).await, "send order");
+    }
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+}
+
+/// A ResendRequest without BeginSeqNo is rejected with reason 1 and
+/// RefTagID 7 instead of silently defaulting to 1.
+#[tokio::test]
+async fn test_resend_request_without_begin_seq_no_is_rejected() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+        ok(
+            framed.send(venue_msg("2", 2, &[(16, "0")])).await,
+            "send resend request without BeginSeqNo",
+        );
+
+        let reject = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&reject), "3");
+        assert_eq!(field(&reject, 45).as_deref(), Some("2"));
+        assert_eq!(field(&reject, 372).as_deref(), Some("2"));
+        assert_eq!(field(&reject, 373).as_deref(), Some("1"));
+        assert_eq!(field(&reject, 371).as_deref(), Some("7"));
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+    let _connection = ok(initiator.connect(addr).await, "connect");
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+}
+
+/// A ResendRequest for messages we never sent is rejected with reason 5.
+#[tokio::test]
+async fn test_resend_request_out_of_range_is_rejected() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+        // We have only sent the Logon (seq 1), so 99 is out of range.
+        ok(
+            framed
+                .send(venue_msg("2", 2, &[(7, "99"), (16, "0")]))
+                .await,
+            "send out-of-range resend request",
+        );
+
+        let reject = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&reject), "3");
+        assert_eq!(field(&reject, 373).as_deref(), Some("5"));
+        assert_eq!(field(&reject, 371).as_deref(), Some("7"));
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+    let _connection = ok(initiator.connect(addr).await, "connect");
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Duplicates, teardown, and handshake edge cases
+// ---------------------------------------------------------------------------
+
+/// A too-low message flagged PossDup is dropped without disturbing the
+/// session.
+#[tokio::test]
+async fn test_poss_dup_duplicate_is_dropped() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+        let report = &[(37, "EX-1"), (17, "E-1"), (150, "0"), (39, "0")];
+        ok(framed.send(venue_msg("8", 2, report)).await, "send report");
+        // Redelivery of the same message, correctly flagged.
+        ok(
+            framed
+                .send(venue_msg(
+                    "8",
+                    2,
+                    &[(37, "EX-1"), (17, "E-1"), (150, "0"), (39, "0"), (43, "Y")],
+                ))
+                .await,
+            "send duplicate report",
+        );
+        // The session must still be alive.
+        ok(
+            framed.send(venue_msg("1", 3, &[(112, "PING-1")])).await,
+            "send test request",
+        );
+
+        let reply = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&reply), "0");
+        assert_eq!(field(&reply, 112).as_deref(), Some("PING-1"));
+    });
+
+    let (app, mut app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    let first = some(
+        ok(
+            timeout(Duration::from_secs(5), app_rx.recv()).await,
+            "app message within 5s",
+        ),
+        "app channel must stay open",
+    );
+    assert_eq!(first, "8");
+    assert!(
+        timeout(Duration::from_millis(200), app_rx.recv())
+            .await
+            .is_err(),
+        "the PossDup duplicate must not be delivered twice"
+    );
+    // The duplicate consumed no sequence number: the TestRequest at 3 was
+    // in sequence and the acceptor asserts the Heartbeat reply, which is the
+    // proof that the session survived the duplicate.
+    assert_eq!(connection.next_target_seq(), 4);
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+}
+
+/// A too-low message without PossDupFlag is unrecoverable: the engine logs
+/// out and closes the session.
+#[tokio::test]
+async fn test_too_low_without_poss_dup_closes_session() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+        let report = &[(37, "EX-1"), (17, "E-1"), (150, "0"), (39, "0")];
+        ok(framed.send(venue_msg("8", 2, report)).await, "send report");
+        ok(
+            framed.send(venue_msg("8", 2, report)).await,
+            "send unflagged duplicate",
+        );
+
+        let logout = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&logout), "5");
+        assert!(
+            some(field(&logout, 58), "logout must carry Text").contains("MsgSeqNum too low"),
+            "logout should explain the sequence failure"
+        );
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    ok(
+        timeout(Duration::from_secs(5), connection.wait_closed()).await,
+        "closed within 5s",
+    );
+    assert!(connection.is_closed());
+    assert!(app.events().contains(&"logout".to_string()));
+
+    ok(acceptor.await, "acceptor task");
+}
+
+/// A gap in the Logon ack itself produces a ResendRequest before the reactor
+/// starts.
+#[tokio::test]
+async fn test_gapped_logon_ack_sends_resend_request() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_framed(listener).await;
+        let _logon = next_frame(&mut framed).await;
+        // Expecting 1, acking with 5.
+        ok(
+            framed
+                .send(venue_msg("A", 5, &[(98, "0"), (108, "30")]))
+                .await,
+            "send gapped logon ack",
+        );
+
+        let resend = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&resend), "2");
+        assert_eq!(field(&resend, 34).as_deref(), Some("2"));
+        assert_eq!(field(&resend, 7).as_deref(), Some("1"));
+        assert_eq!(field(&resend, 16).as_deref(), Some("0"));
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+    let connection = ok(initiator.connect(addr).await, "connect");
+    assert!(app.events().contains(&"logon".to_string()));
+    // The gap is unresolved, so the target expectation is unchanged.
+    assert_eq!(connection.next_target_seq(), 1);
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+}
+
+/// ResetSeqNumFlag on the Logon ack resets the inbound counter before
+/// MsgSeqNum is validated, so a peer-driven reset does not abort a
+/// continuity-seeded handshake.
+#[tokio::test]
+async fn test_logon_ack_reset_seq_num_flag_resets_counters() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_framed(listener).await;
+        let logon = next_frame(&mut framed).await;
+        // Seeded for continuity: our Logon goes out at 10.
+        assert_eq!(field(&logon, 34).as_deref(), Some("10"));
+        ok(
+            framed
+                .send(venue_msg("A", 1, &[(98, "0"), (108, "30"), (141, "Y")]))
+                .await,
+            "send resetting logon ack",
+        );
+
+        // The reset outbound stream continues at 2, never re-emitting 1.
+        let order = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&order), "D");
+        assert_eq!(field(&order, 34).as_deref(), Some("2"));
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app))
+        .with_initial_sequences(10, 10);
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    assert_eq!(connection.next_target_seq(), 2);
+    assert_eq!(connection.next_sender_seq(), 2);
+
+    let mut order = OutboundMessage::new(MsgType::NewOrderSingle);
+    order.push_str(11, "ORDER-1");
+    ok(connection.send(order).await, "send order");
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+}
+
+/// A Logon ack from the wrong counterparty is rejected with reason 9 and
+/// the handshake fails.
+#[tokio::test]
+async fn test_logon_ack_comp_id_mismatch_fails_handshake() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_framed(listener).await;
+        let _logon = next_frame(&mut framed).await;
+        ok(
+            framed
+                .send(venue_msg_from(
+                    "OTHER",
+                    "CLIENT",
+                    "A",
+                    1,
+                    &[(98, "0"), (108, "30")],
+                ))
+                .await,
+            "send cross-wired logon ack",
+        );
+
+        let reject = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&reject), "3");
+        assert_eq!(field(&reject, 373).as_deref(), Some("9"));
+        assert_eq!(field(&reject, 371).as_deref(), Some("49"));
+
+        let logout = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&logout), "5");
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+
+    match initiator.connect(addr).await {
+        Err(EngineError::IdentityMismatch { detail }) => {
+            assert!(detail.contains("tag 49"), "got {detail}");
+        }
+        other => panic!("expected IdentityMismatch, got {other:?}"),
+    }
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+}
+
+/// A mid-session CompID mismatch is rejected with reason 9, logged out, and
+/// closes the session.
+#[tokio::test]
+async fn test_comp_id_mismatch_rejects_and_closes_session() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+        ok(
+            framed
+                .send(venue_msg_from(
+                    "VENUE",
+                    "SOMEONE-ELSE",
+                    "8",
+                    2,
+                    &[(37, "EX-1"), (17, "E-1"), (150, "0"), (39, "0")],
+                ))
+                .await,
+            "send cross-wired report",
+        );
+
+        let reject = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&reject), "3");
+        assert_eq!(field(&reject, 45).as_deref(), Some("2"));
+        assert_eq!(field(&reject, 373).as_deref(), Some("9"));
+        assert_eq!(field(&reject, 371).as_deref(), Some("56"));
+
+        let logout = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&logout), "5");
+    });
+
+    let (app, mut app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    ok(
+        timeout(Duration::from_secs(5), connection.wait_closed()).await,
+        "closed within 5s",
+    );
+    // The foreign message must never reach the application.
+    assert!(
+        timeout(Duration::from_millis(200), app_rx.recv())
+            .await
+            .is_err(),
+        "a cross-wired message must not be delivered"
+    );
+
+    ok(acceptor.await, "acceptor task");
+}
+
+/// An undecodable frame is dropped without killing the session.
+#[tokio::test]
+async fn test_undecodable_frame_is_dropped() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+
+        // Framing is valid (8/9/10) but MsgType is absent, so the tag=value
+        // decoder rejects it.
+        let mut encoder = Encoder::new("FIX.4.4");
+        encoder.put_str(49, "VENUE");
+        encoder.put_str(56, "CLIENT");
+        encoder.put_uint(34, 2);
+        ok(
+            framed.send(encoder.finish()).await,
+            "send undecodable frame",
+        );
+
+        ok(
+            framed.send(venue_msg("1", 2, &[(112, "PING-1")])).await,
+            "send test request",
+        );
+        let reply = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&reply), "0");
+        assert_eq!(field(&reply, 112).as_deref(), Some("PING-1"));
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+    assert!(!connection.is_closed());
+}
+
+/// A frame without MsgSeqNum is dropped without disturbing sequence state.
+#[tokio::test]
+async fn test_frame_without_msg_seq_num_is_dropped() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+
+        let mut encoder = Encoder::new("FIX.4.4");
+        encoder.put_str(35, "0");
+        encoder.put_str(49, "VENUE");
+        encoder.put_str(56, "CLIENT");
+        encoder.put_str(52, Timestamp::now().format_millis().as_str());
+        ok(
+            framed.send(encoder.finish()).await,
+            "send frame without MsgSeqNum",
+        );
+
+        // The dropped frame consumed no sequence number, so 2 is still next.
+        ok(
+            framed.send(venue_msg("1", 2, &[(112, "PING-1")])).await,
+            "send test request",
+        );
+        let reply = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&reply), "0");
+        assert_eq!(field(&reply, 112).as_deref(), Some("PING-1"));
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+    assert_eq!(connection.next_target_seq(), 3);
+}
+
+/// A Logout that is never acknowledged closes the session at the logout
+/// deadline.
+#[tokio::test]
+async fn test_logout_ack_timeout_closes_session() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+        let logout = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&logout), "5");
+        // Never acknowledge; hold the socket so the deadline, not the
+        // transport, is what closes the session.
+        let _ = timeout(Duration::from_secs(3), framed.next()).await;
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let mut config = client_config(Duration::from_secs(30));
+    config.logout_timeout = Duration::from_millis(300);
+    let initiator = Initiator::new(config, Arc::clone(&app));
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    ok(connection.logout().await, "logout");
+    ok(
+        timeout(Duration::from_secs(5), connection.wait_closed()).await,
+        "closed within 5s",
+    );
+    assert!(app.events().contains(&"logout".to_string()));
+
+    acceptor.abort();
+}
+
+/// Dropping every Connection handle logs the session out gracefully.
+#[tokio::test]
+async fn test_dropping_all_handles_logs_out() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+        let logout = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&logout), "5");
+        assert_eq!(field(&logout, 34).as_deref(), Some("2"));
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+    let connection = ok(initiator.connect(addr).await, "connect");
+    drop(connection);
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+}
+
+/// with_initial_sequences seeds both counters for session continuity.
+#[tokio::test]
+async fn test_with_initial_sequences_seeds_counters() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_framed(listener).await;
+        let logon = next_frame(&mut framed).await;
+        assert_eq!(field(&logon, 34).as_deref(), Some("7"));
+        ok(
+            framed
+                .send(venue_msg("A", 9, &[(98, "0"), (108, "30")]))
+                .await,
+            "send logon ack",
+        );
+
+        let order = next_frame(&mut framed).await;
+        assert_eq!(field(&order, 34).as_deref(), Some("8"));
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app))
+        .with_initial_sequences(7, 9);
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    assert_eq!(connection.next_sender_seq(), 8);
+    assert_eq!(connection.next_target_seq(), 10);
+
+    let mut order = OutboundMessage::new(MsgType::NewOrderSingle);
+    order.push_str(11, "ORDER-1");
+    ok(connection.send(order).await, "send order");
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
 }

--- a/ironfix-session/src/sequence.rs
+++ b/ironfix-session/src/sequence.rs
@@ -103,6 +103,10 @@ impl SequenceManager {
     /// [`try_allocate_sender_seq`](Self::try_allocate_sender_seq) for
     /// venue-grade sessions where exhaustion must be an explicit error.
     #[inline]
+    #[deprecated(
+        since = "0.4.0",
+        note = "wraps silently on overflow, which corrupts a live session; use try_allocate_sender_seq. Removed in the next breaking release."
+    )]
     pub fn allocate_sender_seq(&self) -> SeqNum {
         SeqNum::new(self.next_sender_seq.fetch_add(1, Ordering::SeqCst))
     }
@@ -137,6 +141,10 @@ impl SequenceManager {
     /// [`try_increment_target_seq`](Self::try_increment_target_seq) for
     /// venue-grade sessions where exhaustion must be an explicit error.
     #[inline]
+    #[deprecated(
+        since = "0.4.0",
+        note = "wraps silently on overflow, which corrupts a live session; use try_increment_target_seq. Removed in the next breaking release."
+    )]
     pub fn increment_target_seq(&self) {
         self.next_target_seq.fetch_add(1, Ordering::SeqCst);
     }
@@ -270,6 +278,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_allocate_sender_seq() {
         let mgr = SequenceManager::new();
 
@@ -283,6 +292,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_increment_target_seq() {
         let mgr = SequenceManager::new();
 
@@ -309,8 +319,8 @@ mod tests {
     fn test_try_allocate_sender_seq() {
         let mgr = SequenceManager::new();
 
-        assert_eq!(mgr.try_allocate_sender_seq().unwrap().value(), 1);
-        assert_eq!(mgr.try_allocate_sender_seq().unwrap().value(), 2);
+        assert_eq!(mgr.try_allocate_sender_seq().map(SeqNum::value), Ok(1));
+        assert_eq!(mgr.try_allocate_sender_seq().map(SeqNum::value), Ok(2));
         assert_eq!(mgr.next_sender_seq().value(), 3);
     }
 
@@ -318,23 +328,27 @@ mod tests {
     fn test_try_allocate_sender_seq_exhausted() {
         let mgr = SequenceManager::with_initial(u64::MAX, 1);
 
-        let err = mgr.try_allocate_sender_seq().unwrap_err();
-        assert_eq!(err.counter, SequenceCounter::Sender);
+        assert_eq!(
+            mgr.try_allocate_sender_seq(),
+            Err(SequenceExhausted {
+                counter: SequenceCounter::Sender
+            })
+        );
         // Counter untouched: still exhausted, no wraparound.
         assert_eq!(mgr.next_sender_seq().value(), u64::MAX);
         assert!(mgr.try_allocate_sender_seq().is_err());
 
         // Reset restores a usable session.
         mgr.reset();
-        assert_eq!(mgr.try_allocate_sender_seq().unwrap().value(), 1);
+        assert_eq!(mgr.try_allocate_sender_seq().map(SeqNum::value), Ok(1));
     }
 
     #[test]
     fn test_try_increment_target_seq() {
         let mgr = SequenceManager::new();
 
-        assert_eq!(mgr.try_increment_target_seq().unwrap().value(), 2);
-        assert_eq!(mgr.try_increment_target_seq().unwrap().value(), 3);
+        assert_eq!(mgr.try_increment_target_seq().map(SeqNum::value), Ok(2));
+        assert_eq!(mgr.try_increment_target_seq().map(SeqNum::value), Ok(3));
         assert_eq!(mgr.next_target_seq().value(), 3);
     }
 
@@ -342,8 +356,12 @@ mod tests {
     fn test_try_increment_target_seq_exhausted() {
         let mgr = SequenceManager::with_initial(1, u64::MAX);
 
-        let err = mgr.try_increment_target_seq().unwrap_err();
-        assert_eq!(err.counter, SequenceCounter::Target);
+        assert_eq!(
+            mgr.try_increment_target_seq(),
+            Err(SequenceExhausted {
+                counter: SequenceCounter::Target
+            })
+        );
         assert_eq!(mgr.next_target_seq().value(), u64::MAX);
         assert!(mgr.try_increment_target_seq().is_err());
     }


### PR DESCRIPTION
## Summary

Makes the `Initiator`'s inbound session handling conform to the FIX specification. Eight defects from the 2026-07-21 audit, all reachable from a counterparty, several of which lose messages or desynchronise a live session.

Closes #9. Third and last of the P0 set; #23 and #24 are already merged, so this branches straight off `main` and the diff is only its own.

## What was wrong

**1. SequenceReset conflated GapFill with Reset.** Only Reset mode may ignore MsgSeqNum — a GapFill participates in normal sequencing. The old handler jumped the inbound expectation regardless, so a GapFill with `34=10` while expecting 5 skipped messages 5..9, potentially ExecutionReports, permanently. Now `123=Y` validates MsgSeqNum first: a gapped fill triggers a ResendRequest **without** applying NewSeqNo, a too-low duplicate with `43=Y` is dropped, and a decreasing NewSeqNo is Reject reason 5. The `from_admin` verdict is honoured instead of discarded.

**2. The ResendRequest reply ignored the request.** BeginSeqNo silently defaulted to 1 when absent, and EndSeqNo was never read — so a bounded request (`7=5, 16=10`) from a peer we had sent 100 messages to was answered by gap-filling to 100, jumping it past everything it asked to keep. Both tags are now validated (reason 1 with the right RefTagID), `16=0` means infinity, out-of-range is reason 5, and NewSeqNo is bounded by `min(EndSeqNo + 1, next_sender)`.

The reply also now carries **BeginSeqNo as its own MsgSeqNum** and allocates no sender number, because a SequenceReset-GapFill occupies the range it replaces. Verified against FIX 4.4 Vol 2 and QuickFIX/J's `generateSequenceReset`.

**3. PossDupFlag without OrigSendingTime.** The only resent frame the engine emits carried `43=Y` with no tag 122, which strict acceptors reject on exactly the recovery path. 122 is now stamped from the same flag, so it cannot be omitted. With no store there is no original sending time to recover, so the current SendingTime is used — which is what QuickFIX/J does for generated gap fills.

**4. FIX 5.0 sessions were wire-nonconformant.** `FIX.5.0*` went into tag 8 verbatim; every 5.0 variant must send `BeginString=FIXT.1.1` with the variant in ApplVerID. Now FIXT.1.1 with DefaultApplVerID(1137) on the Logon and ApplVerID(1128) on application messages only, in its correct standard-header position.

A version the engine cannot frame conformantly is now **refused before dialling** with `EngineError::UnsupportedVersion`: an unknown string (previously passed through onto the wire, which the coding rules forbid) or `FIXT.1.1` on its own, which names a transport version but no application version for the *required* 1137. Neither is defaulted to a guess.

**5. Inbound ResetSeqNumFlag was ignored.** A peer-driven reset (`141=Y, 34=1`) against continuity-seeded counters read as fatally too low and aborted the handshake. Now honoured before MsgSeqNum validation — and required to arrive under `MsgSeqNum = 1`, since a reset and the number carrying it have to describe the same stream.

**6. No inbound identity validation.** Tags 49/56 were never read, so a cross-wired connection established a session and advanced sequence state against the wrong counterparty — delivering another session's execution reports. Now compared (reversed) on both the Logon ack and every reactor frame, with 50/57 when configured; a mismatch is Reject reason 9 followed by a Logout.

**7. Heartbeat bookkeeping ran before validation**, so foreign or invalid traffic kept the connection alive. It now runs after identity validation.

**8. Every sequence increment wrapped silently.** ~15 call sites used `fetch_add`-based methods documented as wrapping at `u64::MAX`, which corrupts a live session. All now use the checked variants; exhaustion surfaces as a typed teardown, and the wrapping pair is `#[deprecated]`.

## A critical regression this PR's own first draft introduced

Worth stating plainly. The new `from_admin` rejection path returned **without consuming the rejected message's MsgSeqNum**, even when the GapFill was in sequence and therefore occupied that number. Adversarial review reproduced the consequence against a live `Initiator`:

```
venue: one in-sequence GapFill the application rejects, then well-behaved
       ExecutionReports at 3, 4, 5, 6

before the fix: reports delivered = []        next_target_seq = 2
                is_closed = false   is_timed_out = false   on_logout never fired
after the fix:  reports delivered = [E3, E4, E5, E6]   next_target_seq = 7
```

Four ExecutionReports from a well-behaved venue lost after a single admin rejection, with **no signal of any kind** to the application — the expectation parks on the unconsumed number, every later message looks gapped, gets deduplicated against the outstanding ResendRequest, and is dropped. All 33 tests were green while this was live.

Ironically the same function guards against exactly this hazard thirty lines below, with a comment naming it. The fix consumes the number whenever a rejected fill was in sequence, on both rejection paths. The regression test is verified to fail without the fix and pass with it.

## What this PR deliberately does **not** implement

- **Replay from a `MessageStore`** — that is #15. The gap-fill is now correct and bounded, but no application message is ever actually replayed, so mandate items 1, 2 and 4 of the spec's Resend Request section remain unmet. The Phase 1 checkbox stays unticked and says why.
- **SendingTime accuracy checking** (reject reason 10). A clock-skew tolerance is a policy decision needing its own typed knob and a defensible default; guessing one would be worse than declaring the gap.
- **A ceiling on inbound `NewSeqNo`.** A peer can jump the expectation to `u64::MAX`, after which the next message exhausts the counter and the session is torn down with a typed error. The spec offers no principled limit, and a clean teardown beats an invented one. (This is still an improvement: the old code wrapped silently to 0 and carried on, which was real corruption.)
- **Heartbeat conformance.** Adversarial review confirmed two live defects in `ironfix-session::HeartbeatManager` — `HeartBtInt = 0` makes the session flood the peer and time itself out, and a pending TestRequest is cleared only by a Heartbeat echoing tag 112, so a venue answering without it is disconnected while demonstrably alive. Both are issue #10, out of scope here — but "Heartbeat / Test Request" has been **unticked** from the Phase 1 list rather than left claiming to work.
- **Positional CompID enforcement.** Lookup is by tag over the whole message, so CompIDs appearing outside the standard header still satisfy the check. Documented on `PeerIdentity::validate`; fixing it needs positional information the decoder does not retain.

## Public API changes (semver)

The workspace is already at 0.4.0. `cargo semver-checks --release-type minor` reports `enum_variant_added` on `EngineError`, i.e. major required — satisfied.

- `EngineError` gains `#[non_exhaustive]` (matching every sibling error enum after #23/#24) plus `SequenceExhausted(#[from] …)`, `IdentityMismatch { detail }` and `UnsupportedVersion { version, detail }`
- `SequenceManager::{allocate_sender_seq, increment_target_seq}` are `#[deprecated]`; removal queued for the next breaking release

## Tests

Workspace goes from 215 to **248 passing**; the engine integration suite from 11 to 35. New coverage includes both SequenceReset modes and the backward guard, the bounded/unbounded gap-fill replies, PossDup duplicate handling, too-low without `43=Y`, gapped Logon ack, `141=Y` reset, CompID mismatch, logout-ack timeout, drop-all-handles auto-logout, `from_admin` rejection, undecodable and 34-less frames, `with_initial_sequences` seeding, and an exhausted counter failing the handshake.

Two are worth singling out because they pin the crux of a fix rather than its surface: the resend test now sends an application message *after* the gap fill and asserts it goes out at 5, proving the fill consumed no sender number (it would be 6 otherwise); and the regression test above was checked in both directions.

## Verification

```
cargo test --workspace                                    # 248 passed, 0 failed
cargo clippy --all-targets --all-features -- -D warnings  # clean
cargo fmt --all --check                                   # clean
cargo build --release --workspace                         # clean
make doc                                                  # clean (clippy -W missing-docs)
```

No performance claim is made — the repo still has no benchmark harness.
