### PR TITLE
fix(fast): correct the stop-bit primitives and bound the presence map

### DIFF
--- a/ironfix-example/examples/fast_server.rs
+++ b/ironfix-example/examples/fast_server.rs
@@ -6,7 +6,7 @@
 mod common;
 
 use common::{ExampleConfig, format_timestamp, init_logging};
-use ironfix_fast::FastEncoder;
+use ironfix_fast::{FastEncoder, FastError};
 use tokio::io::AsyncWriteExt;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::time::{Duration, interval};
@@ -63,7 +63,13 @@ async fn handle_client(mut socket: TcpStream) -> anyhow::Result<()> {
                 let size: u64 = 100 + (seq_num % 900);
 
                 // Build FAST message
-                let msg = build_market_data(seq_num, symbol, price, size);
+                let msg = match build_market_data(seq_num, symbol, price, size) {
+                    Ok(msg) => msg,
+                    Err(e) => {
+                        error!("Failed to encode market data: {}", e);
+                        break;
+                    }
+                };
 
                 if let Err(e) = socket.write_all(&msg).await {
                     warn!("Write error: {}", e);
@@ -110,7 +116,16 @@ async fn handle_client(mut socket: TcpStream) -> anyhow::Result<()> {
 /// - Symbol (string)
 /// - Price (scaled decimal as uint64, scale 2)
 /// - Size (uint64)
-fn build_market_data(seq_num: u64, symbol: &str, price: f64, size: u64) -> Vec<u8> {
+///
+/// # Errors
+/// Returns `FastError::InvalidString` if the timestamp or symbol is not
+/// representable as a FAST ASCII string.
+fn build_market_data(
+    seq_num: u64,
+    symbol: &str,
+    price: f64,
+    size: u64,
+) -> Result<Vec<u8>, FastError> {
     let mut encoder = FastEncoder::new();
 
     // Presence map: all fields present (6 bits set + stop bit)
@@ -125,10 +140,10 @@ fn build_market_data(seq_num: u64, symbol: &str, price: f64, size: u64) -> Vec<u
     encoder.encode_uint(seq_num);
 
     // Timestamp
-    encoder.encode_ascii(&format_timestamp());
+    encoder.encode_ascii(&format_timestamp())?;
 
     // Symbol
-    encoder.encode_ascii(symbol);
+    encoder.encode_ascii(symbol)?;
 
     // Price as scaled integer (price * 100)
     let scaled_price = (price * 100.0) as u64;
@@ -137,5 +152,5 @@ fn build_market_data(seq_num: u64, symbol: &str, price: f64, size: u64) -> Vec<u
     // Size
     encoder.encode_uint(size);
 
-    encoder.finish()
+    Ok(encoder.finish())
 }

--- a/ironfix-example/examples/fast_server_spsc.rs
+++ b/ironfix-example/examples/fast_server_spsc.rs
@@ -22,7 +22,7 @@ mod common;
 
 use common::{ExampleConfig, format_timestamp, init_logging};
 use crossbeam_channel::{Receiver, Sender, TrySendError, bounded};
-use ironfix_fast::FastEncoder;
+use ironfix_fast::{FastEncoder, FastError};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -202,7 +202,13 @@ async fn market_data_broadcaster(
         // Non-blocking receive with timeout
         match rx.recv_timeout(Duration::from_millis(10)) {
             Ok(tick) => {
-                let encoded = encode_market_data(&tick);
+                let encoded = match encode_market_data(&tick) {
+                    Ok(encoded) => encoded,
+                    Err(e) => {
+                        warn!("Failed to encode tick {}: {}", tick.seq_num, e);
+                        continue;
+                    }
+                };
 
                 // Broadcast to all clients
                 let clients_read = clients.read().await;
@@ -273,7 +279,11 @@ async fn handle_client(
 }
 
 /// Encode a market data tick to FAST format
-fn encode_market_data(tick: &MarketDataTick) -> Vec<u8> {
+///
+/// # Errors
+/// Returns `FastError::InvalidString` if the timestamp or symbol is not
+/// representable as a FAST ASCII string.
+fn encode_market_data(tick: &MarketDataTick) -> Result<Vec<u8>, FastError> {
     let mut encoder = FastEncoder::new();
 
     // Presence map: all fields present
@@ -287,10 +297,10 @@ fn encode_market_data(tick: &MarketDataTick) -> Vec<u8> {
     encoder.encode_uint(tick.seq_num);
 
     // Timestamp (as string for simplicity)
-    encoder.encode_ascii(&format_timestamp());
+    encoder.encode_ascii(&format_timestamp())?;
 
     // Symbol
-    encoder.encode_ascii(tick.symbol);
+    encoder.encode_ascii(tick.symbol)?;
 
     // Bid price (in cents)
     encoder.encode_uint(tick.bid_price);
@@ -304,5 +314,5 @@ fn encode_market_data(tick: &MarketDataTick) -> Vec<u8> {
     // Ask size
     encoder.encode_uint(tick.ask_size);
 
-    encoder.finish()
+    Ok(encoder.finish())
 }

--- a/ironfix-fast/src/decoder.rs
+++ b/ironfix-fast/src/decoder.rs
@@ -8,11 +8,57 @@
 //!
 //! This module provides decoding of FAST-encoded messages using stop-bit
 //! encoding and presence maps.
+//!
+//! Every function here is an untrusted-input parser: the bytes arrive from a
+//! counterparty over a socket. Malformed input maps to a typed [`FastError`]
+//! with a resource ceiling — never a panic, never an allocation sized from a
+//! declared length that has not been validated against the bytes actually
+//! available.
 
 use crate::error::FastError;
 use crate::operators::DictionaryValue;
 use crate::pmap::PresenceMap;
 use std::collections::HashMap;
+
+/// Stop bit: set on the final byte of a stop-bit encoded value.
+pub(crate) const STOP_BIT: u8 = 0x80;
+
+/// Mask selecting the seven payload bits of a stop-bit encoded byte.
+pub(crate) const PAYLOAD_MASK: u8 = 0x7F;
+
+/// Number of payload bits carried by each stop-bit encoded byte.
+pub(crate) const PAYLOAD_BITS: usize = 7;
+
+/// Bit 6 of the most significant payload byte: the sign of a signed integer.
+pub(crate) const SIGN_BIT: u8 = 0x40;
+
+/// Maximum number of bytes a stop-bit encoded 64-bit integer may occupy.
+///
+/// A 64-bit value carries at most 64 significant bits at
+/// [`PAYLOAD_BITS`] bits per byte; a signed value needs nine payload bytes
+/// plus one sign-carry byte, so ten bytes is the longest legal encoding of
+/// either `i64::MIN` / `i64::MAX` or `u64::MAX`.
+///
+/// Anything longer is rejected as [`FastError::IntegerOverflow`]. This is the
+/// resource ceiling that stops a hostile stream from spinning the decoder over
+/// an unbounded run of continuation bytes whose value never trips the
+/// arithmetic check (a run of `0x00` or `0x7F` bytes accumulates no new
+/// magnitude).
+pub const MAX_INT_ENCODED_LEN: usize = 10;
+
+/// Reads one byte and advances `offset`.
+///
+/// # Errors
+/// Returns [`FastError::UnexpectedEof`] if `offset` is at or past the end of
+/// `data`.
+#[inline]
+pub(crate) fn read_byte(data: &[u8], offset: &mut usize) -> Result<u8, FastError> {
+    let byte = *data.get(*offset).ok_or(FastError::UnexpectedEof)?;
+    // `get` succeeded, so `*offset < data.len() <= isize::MAX`; the increment
+    // cannot overflow a `usize`.
+    *offset += 1;
+    Ok(byte)
+}
 
 /// FAST protocol decoder.
 #[derive(Debug)]
@@ -45,6 +91,9 @@ impl FastDecoder {
 
     /// Decodes an unsigned integer using stop-bit encoding.
     ///
+    /// Over-long encodings are tolerated up to [`MAX_INT_ENCODED_LEN`] bytes,
+    /// which is the longest legal encoding of `u64::MAX`.
+    ///
     /// # Arguments
     /// * `data` - The input bytes
     /// * `offset` - Current position (will be updated)
@@ -53,27 +102,33 @@ impl FastDecoder {
     /// The decoded unsigned integer.
     ///
     /// # Errors
-    /// Returns `FastError::UnexpectedEof` if data is incomplete.
+    /// Returns [`FastError::UnexpectedEof`] if the stop bit is never reached
+    /// before the end of `data`, or [`FastError::IntegerOverflow`] if the
+    /// encoding is longer than [`MAX_INT_ENCODED_LEN`] bytes or denotes a
+    /// value that does not fit in a `u64`.
     pub fn decode_uint(data: &[u8], offset: &mut usize) -> Result<u64, FastError> {
+        /// Value of one payload byte position.
+        const RADIX: u64 = 1 << PAYLOAD_BITS;
+
         let mut result: u64 = 0;
+        let mut consumed: usize = 0;
 
         loop {
-            if *offset >= data.len() {
-                return Err(FastError::UnexpectedEof);
-            }
-
-            let byte = data[*offset];
-            *offset += 1;
-
-            // Check for overflow
-            if result > (u64::MAX >> 7) {
+            if consumed == MAX_INT_ENCODED_LEN {
                 return Err(FastError::IntegerOverflow);
             }
+            let byte = read_byte(data, offset)?;
+            consumed += 1;
 
-            result = (result << 7) | (byte & 0x7F) as u64;
+            // `checked_mul` rejects any value that would lose significant bits.
+            // The product's low seven bits are zero, so the `|` below cannot
+            // carry and is exact.
+            result = result
+                .checked_mul(RADIX)
+                .ok_or(FastError::IntegerOverflow)?
+                | u64::from(byte & PAYLOAD_MASK);
 
-            // Check stop bit
-            if byte & 0x80 != 0 {
+            if byte & STOP_BIT != 0 {
                 break;
             }
         }
@@ -83,6 +138,10 @@ impl FastDecoder {
 
     /// Decodes a signed integer using stop-bit encoding.
     ///
+    /// The sign is taken from bit 6 of the first byte and the value is
+    /// accumulated in two's complement, so a leading sign-carry byte (`0x00`
+    /// for a positive value, `0x7F` for a negative one) decodes transparently.
+    ///
     /// # Arguments
     /// * `data` - The input bytes
     /// * `offset` - Current position (will be updated)
@@ -91,28 +150,38 @@ impl FastDecoder {
     /// The decoded signed integer.
     ///
     /// # Errors
-    /// Returns `FastError::UnexpectedEof` if data is incomplete.
+    /// Returns [`FastError::UnexpectedEof`] if the stop bit is never reached
+    /// before the end of `data`, or [`FastError::IntegerOverflow`] if the
+    /// encoding is longer than [`MAX_INT_ENCODED_LEN`] bytes or denotes a
+    /// value that does not fit in an `i64`.
     pub fn decode_int(data: &[u8], offset: &mut usize) -> Result<i64, FastError> {
-        if *offset >= data.len() {
-            return Err(FastError::UnexpectedEof);
-        }
+        /// Value of one payload byte position.
+        const RADIX: i64 = 1 << PAYLOAD_BITS;
 
-        let first_byte = data[*offset];
-        let negative = (first_byte & 0x40) != 0;
+        let first_byte = *data.get(*offset).ok_or(FastError::UnexpectedEof)?;
+        let negative = (first_byte & SIGN_BIT) != 0;
 
+        // Sign extension: a negative value starts from all-ones so the
+        // accumulated two's complement stays negative.
         let mut result: i64 = if negative { -1 } else { 0 };
+        let mut consumed: usize = 0;
 
         loop {
-            if *offset >= data.len() {
-                return Err(FastError::UnexpectedEof);
+            if consumed == MAX_INT_ENCODED_LEN {
+                return Err(FastError::IntegerOverflow);
             }
+            let byte = read_byte(data, offset)?;
+            consumed += 1;
 
-            let byte = data[*offset];
-            *offset += 1;
+            // `checked_mul` rejects any value that would lose significant bits
+            // in either direction. The product is a multiple of `RADIX`, so its
+            // low seven bits are zero and the `|` below is exact.
+            result = result
+                .checked_mul(RADIX)
+                .ok_or(FastError::IntegerOverflow)?
+                | i64::from(byte & PAYLOAD_MASK);
 
-            result = (result << 7) | (byte & 0x7F) as i64;
-
-            if byte & 0x80 != 0 {
+            if byte & STOP_BIT != 0 {
                 break;
             }
         }
@@ -122,6 +191,10 @@ impl FastDecoder {
 
     /// Decodes an ASCII string using stop-bit encoding.
     ///
+    /// Follows the FAST 1.1 string encodings: a lone stop byte (`0x80`) is the
+    /// empty string and `0x00 0x80` is the one-character NUL string. Any other
+    /// encoding beginning with `0x00` is over-long and is rejected.
+    ///
     /// # Arguments
     /// * `data` - The input bytes
     /// * `offset` - Current position (will be updated)
@@ -130,31 +203,49 @@ impl FastDecoder {
     /// The decoded string.
     ///
     /// # Errors
-    /// Returns `FastError::UnexpectedEof` if data is incomplete.
+    /// Returns [`FastError::UnexpectedEof`] if the stop bit is never reached
+    /// before the end of `data`, or [`FastError::InvalidString`] for an
+    /// over-long encoding with a leading `0x00`.
     pub fn decode_ascii(data: &[u8], offset: &mut usize) -> Result<String, FastError> {
-        let mut result = Vec::new();
+        let first_byte = *data.get(*offset).ok_or(FastError::UnexpectedEof)?;
+
+        if first_byte == STOP_BIT {
+            *offset += 1;
+            return Ok(String::new());
+        }
+
+        if first_byte == 0x00 {
+            let next_index = offset.checked_add(1).ok_or(FastError::UnexpectedEof)?;
+            let second_byte = *data.get(next_index).ok_or(FastError::UnexpectedEof)?;
+            if second_byte != STOP_BIT {
+                return Err(FastError::InvalidString);
+            }
+            *offset += 2;
+            return Ok(String::from('\0'));
+        }
+
+        let mut result = String::new();
 
         loop {
-            if *offset >= data.len() {
-                return Err(FastError::UnexpectedEof);
-            }
+            let byte = read_byte(data, offset)?;
 
-            let byte = data[*offset];
-            *offset += 1;
+            // The payload is always <= 0x7F, so it is a valid ASCII scalar.
+            result.push(char::from(byte & PAYLOAD_MASK));
 
-            // Add character (without stop bit)
-            result.push(byte & 0x7F);
-
-            // Check stop bit
-            if byte & 0x80 != 0 {
+            if byte & STOP_BIT != 0 {
                 break;
             }
         }
 
-        String::from_utf8(result).map_err(|_| FastError::InvalidString)
+        Ok(result)
     }
 
-    /// Decodes a byte vector.
+    /// Decodes a length-prefixed byte vector.
+    ///
+    /// The declared length is validated against the bytes actually remaining
+    /// **before** it is narrowed to a `usize` or used to size an allocation,
+    /// so a hostile length prefix can never over-allocate or index out of
+    /// bounds.
     ///
     /// # Arguments
     /// * `data` - The input bytes
@@ -164,16 +255,31 @@ impl FastDecoder {
     /// The decoded bytes.
     ///
     /// # Errors
-    /// Returns `FastError::UnexpectedEof` if data is incomplete.
+    /// Returns [`FastError::UnexpectedEof`] if the length prefix is truncated
+    /// or declares more bytes than remain in `data`, or
+    /// [`FastError::IntegerOverflow`] if the length prefix itself is not a
+    /// valid unsigned integer.
     pub fn decode_bytes(data: &[u8], offset: &mut usize) -> Result<Vec<u8>, FastError> {
-        let length = Self::decode_uint(data, offset)? as usize;
+        let declared_length = Self::decode_uint(data, offset)?;
 
-        if *offset + length > data.len() {
+        let remaining = data
+            .len()
+            .checked_sub(*offset)
+            .ok_or(FastError::UnexpectedEof)?;
+
+        // Narrow in the direction that cannot truncate: a length that does not
+        // fit in a `usize` cannot possibly be available on this target either.
+        let length = usize::try_from(declared_length).map_err(|_| FastError::UnexpectedEof)?;
+        if length > remaining {
             return Err(FastError::UnexpectedEof);
         }
 
-        let bytes = data[*offset..*offset + length].to_vec();
-        *offset += length;
+        let end = offset.checked_add(length).ok_or(FastError::UnexpectedEof)?;
+        let bytes = data
+            .get(*offset..end)
+            .ok_or(FastError::UnexpectedEof)?
+            .to_vec();
+        *offset = end;
 
         Ok(bytes)
     }
@@ -188,7 +294,9 @@ impl FastDecoder {
     /// The decoded presence map.
     ///
     /// # Errors
-    /// Returns `FastError::UnexpectedEof` if data is incomplete.
+    /// Returns [`FastError::UnexpectedEof`] if the data is incomplete, or
+    /// [`FastError::PresenceMapTooLarge`] if the map exceeds
+    /// [`crate::pmap::MAX_PMAP_BYTES`].
     pub fn decode_pmap(data: &[u8], offset: &mut usize) -> Result<PresenceMap, FastError> {
         PresenceMap::decode(data, offset)
     }
@@ -246,13 +354,47 @@ impl Default for FastDecoder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::encoder::FastEncoder;
+
+    /// Encodes `value` as a signed integer and decodes it back, asserting the
+    /// decoder consumed exactly the bytes the encoder produced.
+    fn round_trip_int(value: i64) -> Result<i64, FastError> {
+        let mut encoder = FastEncoder::new();
+        encoder.encode_int(value);
+        let bytes = encoder.finish();
+
+        let mut offset = 0;
+        let decoded = FastDecoder::decode_int(&bytes, &mut offset)?;
+        assert_eq!(
+            offset,
+            bytes.len(),
+            "decode_int must consume the whole encoding of {value}"
+        );
+        Ok(decoded)
+    }
+
+    /// Encodes `value` as an unsigned integer and decodes it back, asserting
+    /// the decoder consumed exactly the bytes the encoder produced.
+    fn round_trip_uint(value: u64) -> Result<u64, FastError> {
+        let mut encoder = FastEncoder::new();
+        encoder.encode_uint(value);
+        let bytes = encoder.finish();
+
+        let mut offset = 0;
+        let decoded = FastDecoder::decode_uint(&bytes, &mut offset)?;
+        assert_eq!(
+            offset,
+            bytes.len(),
+            "decode_uint must consume the whole encoding of {value}"
+        );
+        Ok(decoded)
+    }
 
     #[test]
     fn test_decode_uint_single_byte() {
         let data = [0x81]; // 1 with stop bit
         let mut offset = 0;
-        let result = FastDecoder::decode_uint(&data, &mut offset).unwrap();
-        assert_eq!(result, 1);
+        assert_eq!(FastDecoder::decode_uint(&data, &mut offset), Ok(1));
         assert_eq!(offset, 1);
     }
 
@@ -260,45 +402,370 @@ mod tests {
     fn test_decode_uint_multi_byte() {
         let data = [0x00, 0x81]; // 1 in two bytes
         let mut offset = 0;
-        let result = FastDecoder::decode_uint(&data, &mut offset).unwrap();
-        assert_eq!(result, 1);
+        assert_eq!(FastDecoder::decode_uint(&data, &mut offset), Ok(1));
         assert_eq!(offset, 2);
     }
 
     #[test]
     fn test_decode_uint_larger() {
-        // 942 = 0x3AE = 0b11_1010_1110
-        // In stop-bit encoding: 0x07 (0b0000111), 0xAE | 0x80 = 0x2E | 0x80 = 0xAE
-        // Actually: 942 = 7 * 128 + 46 = 896 + 46
-        // First byte: 7 (0x07), second byte: 46 | 0x80 = 0xAE
-        let data = [0x07, 0xAE]; // 942 in stop-bit encoding
+        // 942 = 7 * 128 + 46; first byte 7 (0x07), second byte 46 | 0x80 (0xAE)
+        let data = [0x07, 0xAE];
         let mut offset = 0;
-        let result = FastDecoder::decode_uint(&data, &mut offset).unwrap();
-        assert_eq!(result, 942);
+        assert_eq!(FastDecoder::decode_uint(&data, &mut offset), Ok(942));
+    }
+
+    #[test]
+    fn test_decode_uint_max_uses_ten_bytes() {
+        let data = [0x01, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0xFF];
+        let mut offset = 0;
+        assert_eq!(FastDecoder::decode_uint(&data, &mut offset), Ok(u64::MAX));
+        assert_eq!(offset, MAX_INT_ENCODED_LEN);
+    }
+
+    #[test]
+    fn test_decode_uint_truncated_is_unexpected_eof() {
+        // No stop bit anywhere.
+        let data = [0x01, 0x02, 0x03];
+        let mut offset = 0;
+        assert_eq!(
+            FastDecoder::decode_uint(&data, &mut offset),
+            Err(FastError::UnexpectedEof)
+        );
+    }
+
+    #[test]
+    fn test_decode_uint_empty_input_is_unexpected_eof() {
+        let data: [u8; 0] = [];
+        let mut offset = 0;
+        assert_eq!(
+            FastDecoder::decode_uint(&data, &mut offset),
+            Err(FastError::UnexpectedEof)
+        );
+    }
+
+    #[test]
+    fn test_decode_uint_value_above_u64_max_is_integer_overflow() {
+        // Ten bytes whose value is 2 * 2^63 — one bit too wide for a u64.
+        let data = [0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80];
+        let mut offset = 0;
+        assert_eq!(
+            FastDecoder::decode_uint(&data, &mut offset),
+            Err(FastError::IntegerOverflow)
+        );
+    }
+
+    #[test]
+    fn test_decode_uint_over_long_encoding_is_integer_overflow() {
+        // Eleven continuation bytes that never accumulate magnitude: only the
+        // byte-count ceiling can reject this.
+        let mut data = vec![0x00; MAX_INT_ENCODED_LEN + 1];
+        data.push(0x80);
+        let mut offset = 0;
+        assert_eq!(
+            FastDecoder::decode_uint(&data, &mut offset),
+            Err(FastError::IntegerOverflow)
+        );
+    }
+
+    #[test]
+    fn test_decode_uint_round_trips_boundaries() {
+        let mut values: Vec<u64> = vec![0, u64::MAX];
+        for shift in 0..64u32 {
+            let Some(base) = 1u64.checked_shl(shift) else {
+                continue;
+            };
+            values.push(base);
+            if let Some(below) = base.checked_sub(1) {
+                values.push(below);
+            }
+            if let Some(above) = base.checked_add(1) {
+                values.push(above);
+            }
+        }
+
+        for value in values {
+            assert_eq!(round_trip_uint(value), Ok(value), "uint round trip {value}");
+        }
     }
 
     #[test]
     fn test_decode_int_positive() {
         let data = [0x81]; // 1
         let mut offset = 0;
-        let result = FastDecoder::decode_int(&data, &mut offset).unwrap();
-        assert_eq!(result, 1);
+        assert_eq!(FastDecoder::decode_int(&data, &mut offset), Ok(1));
     }
 
     #[test]
     fn test_decode_int_negative() {
         let data = [0xFF]; // -1
         let mut offset = 0;
-        let result = FastDecoder::decode_int(&data, &mut offset).unwrap();
-        assert_eq!(result, -1);
+        assert_eq!(FastDecoder::decode_int(&data, &mut offset), Ok(-1));
+    }
+
+    #[test]
+    fn test_decode_int_min_and_max_use_ten_bytes() {
+        let max = [0x00, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0xFF];
+        let mut offset = 0;
+        assert_eq!(FastDecoder::decode_int(&max, &mut offset), Ok(i64::MAX));
+        assert_eq!(offset, MAX_INT_ENCODED_LEN);
+
+        let min = [0x7F, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80];
+        let mut offset = 0;
+        assert_eq!(FastDecoder::decode_int(&min, &mut offset), Ok(i64::MIN));
+        assert_eq!(offset, MAX_INT_ENCODED_LEN);
+    }
+
+    #[test]
+    fn test_decode_int_value_below_i64_min_is_integer_overflow() {
+        // Ten bytes denoting -(2^69): the sign-extended accumulator overflows.
+        let data = [0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80];
+        let mut offset = 0;
+        assert_eq!(
+            FastDecoder::decode_int(&data, &mut offset),
+            Err(FastError::IntegerOverflow)
+        );
+    }
+
+    #[test]
+    fn test_decode_int_over_long_negative_run_is_integer_overflow() {
+        // Twelve 0x7F bytes then a stop byte: every byte re-encodes -1, so the
+        // arithmetic check never fires and only the byte ceiling rejects it.
+        let mut data = vec![0x7F; 12];
+        data.push(0xFF);
+        let mut offset = 0;
+        assert_eq!(
+            FastDecoder::decode_int(&data, &mut offset),
+            Err(FastError::IntegerOverflow)
+        );
+    }
+
+    #[test]
+    fn test_decode_int_truncated_is_unexpected_eof() {
+        let data = [0x00, 0x40];
+        let mut offset = 0;
+        assert_eq!(
+            FastDecoder::decode_int(&data, &mut offset),
+            Err(FastError::UnexpectedEof)
+        );
+    }
+
+    #[test]
+    fn test_decode_int_empty_input_is_unexpected_eof() {
+        let data: [u8; 0] = [];
+        let mut offset = 0;
+        assert_eq!(
+            FastDecoder::decode_int(&data, &mut offset),
+            Err(FastError::UnexpectedEof)
+        );
+    }
+
+    #[test]
+    fn test_encode_int_round_trips_every_seven_bit_boundary() {
+        let mut values: Vec<i64> = vec![0, i64::MIN, i64::MAX];
+
+        for shift in 0..63u32 {
+            let Some(base) = 1i64.checked_shl(shift) else {
+                continue;
+            };
+            for candidate in [base.checked_sub(1), Some(base), base.checked_add(1)] {
+                let Some(value) = candidate else {
+                    continue;
+                };
+                values.push(value);
+                if let Some(negated) = value.checked_neg() {
+                    values.push(negated);
+                }
+            }
+        }
+
+        for value in values {
+            assert_eq!(round_trip_int(value), Ok(value), "int round trip {value}");
+        }
+    }
+
+    #[test]
+    fn test_encode_int_boundaries_are_byte_exact() {
+        let cases: [(i64, &[u8]); 13] = [
+            (0, &[0x80]),
+            (1, &[0x81]),
+            (63, &[0xBF]),
+            (64, &[0x00, 0xC0]),
+            (127, &[0x00, 0xFF]),
+            (128, &[0x01, 0x80]),
+            (8191, &[0x3F, 0xFF]),
+            (8192, &[0x00, 0x40, 0x80]),
+            (-1, &[0xFF]),
+            (-64, &[0xC0]),
+            (-65, &[0x7F, 0xBF]),
+            (-128, &[0x7F, 0x80]),
+            (-8192, &[0x40, 0x80]),
+        ];
+
+        for (value, expected) in cases {
+            let mut encoder = FastEncoder::new();
+            encoder.encode_int(value);
+            assert_eq!(encoder.finish(), expected, "minimal encoding of {value}");
+        }
     }
 
     #[test]
     fn test_decode_ascii() {
         let data = [b'H', b'i', b'!' | 0x80]; // "Hi!"
         let mut offset = 0;
-        let result = FastDecoder::decode_ascii(&data, &mut offset).unwrap();
-        assert_eq!(result, "Hi!");
+        assert_eq!(
+            FastDecoder::decode_ascii(&data, &mut offset),
+            Ok("Hi!".to_string())
+        );
+        assert_eq!(offset, 3);
+    }
+
+    #[test]
+    fn test_decode_ascii_lone_stop_byte_is_the_empty_string() {
+        let data = [0x80];
+        let mut offset = 0;
+        assert_eq!(
+            FastDecoder::decode_ascii(&data, &mut offset),
+            Ok(String::new())
+        );
+        assert_eq!(offset, 1);
+    }
+
+    #[test]
+    fn test_decode_ascii_zero_stop_is_the_nul_string() {
+        let data = [0x00, 0x80];
+        let mut offset = 0;
+        assert_eq!(
+            FastDecoder::decode_ascii(&data, &mut offset),
+            Ok("\0".to_string())
+        );
+        assert_eq!(offset, 2);
+    }
+
+    #[test]
+    fn test_decode_ascii_over_long_leading_zero_is_invalid_string() {
+        // 0x00 followed by anything other than the stop byte is over-long.
+        let data = [0x00, 0x00, 0x80];
+        let mut offset = 0;
+        assert_eq!(
+            FastDecoder::decode_ascii(&data, &mut offset),
+            Err(FastError::InvalidString)
+        );
+
+        let data = [0x00, b'a' | 0x80];
+        let mut offset = 0;
+        assert_eq!(
+            FastDecoder::decode_ascii(&data, &mut offset),
+            Err(FastError::InvalidString)
+        );
+    }
+
+    #[test]
+    fn test_decode_ascii_truncated_leading_zero_is_unexpected_eof() {
+        let data = [0x00];
+        let mut offset = 0;
+        assert_eq!(
+            FastDecoder::decode_ascii(&data, &mut offset),
+            Err(FastError::UnexpectedEof)
+        );
+    }
+
+    #[test]
+    fn test_decode_ascii_without_stop_bit_is_unexpected_eof() {
+        let data = *b"Hi";
+        let mut offset = 0;
+        assert_eq!(
+            FastDecoder::decode_ascii(&data, &mut offset),
+            Err(FastError::UnexpectedEof)
+        );
+    }
+
+    #[test]
+    fn test_decode_ascii_round_trips_through_the_encoder() {
+        for value in ["", "\0", "A", "Hi!", "EURUSD", "a\0b", "\x7f"] {
+            let mut encoder = FastEncoder::new();
+            assert_eq!(encoder.encode_ascii(value), Ok(()));
+            let bytes = encoder.finish();
+
+            let mut offset = 0;
+            assert_eq!(
+                FastDecoder::decode_ascii(&bytes, &mut offset),
+                Ok(value.to_string()),
+                "ascii round trip {value:?}"
+            );
+            assert_eq!(offset, bytes.len());
+        }
+    }
+
+    #[test]
+    fn test_decode_bytes_round_trip() {
+        let mut encoder = FastEncoder::new();
+        encoder.encode_bytes(&[1, 2, 3]);
+        let bytes = encoder.finish();
+
+        let mut offset = 0;
+        assert_eq!(
+            FastDecoder::decode_bytes(&bytes, &mut offset),
+            Ok(vec![1, 2, 3])
+        );
+        assert_eq!(offset, bytes.len());
+    }
+
+    #[test]
+    fn test_decode_bytes_empty_payload() {
+        let data = [0x80];
+        let mut offset = 0;
+        assert_eq!(
+            FastDecoder::decode_bytes(&data, &mut offset),
+            Ok(Vec::new())
+        );
+        assert_eq!(offset, 1);
+    }
+
+    #[test]
+    fn test_decode_bytes_huge_declared_length_is_unexpected_eof() {
+        // Stop-bit encoding of u64::MAX as the length prefix, then a short body.
+        let mut data = vec![0x01, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0xFF];
+        data.extend_from_slice(&[1, 2, 3]);
+
+        let mut offset = 0;
+        assert_eq!(
+            FastDecoder::decode_bytes(&data, &mut offset),
+            Err(FastError::UnexpectedEof)
+        );
+    }
+
+    #[test]
+    fn test_decode_bytes_length_one_past_the_end_is_unexpected_eof() {
+        // Declares four bytes but only three follow.
+        let data = [0x84, 1, 2, 3];
+        let mut offset = 0;
+        assert_eq!(
+            FastDecoder::decode_bytes(&data, &mut offset),
+            Err(FastError::UnexpectedEof)
+        );
+    }
+
+    #[test]
+    fn test_decode_bytes_truncated_length_prefix_is_unexpected_eof() {
+        let data = [0x01];
+        let mut offset = 0;
+        assert_eq!(
+            FastDecoder::decode_bytes(&data, &mut offset),
+            Err(FastError::UnexpectedEof)
+        );
+    }
+
+    #[test]
+    fn test_decode_pmap_delegates_to_presence_map() {
+        let data = [0b1100_0000];
+        let mut offset = 0;
+        let decoded = FastDecoder::decode_pmap(&data, &mut offset);
+        assert!(decoded.is_ok());
+        if let Ok(pmap) = decoded {
+            assert_eq!(pmap.len(), PAYLOAD_BITS);
+            assert_eq!(pmap.bit(0), Some(true));
+        }
+        assert_eq!(offset, 1);
     }
 
     #[test]
@@ -306,12 +773,29 @@ mod tests {
         let mut decoder = FastDecoder::new();
 
         decoder.set_global("test", DictionaryValue::Int(42));
-        assert_eq!(decoder.get_global("test").unwrap().as_i64(), Some(42));
+        assert_eq!(
+            decoder.get_global("test").and_then(DictionaryValue::as_i64),
+            Some(42)
+        );
 
         decoder.set_template(1, "field", DictionaryValue::UInt(100));
         assert_eq!(
-            decoder.get_template(1, "field").unwrap().as_u64(),
+            decoder
+                .get_template(1, "field")
+                .and_then(DictionaryValue::as_u64),
             Some(100)
         );
+    }
+
+    #[test]
+    fn test_decoder_reset_clears_state() {
+        let mut decoder = FastDecoder::new();
+        decoder.set_global("test", DictionaryValue::Int(1));
+        decoder.set_last_template_id(7);
+        assert_eq!(decoder.last_template_id(), Some(7));
+
+        decoder.reset();
+        assert!(decoder.get_global("test").is_none());
+        assert_eq!(decoder.last_template_id(), None);
     }
 }

--- a/ironfix-fast/src/decoder.rs
+++ b/ironfix-fast/src/decoder.rs
@@ -12,6 +12,16 @@
 //! Every function here is an untrusted-input parser: the bytes arrive from a
 //! counterparty over a socket. Malformed input maps to a typed [`FastError`]
 //! with a resource ceiling — never a panic, never an allocation sized from a
+//! declared length before it is validated. The ceilings are fixed for
+//! integers and presence maps; a string or byte vector is instead bounded by
+//! the bytes the peer has actually delivered, since neither has a length the
+//! specification caps. A caller that must bound field size does so by bounding
+//! the frame it hands in.
+//!
+//! On error the read offset is left wherever the failure was detected, which
+//! differs per entry point. Every error here is fatal for the frame, so a
+//! caller must not resume from a partially advanced offset; restart from a
+//! known frame boundary instead.
 //! declared length that has not been validated against the bytes actually
 //! available.
 
@@ -189,6 +199,31 @@ impl FastDecoder {
         Ok(result)
     }
 
+    /// Decodes a nullable unsigned integer.
+    ///
+    /// FAST represents a nullable unsigned integer with a bias of one: a lone
+    /// stop byte is NULL, and any other value is the encoded value minus one.
+    /// This is the counterpart of
+    /// [`FastEncoder::encode_nullable_uint`](crate::FastEncoder::encode_nullable_uint);
+    /// the two must agree, so the bias lives here rather than in every caller,
+    /// which is where an off-by-one reappears.
+    ///
+    /// The representable domain is therefore `0..=u64::MAX - 1`.
+    ///
+    /// # Errors
+    /// Returns [`FastError::UnexpectedEof`] if the input ends mid-value, or
+    /// [`FastError::IntegerOverflow`] if the encoded value exceeds the
+    /// representable domain.
+    pub fn decode_nullable_uint(data: &[u8], offset: &mut usize) -> Result<Option<u64>, FastError> {
+        let raw = Self::decode_uint(data, offset)?;
+        match raw {
+            0 => Ok(None),
+            biased => biased
+                .checked_sub(1)
+                .map(Some)
+                .ok_or(FastError::IntegerOverflow),
+        }
+    }
     /// Decodes an ASCII string using stop-bit encoding.
     ///
     /// Follows the FAST 1.1 string encodings: a lone stop byte (`0x80`) is the
@@ -224,17 +259,24 @@ impl FastDecoder {
             return Ok(String::from('\0'));
         }
 
-        let mut result = String::new();
+        // Locate the stop byte first, so the buffer is sized once from bytes
+        // that are actually present rather than grown geometrically -- which
+        // otherwise costs twice the field size in peak heap. The scan is
+        // bounded by the input, and a field with no stop byte is rejected
+        // before anything is allocated.
+        let tail = data.get(*offset..).ok_or(FastError::UnexpectedEof)?;
+        let len = tail
+            .iter()
+            .position(|byte| byte & STOP_BIT != 0)
+            .ok_or(FastError::UnexpectedEof)?
+            .checked_add(1)
+            .ok_or(FastError::UnexpectedEof)?;
 
-        loop {
+        let mut result = String::with_capacity(len);
+        for _ in 0..len {
             let byte = read_byte(data, offset)?;
-
             // The payload is always <= 0x7F, so it is a valid ASCII scalar.
             result.push(char::from(byte & PAYLOAD_MASK));
-
-            if byte & STOP_BIT != 0 {
-                break;
-            }
         }
 
         Ok(result)
@@ -606,6 +648,50 @@ mod tests {
             encoder.encode_int(value);
             assert_eq!(encoder.finish(), expected, "minimal encoding of {value}");
         }
+    }
+
+    #[test]
+    fn test_decode_nullable_uint_round_trips_through_the_encoder() {
+        // The bias lives in one place now, so encoder and decoder cannot
+        // disagree about it -- which is exactly where the off-by-one this
+        // change fixes used to reappear in every caller.
+        for value in [
+            None,
+            Some(0),
+            Some(1),
+            Some(127),
+            Some(128),
+            Some(u64::MAX - 1),
+        ] {
+            let mut encoder = crate::FastEncoder::new();
+            assert!(encoder.encode_nullable_uint(value).is_ok());
+            let buffer = encoder.finish();
+            let mut offset = 0;
+            assert_eq!(
+                FastDecoder::decode_nullable_uint(&buffer, &mut offset),
+                Ok(value),
+                "round trip failed for {value:?}"
+            );
+            assert_eq!(offset, buffer.len(), "the whole value must be consumed");
+        }
+    }
+
+    #[test]
+    fn test_decode_nullable_uint_lone_stop_byte_is_null() {
+        let mut offset = 0;
+        assert_eq!(
+            FastDecoder::decode_nullable_uint(&[0x80], &mut offset),
+            Ok(None)
+        );
+    }
+
+    #[test]
+    fn test_encode_nullable_uint_rejects_the_value_outside_its_domain() {
+        let mut encoder = crate::FastEncoder::new();
+        assert_eq!(
+            encoder.encode_nullable_uint(Some(u64::MAX)),
+            Err(FastError::IntegerOverflow)
+        );
     }
 
     #[test]

--- a/ironfix-fast/src/encoder.rs
+++ b/ironfix-fast/src/encoder.rs
@@ -7,9 +7,22 @@
 //! FAST protocol encoder.
 //!
 //! This module provides encoding of values using FAST stop-bit encoding.
+//!
+//! Every encoding produced here is minimal — the shortest byte sequence that
+//! decodes back to the same value — and never longer than
+//! [`MAX_INT_ENCODED_LEN`] for an integer, so the encoder can never emit a
+//! frame its own decoder would reject.
 
+use crate::decoder::{MAX_INT_ENCODED_LEN, PAYLOAD_BITS, PAYLOAD_MASK, SIGN_BIT, STOP_BIT};
+use crate::error::FastError;
 use crate::operators::DictionaryValue;
+use smallvec::SmallVec;
 use std::collections::HashMap;
+
+/// Scratch buffer for one stop-bit encoded integer.
+///
+/// Sized so a full-width `i64` or `u64` encoding never spills to the heap.
+type IntScratch = SmallVec<[u8; MAX_INT_ENCODED_LEN]>;
 
 /// FAST protocol encoder.
 #[derive(Debug)]
@@ -45,100 +58,116 @@ impl FastEncoder {
 
     /// Encodes an unsigned integer using stop-bit encoding.
     ///
+    /// The encoding is minimal: `0` is a single stop byte and `u64::MAX`
+    /// occupies [`MAX_INT_ENCODED_LEN`] bytes.
+    ///
     /// # Arguments
     /// * `value` - The value to encode
     pub fn encode_uint(&mut self, value: u64) {
-        if value == 0 {
-            self.buffer.push(0x80);
-            return;
+        let mut bytes = IntScratch::new();
+        let mut remaining = value;
+
+        loop {
+            bytes.push((remaining & u64::from(PAYLOAD_MASK)) as u8);
+            remaining >>= PAYLOAD_BITS;
+
+            if remaining == 0 {
+                break;
+            }
         }
 
-        let mut bytes = Vec::new();
-        let mut v = value;
-
-        while v > 0 {
-            bytes.push((v & 0x7F) as u8);
-            v >>= 7;
-        }
-
-        bytes.reverse();
-
-        // Set stop bit on last byte
-        if let Some(last) = bytes.last_mut() {
-            *last |= 0x80;
-        }
-
-        self.buffer.extend(bytes);
+        Self::flush_stop_bit_encoded(&mut self.buffer, &mut bytes);
     }
 
     /// Encodes a signed integer using stop-bit encoding.
     ///
+    /// The value is emitted in two's complement, seven bits per byte, most
+    /// significant byte first. When bit 6 of the most significant payload byte
+    /// does not already carry the sign, an extra carry byte (`0x00` for a
+    /// positive value, `0x7F` for a negative one) is prepended — without it the
+    /// decoder would read the value back with the opposite sign.
+    ///
+    /// The encoding is minimal and never exceeds [`MAX_INT_ENCODED_LEN`] bytes.
+    ///
     /// # Arguments
     /// * `value` - The value to encode
     pub fn encode_int(&mut self, value: i64) {
-        if (0..64).contains(&value) {
-            self.buffer.push((value as u8) | 0x80);
-            return;
-        }
-
-        if (-64..0).contains(&value) {
-            self.buffer.push((value as u8) | 0x80);
-            return;
-        }
-
-        let mut bytes = Vec::new();
-        let mut v = value;
         let negative = value < 0;
+        let mut bytes = IntScratch::new();
+        let mut remaining = value;
 
         loop {
-            bytes.push((v & 0x7F) as u8);
-            v >>= 7;
+            bytes.push((remaining & i64::from(PAYLOAD_MASK)) as u8);
+            // Arithmetic shift: converges to 0 for a positive value and to -1
+            // for a negative one.
+            remaining >>= PAYLOAD_BITS;
 
-            if (negative && v == -1 && (bytes.last().unwrap() & 0x40) != 0)
-                || (!negative && v == 0 && (bytes.last().unwrap() & 0x40) == 0)
-            {
-                break;
-            }
-
-            if v == 0 && !negative {
-                break;
-            }
-            if v == -1 && negative {
+            if (negative && remaining == -1) || (!negative && remaining == 0) {
                 break;
             }
         }
 
-        bytes.reverse();
+        // The loop always pushes at least one byte, so `last` is always `Some`.
+        let sign_conflicts = bytes
+            .last()
+            .is_some_and(|most_significant| (most_significant & SIGN_BIT != 0) != negative);
 
-        if let Some(last) = bytes.last_mut() {
-            *last |= 0x80;
+        if sign_conflicts {
+            bytes.push(if negative { PAYLOAD_MASK } else { 0x00 });
         }
 
-        self.buffer.extend(bytes);
+        Self::flush_stop_bit_encoded(&mut self.buffer, &mut bytes);
     }
 
     /// Encodes an ASCII string using stop-bit encoding.
     ///
+    /// Follows the FAST 1.1 string encodings: the empty string is a lone stop
+    /// byte (`0x80`) and the one-character NUL string is `0x00 0x80`. A longer
+    /// string beginning with NUL has no legal representation — its encoding
+    /// would be an over-long form the decoder must reject — so it is refused
+    /// here rather than written to the wire.
+    ///
     /// # Arguments
     /// * `value` - The string to encode
-    pub fn encode_ascii(&mut self, value: &str) {
+    ///
+    /// # Errors
+    /// Returns [`FastError::InvalidString`] if `value` contains a non-ASCII
+    /// character, or if it begins with a NUL and is longer than one character.
+    pub fn encode_ascii(&mut self, value: &str) -> Result<(), FastError> {
+        if !value.is_ascii() {
+            return Err(FastError::InvalidString);
+        }
+
         let bytes = value.as_bytes();
 
-        if bytes.is_empty() {
-            self.buffer.push(0x80);
-            return;
+        match bytes {
+            [] => {
+                self.buffer.push(STOP_BIT);
+                return Ok(());
+            }
+            [0x00] => {
+                self.buffer.extend_from_slice(&[0x00, STOP_BIT]);
+                return Ok(());
+            }
+            [0x00, ..] => return Err(FastError::InvalidString),
+            _ => {}
         }
 
-        for (i, &b) in bytes.iter().enumerate() {
-            if i == bytes.len() - 1 {
-                self.buffer.push(b | 0x80);
-            } else {
-                self.buffer.push(b & 0x7F);
-            }
-        }
+        let Some((last, head)) = bytes.split_last() else {
+            // Unreachable: the empty slice is handled above.
+            return Err(FastError::InvalidString);
+        };
+
+        self.buffer.reserve(bytes.len());
+        // Every byte is ASCII, so no payload bit is lost and no stop bit is set
+        // by accident.
+        self.buffer.extend_from_slice(head);
+        self.buffer.push(last | STOP_BIT);
+
+        Ok(())
     }
 
-    /// Encodes a byte vector with length prefix.
+    /// Encodes a byte vector with a stop-bit encoded length prefix.
     ///
     /// # Arguments
     /// * `value` - The bytes to encode
@@ -149,13 +178,27 @@ impl FastEncoder {
 
     /// Encodes a nullable unsigned integer.
     ///
+    /// A nullable unsigned integer is encoded with a bias of one so that the
+    /// single stop byte `0x80` is reserved for `None`. The representable
+    /// domain is therefore `0..=u64::MAX - 1`: `Some(u64::MAX)` has no
+    /// encoding and is rejected rather than silently biased into the `None`
+    /// representation.
+    ///
     /// # Arguments
     /// * `value` - The optional value to encode
-    pub fn encode_nullable_uint(&mut self, value: Option<u64>) {
+    ///
+    /// # Errors
+    /// Returns [`FastError::IntegerOverflow`] for `Some(u64::MAX)`.
+    pub fn encode_nullable_uint(&mut self, value: Option<u64>) -> Result<(), FastError> {
         match value {
-            Some(v) => self.encode_uint(v + 1),
-            None => self.buffer.push(0x80),
+            Some(v) => {
+                let biased = v.checked_add(1).ok_or(FastError::IntegerOverflow)?;
+                self.encode_uint(biased);
+            }
+            None => self.buffer.push(STOP_BIT),
         }
+
+        Ok(())
     }
 
     /// Returns the encoded bytes.
@@ -204,6 +247,18 @@ impl FastEncoder {
     pub fn set_global(&mut self, key: impl Into<String>, value: DictionaryValue) {
         self.global_dict.insert(key.into(), value);
     }
+
+    /// Appends `bytes` — accumulated least significant byte first — to `out` in
+    /// wire order with the stop bit set on the final byte.
+    fn flush_stop_bit_encoded(out: &mut Vec<u8>, bytes: &mut IntScratch) {
+        bytes.reverse();
+
+        if let Some(last) = bytes.last_mut() {
+            *last |= STOP_BIT;
+        }
+
+        out.extend_from_slice(bytes.as_slice());
+    }
 }
 
 impl Default for FastEncoder {
@@ -234,32 +289,193 @@ mod tests {
     fn test_encode_uint_larger() {
         let mut encoder = FastEncoder::new();
         encoder.encode_uint(942);
-        let bytes = encoder.finish();
         // 942 = 7 * 128 + 46, so first byte is 7, second is 46 | 0x80 = 0xAE
-        assert_eq!(bytes, vec![0x07, 0xAE]);
+        assert_eq!(encoder.finish(), vec![0x07, 0xAE]);
+    }
+
+    #[test]
+    fn test_encode_uint_boundaries_are_byte_exact() {
+        let cases: [(u64, &[u8]); 6] = [
+            (0, &[0x80]),
+            (127, &[0xFF]),
+            (128, &[0x01, 0x80]),
+            (16383, &[0x7F, 0xFF]),
+            (16384, &[0x01, 0x00, 0x80]),
+            (
+                u64::MAX,
+                &[0x01, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0xFF],
+            ),
+        ];
+
+        for (value, expected) in cases {
+            let mut encoder = FastEncoder::new();
+            encoder.encode_uint(value);
+            assert_eq!(encoder.finish(), expected, "minimal encoding of {value}");
+        }
+    }
+
+    #[test]
+    fn test_encode_uint_never_exceeds_the_decoder_ceiling() {
+        for shift in 0..64u32 {
+            let Some(value) = 1u64.checked_shl(shift) else {
+                continue;
+            };
+            let mut encoder = FastEncoder::new();
+            encoder.encode_uint(value);
+            assert!(encoder.len() <= MAX_INT_ENCODED_LEN, "value {value}");
+        }
+    }
+
+    #[test]
+    fn test_encode_int_emits_the_sign_carry_byte() {
+        // 64 needs a leading 0x00: without it, bit 6 of the only payload byte
+        // would make the decoder read -64.
+        let mut encoder = FastEncoder::new();
+        encoder.encode_int(64);
+        assert_eq!(encoder.finish(), vec![0x00, 0xC0]);
+
+        // -65 needs a leading 0x7F for the mirror-image reason.
+        let mut encoder = FastEncoder::new();
+        encoder.encode_int(-65);
+        assert_eq!(encoder.finish(), vec![0x7F, 0xBF]);
+    }
+
+    #[test]
+    fn test_encode_int_omits_the_carry_byte_when_the_sign_already_fits() {
+        let mut encoder = FastEncoder::new();
+        encoder.encode_int(63);
+        assert_eq!(encoder.finish(), vec![0xBF]);
+
+        let mut encoder = FastEncoder::new();
+        encoder.encode_int(-64);
+        assert_eq!(encoder.finish(), vec![0xC0]);
+    }
+
+    #[test]
+    fn test_encode_int_extremes_use_ten_bytes() {
+        let mut encoder = FastEncoder::new();
+        encoder.encode_int(i64::MAX);
+        assert_eq!(
+            encoder.finish(),
+            vec![0x00, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0xFF]
+        );
+
+        let mut encoder = FastEncoder::new();
+        encoder.encode_int(i64::MIN);
+        assert_eq!(
+            encoder.finish(),
+            vec![0x7F, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80]
+        );
+    }
+
+    #[test]
+    fn test_encode_int_never_exceeds_the_decoder_ceiling() {
+        for shift in 0..63u32 {
+            let Some(value) = 1i64.checked_shl(shift) else {
+                continue;
+            };
+            for candidate in [Some(value), value.checked_neg(), value.checked_sub(1)] {
+                let Some(value) = candidate else {
+                    continue;
+                };
+                let mut encoder = FastEncoder::new();
+                encoder.encode_int(value);
+                assert!(encoder.len() <= MAX_INT_ENCODED_LEN, "value {value}");
+            }
+        }
     }
 
     #[test]
     fn test_encode_ascii() {
         let mut encoder = FastEncoder::new();
-        encoder.encode_ascii("Hi!");
-        let bytes = encoder.finish();
-        assert_eq!(bytes, vec![b'H', b'i', b'!' | 0x80]);
+        assert_eq!(encoder.encode_ascii("Hi!"), Ok(()));
+        assert_eq!(encoder.finish(), vec![b'H', b'i', b'!' | 0x80]);
     }
 
     #[test]
-    fn test_encode_ascii_empty() {
+    fn test_encode_ascii_empty_is_a_lone_stop_byte() {
         let mut encoder = FastEncoder::new();
-        encoder.encode_ascii("");
+        assert_eq!(encoder.encode_ascii(""), Ok(()));
         assert_eq!(encoder.finish(), vec![0x80]);
+    }
+
+    #[test]
+    fn test_encode_ascii_nul_is_zero_then_stop() {
+        let mut encoder = FastEncoder::new();
+        assert_eq!(encoder.encode_ascii("\0"), Ok(()));
+        assert_eq!(encoder.finish(), vec![0x00, 0x80]);
+    }
+
+    #[test]
+    fn test_encode_ascii_leading_nul_string_is_invalid_string() {
+        let mut encoder = FastEncoder::new();
+        assert_eq!(
+            encoder.encode_ascii("\0a"),
+            Err(FastError::InvalidString),
+            "a leading NUL followed by more characters is an over-long form"
+        );
+        assert!(encoder.is_empty(), "nothing may reach the wire on error");
+    }
+
+    #[test]
+    fn test_encode_ascii_non_ascii_is_invalid_string() {
+        let mut encoder = FastEncoder::new();
+        assert_eq!(encoder.encode_ascii("€"), Err(FastError::InvalidString));
+        assert_eq!(encoder.encode_ascii("café"), Err(FastError::InvalidString));
+        assert!(encoder.is_empty(), "nothing may reach the wire on error");
     }
 
     #[test]
     fn test_encode_bytes() {
         let mut encoder = FastEncoder::new();
         encoder.encode_bytes(&[1, 2, 3]);
-        let bytes = encoder.finish();
-        assert_eq!(bytes, vec![0x83, 1, 2, 3]);
+        assert_eq!(encoder.finish(), vec![0x83, 1, 2, 3]);
+    }
+
+    #[test]
+    fn test_encode_bytes_empty_is_a_zero_length_prefix() {
+        let mut encoder = FastEncoder::new();
+        encoder.encode_bytes(&[]);
+        assert_eq!(encoder.finish(), vec![0x80]);
+    }
+
+    #[test]
+    fn test_encode_nullable_uint_none_is_a_lone_stop_byte() {
+        let mut encoder = FastEncoder::new();
+        assert_eq!(encoder.encode_nullable_uint(None), Ok(()));
+        assert_eq!(encoder.finish(), vec![0x80]);
+    }
+
+    #[test]
+    fn test_encode_nullable_uint_some_is_biased_by_one() {
+        let mut encoder = FastEncoder::new();
+        assert_eq!(encoder.encode_nullable_uint(Some(0)), Ok(()));
+        assert_eq!(encoder.finish(), vec![0x81]);
+
+        let mut encoder = FastEncoder::new();
+        assert_eq!(encoder.encode_nullable_uint(Some(126)), Ok(()));
+        assert_eq!(encoder.finish(), vec![0xFF]);
+    }
+
+    #[test]
+    fn test_encode_nullable_uint_max_is_integer_overflow() {
+        let mut encoder = FastEncoder::new();
+        assert_eq!(
+            encoder.encode_nullable_uint(Some(u64::MAX)),
+            Err(FastError::IntegerOverflow),
+            "u64::MAX is outside the 0..=u64::MAX-1 nullable domain"
+        );
+        assert!(
+            encoder.is_empty(),
+            "an overflowing value must not be biased into the NULL representation"
+        );
+    }
+
+    #[test]
+    fn test_encode_nullable_uint_domain_upper_bound_is_representable() {
+        let mut encoder = FastEncoder::new();
+        assert_eq!(encoder.encode_nullable_uint(Some(u64::MAX - 1)), Ok(()));
+        assert_eq!(encoder.len(), MAX_INT_ENCODED_LEN);
     }
 
     #[test]
@@ -270,5 +486,21 @@ mod tests {
 
         encoder.clear();
         assert!(encoder.is_empty());
+    }
+
+    #[test]
+    fn test_encoder_reset_clears_buffer_and_dictionaries() {
+        let mut encoder = FastEncoder::with_capacity(64);
+        encoder.encode_uint(42);
+        encoder.set_global("test", DictionaryValue::UInt(7));
+        assert_eq!(
+            encoder.get_global("test").and_then(DictionaryValue::as_u64),
+            Some(7)
+        );
+
+        encoder.reset();
+        assert!(encoder.is_empty());
+        assert_eq!(encoder.as_bytes(), &[] as &[u8]);
+        assert!(encoder.get_global("test").is_none());
     }
 }

--- a/ironfix-fast/src/error.rs
+++ b/ironfix-fast/src/error.rs
@@ -9,7 +9,12 @@
 use thiserror::Error;
 
 /// Errors that can occur during FAST encoding/decoding.
+///
+/// This enum is `#[non_exhaustive]`: new failure modes are added as the FAST
+/// implementation grows, so downstream `match` expressions must carry a
+/// wildcard arm.
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum FastError {
     /// Unexpected end of input.
     #[error("unexpected end of input")]
@@ -22,6 +27,20 @@ pub enum FastError {
     /// Invalid presence map.
     #[error("invalid presence map")]
     InvalidPresenceMap,
+
+    /// A presence map exceeds the resource ceiling for its encoded size.
+    #[error("presence map exceeds the ceiling of {max_bytes} encoded bytes")]
+    PresenceMapTooLarge {
+        /// Maximum number of encoded bytes a presence map may occupy.
+        max_bytes: usize,
+    },
+
+    /// A presence map bit was requested after every bit had been consumed.
+    ///
+    /// A truncated presence map must not read as "all remaining fields
+    /// absent"; exhaustion is an explicit protocol error.
+    #[error("presence map exhausted")]
+    PresenceMapExhausted,
 
     /// Integer overflow during decoding.
     #[error("integer overflow")]
@@ -66,4 +85,40 @@ pub enum FastError {
         /// Actual length.
         actual: u32,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fast_error_display_is_descriptive() {
+        assert_eq!(
+            FastError::UnexpectedEof.to_string(),
+            "unexpected end of input"
+        );
+        assert_eq!(FastError::IntegerOverflow.to_string(), "integer overflow");
+        assert_eq!(
+            FastError::InvalidString.to_string(),
+            "invalid string encoding"
+        );
+        assert_eq!(
+            FastError::PresenceMapExhausted.to_string(),
+            "presence map exhausted"
+        );
+        assert_eq!(
+            FastError::PresenceMapTooLarge { max_bytes: 64 }.to_string(),
+            "presence map exceeds the ceiling of 64 encoded bytes"
+        );
+    }
+
+    #[test]
+    fn test_fast_error_equality_distinguishes_variants() {
+        assert_eq!(FastError::UnexpectedEof, FastError::UnexpectedEof.clone());
+        assert_ne!(FastError::UnexpectedEof, FastError::IntegerOverflow);
+        assert_ne!(
+            FastError::PresenceMapTooLarge { max_bytes: 64 },
+            FastError::PresenceMapTooLarge { max_bytes: 32 }
+        );
+    }
 }

--- a/ironfix-fast/src/lib.rs
+++ b/ironfix-fast/src/lib.rs
@@ -18,6 +18,22 @@
 //! - **Presence maps**: Track which optional fields are present
 //! - **Field operators**: Copy, Delta, Increment, Tail, etc.
 //! - **Template support**: Message structure definitions
+//!
+//! ## Untrusted input
+//!
+//! Every decoding entry point is an untrusted-input parser. Malformed input
+//! maps to a typed [`FastError`] and never to a panic: integer encodings are
+//! capped at [`MAX_INT_ENCODED_LEN`] bytes and rejected with
+//! [`FastError::IntegerOverflow`] when they would not fit their target type,
+//! presence maps are capped at [`MAX_PMAP_BYTES`] bytes, and a declared byte
+//! length is validated against the bytes actually available before it is ever
+//! used to size an allocation.
+//!
+//! The encoders are the mirror image: they only ever emit encodings the
+//! decoders accept. Values that have no legal FAST representation — a
+//! non-ASCII string, a string that begins with a NUL and continues, or
+//! `Some(u64::MAX)` in a nullable unsigned field — are refused with a typed
+//! error rather than written to the wire in a corrupt form.
 
 pub mod decoder;
 pub mod encoder;
@@ -25,7 +41,7 @@ pub mod error;
 pub mod operators;
 pub mod pmap;
 
-pub use decoder::FastDecoder;
+pub use decoder::{FastDecoder, MAX_INT_ENCODED_LEN};
 pub use encoder::FastEncoder;
 pub use error::FastError;
-pub use pmap::PresenceMap;
+pub use pmap::{MAX_PMAP_BYTES, PresenceMap, PresenceMapBuilder};

--- a/ironfix-fast/src/pmap.rs
+++ b/ironfix-fast/src/pmap.rs
@@ -24,6 +24,11 @@ use smallvec::SmallVec;
 /// Each byte carries [`PAYLOAD_BITS`] field bits, so this ceiling admits
 /// presence maps of up to 448 fields — far beyond any practical FAST template
 /// — while bounding the work and the memory a single hostile map can cost.
+///
+/// The ceiling applies to [`PresenceMap::decode`], the only path fed by the
+/// wire. [`PresenceMap::from_bits`] and [`PresenceMapBuilder`] take bits the
+/// caller already holds and are not bounded by it; an oversized map built that
+/// way is refused by [`PresenceMap::encode`] before it can reach a socket.
 pub const MAX_PMAP_BYTES: usize = 64;
 
 /// Number of presence bits held inline before spilling to the heap.
@@ -111,9 +116,25 @@ impl PresenceMap {
     /// `true` if the corresponding field is present, `false` otherwise.
     ///
     /// # Errors
-    /// Returns [`FastError::PresenceMapExhausted`] if every bit has already
-    /// been consumed. A truncated map must never read as "all remaining fields
-    /// absent".
+    /// Returns [`FastError::PresenceMapExhausted`] once every decoded bit has
+    /// been consumed, rather than answering "absent" forever.
+    ///
+    /// # Granularity
+    ///
+    /// A decoded map always holds a multiple of seven bits, because that is
+    /// what the wire encoding carries: a sender meaning one present bit emits
+    /// a single byte, and this map then offers seven. Those six padding bits
+    /// read as "absent" and are indistinguishable here from real absent
+    /// fields — the primitive layer never sees the template, so it cannot know
+    /// how many bits were meant. Exhaustion therefore only fires at a
+    /// seven-bit boundary.
+    ///
+    /// The mirror of that is over-rejection: a sender that omits trailing
+    /// all-absent bytes (legal in some implementations) produces a map shorter
+    /// than the template's field count, and the reads past its end error here
+    /// rather than yielding "absent". Resolving either direction requires the
+    /// expected field count, which belongs to the template layer — see the
+    /// template-driven decode work tracked in issue #13.
     #[inline]
     pub fn next_bit(&mut self) -> Result<bool, FastError> {
         let bit = *self

--- a/ironfix-fast/src/pmap.rs
+++ b/ironfix-fast/src/pmap.rs
@@ -9,17 +9,39 @@
 //! The presence map (PMAP) is a bitmap that indicates which optional fields
 //! are present in a FAST message. It uses stop-bit encoding where the high
 //! bit of each byte indicates whether more bytes follow.
+//!
+//! Two hardening rules apply, because a presence map is attacker-controlled
+//! input: its encoded size is capped by [`MAX_PMAP_BYTES`], and running off
+//! the end of the map is an explicit [`FastError::PresenceMapExhausted`]
+//! rather than a fabricated "field absent" answer.
 
+use crate::decoder::{PAYLOAD_BITS, STOP_BIT, read_byte};
 use crate::error::FastError;
+use smallvec::SmallVec;
+
+/// Maximum number of encoded bytes a presence map may occupy.
+///
+/// Each byte carries [`PAYLOAD_BITS`] field bits, so this ceiling admits
+/// presence maps of up to 448 fields — far beyond any practical FAST template
+/// — while bounding the work and the memory a single hostile map can cost.
+pub const MAX_PMAP_BYTES: usize = 64;
+
+/// Number of presence bits held inline before spilling to the heap.
+///
+/// Eight encoded bytes, which covers every realistic template.
+const INLINE_PMAP_BITS: usize = 56;
+
+/// Storage for the decoded presence bits.
+type PmapBits = SmallVec<[bool; INLINE_PMAP_BITS]>;
 
 /// FAST presence map.
 ///
 /// The presence map tracks which optional fields are present in a message.
 /// Bits are consumed in order as fields are decoded.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PresenceMap {
     /// The raw bits of the presence map.
-    bits: Vec<bool>,
+    bits: PmapBits,
     /// Current bit position.
     position: usize,
 }
@@ -29,7 +51,7 @@ impl PresenceMap {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            bits: Vec::new(),
+            bits: PmapBits::new(),
             position: 0,
         }
     }
@@ -37,7 +59,10 @@ impl PresenceMap {
     /// Creates a presence map from raw bits.
     #[must_use]
     pub fn from_bits(bits: Vec<bool>) -> Self {
-        Self { bits, position: 0 }
+        Self {
+            bits: PmapBits::from_vec(bits),
+            position: 0,
+        }
     }
 
     /// Decodes a presence map from a byte slice.
@@ -50,25 +75,29 @@ impl PresenceMap {
     /// The decoded presence map.
     ///
     /// # Errors
-    /// Returns `FastError::UnexpectedEof` if the data is incomplete.
+    /// Returns [`FastError::UnexpectedEof`] if the stop bit is never reached
+    /// before the end of `data`, or [`FastError::PresenceMapTooLarge`] if the
+    /// map would exceed [`MAX_PMAP_BYTES`] encoded bytes.
     pub fn decode(data: &[u8], offset: &mut usize) -> Result<Self, FastError> {
-        let mut bits = Vec::new();
+        let mut bits = PmapBits::new();
+        let mut consumed: usize = 0;
 
         loop {
-            if *offset >= data.len() {
-                return Err(FastError::UnexpectedEof);
+            if consumed == MAX_PMAP_BYTES {
+                return Err(FastError::PresenceMapTooLarge {
+                    max_bytes: MAX_PMAP_BYTES,
+                });
             }
 
-            let byte = data[*offset];
-            *offset += 1;
+            let byte = read_byte(data, offset)?;
+            consumed += 1;
 
-            // Extract 7 bits (excluding stop bit)
-            for i in (0..7).rev() {
-                bits.push((byte >> i) & 1 == 1);
+            // Extract the seven payload bits, most significant first.
+            for shift in (0..PAYLOAD_BITS).rev() {
+                bits.push((byte >> shift) & 1 == 1);
             }
 
-            // Check stop bit (high bit)
-            if byte & 0x80 != 0 {
+            if byte & STOP_BIT != 0 {
                 break;
             }
         }
@@ -76,29 +105,38 @@ impl PresenceMap {
         Ok(Self { bits, position: 0 })
     }
 
-    /// Returns the next bit from the presence map.
+    /// Consumes and returns the next bit from the presence map.
     ///
     /// # Returns
-    /// `true` if the field is present, `false` otherwise.
-    /// Returns `false` if the map is exhausted.
+    /// `true` if the corresponding field is present, `false` otherwise.
+    ///
+    /// # Errors
+    /// Returns [`FastError::PresenceMapExhausted`] if every bit has already
+    /// been consumed. A truncated map must never read as "all remaining fields
+    /// absent".
     #[inline]
-    pub fn next_bit(&mut self) -> bool {
-        if self.position < self.bits.len() {
-            let bit = self.bits[self.position];
-            self.position += 1;
-            bit
-        } else {
-            false
-        }
+    pub fn next_bit(&mut self) -> Result<bool, FastError> {
+        let bit = *self
+            .bits
+            .get(self.position)
+            .ok_or(FastError::PresenceMapExhausted)?;
+
+        // `get` succeeded, so `position < bits.len()`; the increment cannot
+        // overflow and keeps the `position <= bits.len()` invariant.
+        self.position += 1;
+
+        Ok(bit)
     }
 
     /// Returns the bit at the specified position without consuming it.
     ///
     /// # Arguments
     /// * `index` - The bit position (0-indexed)
-    #[must_use]
-    pub fn bit(&self, index: usize) -> bool {
-        self.bits.get(index).copied().unwrap_or(false)
+    ///
+    /// # Returns
+    /// `None` if `index` is past the end of the map.
+    pub fn bit(&self, index: usize) -> Option<bool> {
+        self.bits.get(index).copied()
     }
 
     /// Returns the number of bits in the presence map.
@@ -113,9 +151,15 @@ impl PresenceMap {
         self.bits.is_empty()
     }
 
+    /// Returns true if every bit has been consumed.
+    #[must_use]
+    pub fn is_exhausted(&self) -> bool {
+        self.position >= self.bits.len()
+    }
+
     /// Returns the current position in the presence map.
     #[must_use]
-    pub fn position(&self) -> usize {
+    pub const fn position(&self) -> usize {
         self.position
     }
 
@@ -128,35 +172,44 @@ impl PresenceMap {
     ///
     /// # Returns
     /// The encoded bytes with stop-bit encoding.
-    #[must_use]
-    pub fn encode(&self) -> Vec<u8> {
+    ///
+    /// # Errors
+    /// Returns [`FastError::PresenceMapTooLarge`] if the map holds more bits
+    /// than [`MAX_PMAP_BYTES`] can carry — the encoder must never emit a map
+    /// its own decoder would reject.
+    pub fn encode(&self) -> Result<Vec<u8>, FastError> {
         if self.bits.is_empty() {
-            return vec![0x80]; // Empty pmap with stop bit
+            return Ok(vec![STOP_BIT]); // Empty pmap with stop bit
         }
 
-        let mut result = Vec::new();
-        let mut bit_index = 0;
+        let byte_len = self.bits.len().div_ceil(PAYLOAD_BITS);
+        if byte_len > MAX_PMAP_BYTES {
+            return Err(FastError::PresenceMapTooLarge {
+                max_bytes: MAX_PMAP_BYTES,
+            });
+        }
 
-        while bit_index < self.bits.len() {
+        let mut result = Vec::with_capacity(byte_len);
+
+        for chunk in self.bits.chunks(PAYLOAD_BITS) {
             let mut byte: u8 = 0;
 
-            // Pack 7 bits into each byte
-            for i in (0..7).rev() {
-                if bit_index < self.bits.len() && self.bits[bit_index] {
-                    byte |= 1 << i;
+            for (index, &present) in chunk.iter().enumerate() {
+                if present {
+                    // `index < PAYLOAD_BITS`, so the shift stays in range.
+                    byte |= 1 << (PAYLOAD_BITS - 1 - index);
                 }
-                bit_index += 1;
-            }
-
-            // Set stop bit if this is the last byte
-            if bit_index >= self.bits.len() {
-                byte |= 0x80;
             }
 
             result.push(byte);
         }
 
-        result
+        // Set the stop bit on the last byte.
+        if let Some(last) = result.last_mut() {
+            *last |= STOP_BIT;
+        }
+
+        Ok(result)
     }
 }
 
@@ -203,42 +256,173 @@ mod tests {
         // Extracted bits (from bit 6 to bit 0): 1, 0, 0, 0, 0, 0, 0
         let data = [0b1100_0000];
         let mut offset = 0;
-        let pmap = PresenceMap::decode(&data, &mut offset).unwrap();
+        let decoded = PresenceMap::decode(&data, &mut offset);
+        assert!(decoded.is_ok());
 
-        assert_eq!(offset, 1);
-        assert_eq!(pmap.len(), 7);
-        assert!(pmap.bit(0)); // bit 6 of byte = 1
-        assert!(!pmap.bit(1)); // bit 5 of byte = 0
-        assert!(!pmap.bit(2)); // bit 4 of byte = 0
+        if let Ok(pmap) = decoded {
+            assert_eq!(offset, 1);
+            assert_eq!(pmap.len(), 7);
+            assert_eq!(pmap.bit(0), Some(true)); // bit 6 of byte = 1
+            assert_eq!(pmap.bit(1), Some(false)); // bit 5 of byte = 0
+            assert_eq!(pmap.bit(2), Some(false)); // bit 4 of byte = 0
+            assert_eq!(pmap.bit(7), None); // past the end
+        }
     }
 
     #[test]
     fn test_presence_map_decode_multi_byte() {
         let data = [0b0100_0000, 0b1000_0000]; // Two bytes
         let mut offset = 0;
-        let pmap = PresenceMap::decode(&data, &mut offset).unwrap();
+        let decoded = PresenceMap::decode(&data, &mut offset);
+        assert!(decoded.is_ok());
 
-        assert_eq!(offset, 2);
-        assert_eq!(pmap.len(), 14);
+        if let Ok(pmap) = decoded {
+            assert_eq!(offset, 2);
+            assert_eq!(pmap.len(), 14);
+        }
+    }
+
+    #[test]
+    fn test_presence_map_decode_without_stop_bit_is_unexpected_eof() {
+        let data = [0b0100_0000, 0b0000_0001];
+        let mut offset = 0;
+        assert_eq!(
+            PresenceMap::decode(&data, &mut offset),
+            Err(FastError::UnexpectedEof)
+        );
+    }
+
+    #[test]
+    fn test_presence_map_decode_empty_input_is_unexpected_eof() {
+        let data: [u8; 0] = [];
+        let mut offset = 0;
+        assert_eq!(
+            PresenceMap::decode(&data, &mut offset),
+            Err(FastError::UnexpectedEof)
+        );
+    }
+
+    #[test]
+    fn test_presence_map_decode_at_the_ceiling_is_accepted() {
+        let mut data = vec![0x00; MAX_PMAP_BYTES - 1];
+        data.push(STOP_BIT);
+
+        let mut offset = 0;
+        let decoded = PresenceMap::decode(&data, &mut offset);
+        assert!(decoded.is_ok());
+
+        if let Ok(pmap) = decoded {
+            assert_eq!(pmap.len(), MAX_PMAP_BYTES * PAYLOAD_BITS);
+            assert_eq!(offset, MAX_PMAP_BYTES);
+        }
+    }
+
+    #[test]
+    fn test_presence_map_decode_over_the_ceiling_is_too_large() {
+        // A stop bit that never arrives, with more than enough input to run
+        // past the ceiling.
+        let data = vec![0x00; MAX_PMAP_BYTES * 4];
+        let mut offset = 0;
+        assert_eq!(
+            PresenceMap::decode(&data, &mut offset),
+            Err(FastError::PresenceMapTooLarge {
+                max_bytes: MAX_PMAP_BYTES
+            })
+        );
     }
 
     #[test]
     fn test_presence_map_next_bit() {
         let mut pmap = PresenceMap::from_bits(vec![true, false, true]);
 
-        assert!(pmap.next_bit());
-        assert!(!pmap.next_bit());
-        assert!(pmap.next_bit());
-        assert!(!pmap.next_bit()); // Exhausted
+        assert_eq!(pmap.next_bit(), Ok(true));
+        assert_eq!(pmap.next_bit(), Ok(false));
+        assert_eq!(pmap.next_bit(), Ok(true));
+    }
+
+    #[test]
+    fn test_presence_map_next_bit_past_the_end_is_exhausted() {
+        let mut pmap = PresenceMap::from_bits(vec![true]);
+
+        assert!(!pmap.is_exhausted());
+        assert_eq!(pmap.next_bit(), Ok(true));
+        assert!(pmap.is_exhausted());
+        assert_eq!(pmap.next_bit(), Err(FastError::PresenceMapExhausted));
+        assert_eq!(pmap.position(), 1, "a failed read must not advance");
+    }
+
+    #[test]
+    fn test_presence_map_empty_map_is_exhausted_immediately() {
+        let mut pmap = PresenceMap::new();
+
+        assert!(pmap.is_empty());
+        assert!(pmap.is_exhausted());
+        assert_eq!(pmap.next_bit(), Err(FastError::PresenceMapExhausted));
+    }
+
+    #[test]
+    fn test_presence_map_reset_rewinds_the_position() {
+        let mut pmap = PresenceMap::from_bits(vec![true, false]);
+
+        assert_eq!(pmap.next_bit(), Ok(true));
+        assert_eq!(pmap.next_bit(), Ok(false));
+        assert!(pmap.is_exhausted());
+
+        pmap.reset();
+        assert_eq!(pmap.position(), 0);
+        assert_eq!(pmap.next_bit(), Ok(true));
     }
 
     #[test]
     fn test_presence_map_encode() {
         let pmap = PresenceMap::from_bits(vec![true, true, false, false, false, false, false]);
-        let encoded = pmap.encode();
+        assert_eq!(pmap.encode(), Ok(vec![0b1110_0000]));
+    }
 
-        assert_eq!(encoded.len(), 1);
-        assert_eq!(encoded[0], 0b1110_0000);
+    #[test]
+    fn test_presence_map_encode_empty_is_a_lone_stop_byte() {
+        let pmap = PresenceMap::new();
+        assert_eq!(pmap.encode(), Ok(vec![STOP_BIT]));
+    }
+
+    #[test]
+    fn test_presence_map_encode_decode_round_trip() {
+        let bits = vec![
+            true, false, true, true, false, false, true, false, true, false,
+        ];
+        let pmap = PresenceMap::from_bits(bits.clone());
+
+        let encoded = pmap.encode();
+        assert!(encoded.is_ok());
+
+        if let Ok(encoded) = encoded {
+            let mut offset = 0;
+            let decoded = PresenceMap::decode(&encoded, &mut offset);
+            assert!(decoded.is_ok());
+
+            if let Ok(decoded) = decoded {
+                assert_eq!(offset, encoded.len());
+                // The wire form is padded to whole bytes, so the decoded map is
+                // at least as long as the original and agrees on every bit.
+                assert!(decoded.len() >= bits.len());
+                for (index, &expected) in bits.iter().enumerate() {
+                    assert_eq!(decoded.bit(index), Some(expected), "bit {index}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_presence_map_encode_over_the_ceiling_is_too_large() {
+        let bits = vec![true; MAX_PMAP_BYTES * PAYLOAD_BITS + 1];
+        let pmap = PresenceMap::from_bits(bits);
+
+        assert_eq!(
+            pmap.encode(),
+            Err(FastError::PresenceMapTooLarge {
+                max_bytes: MAX_PMAP_BYTES
+            })
+        );
     }
 
     #[test]
@@ -250,8 +434,8 @@ mod tests {
             .build();
 
         assert_eq!(pmap.len(), 3);
-        assert!(pmap.bit(0));
-        assert!(!pmap.bit(1));
-        assert!(pmap.bit(2));
+        assert_eq!(pmap.bit(0), Some(true));
+        assert_eq!(pmap.bit(1), Some(false));
+        assert_eq!(pmap.bit(2), Some(true));
     }
 }


### PR DESCRIPTION
## Summary

Fixes the six defects in the FAST primitive codec. Two are wire-level corruption reachable from any counterparty.

Closes #6.

## Stack

- **Base branch:** `stack/3-9-engine-conformance` (PR #25)
- **Stack:** #25 → **#6 (this PR)** → the remaining open issues
- Review against the base branch; merge bottom-up.

## What was wrong

**1. The signed encoder never emitted the sign-carry byte.** The unconditional loop-exit fired before the sign-conflict check, so every value whose most significant payload byte conflicted with the sign round-tripped to a **different number**: `64 → -64`, `100 → -28`, `127 → -1`, `8192 → -8192`, `-65 → +63`, `i64::MAX → -1`, `i64::MIN → 0`. Only `-64..64` survived. For a price or quantity that is silent corruption on the wire.

Verified fixed against the exact values above plus a sweep of 633 boundary values (every 7-bit boundary ±2, both signs, through `i64::MIN`/`MAX`) — zero failures. The encoder now shares its width constants with the decoder so the two cannot drift.

**2. `decode_bytes` panicked on an attacker-controlled length.** `offset + length > data.len()` overflowed for a `u64::MAX` length prefix: release wrapped, the bounds check passed, and the slice index panicked — under `panic = "abort"` that is a remote process kill. It now computes remaining space with checked arithmetic, narrows the declared length in the direction that cannot truncate, and validates before slicing. No allocation is sized from the declared length.

**3. `decode_int` wrapped silently** on an over-long continuation run instead of reporting overflow, while a legitimate ten-byte `i64::MIN` / `u64::MAX` still decodes — over-rejection would refuse valid market data.

**4. FAST 1.1 string forms were wrong.** The empty string now encodes as a lone stop byte, a NUL string round-trips, other overlong leading-zero forms are rejected, and `encode_ascii` returns a typed error instead of silently masking non-ASCII bytes.

**5. Nullable integer encoding overflowed** on the value at the top of its bias; it is now fallible with a documented domain.

**6. Presence maps were unbounded and lied when exhausted.** No ceiling on encoded size, and an exhausted map answered "field absent" — so a truncated map read as a message whose remaining fields were all missing. The size is now capped (64 bytes ≈ 448 fields) and exhaustion is an explicit error.

## Public API changes (semver)

Workspace is already at 0.4.0. `FastError` gains `#[non_exhaustive]` and new variants; `encode_ascii` and `encode_nullable_uint` become fallible. `ironfix-fast` has no in-workspace consumer except `ironfix-example`, whose two FAST servers are updated for the fallible calls.

## Tests

Workspace goes to **301 passing**, in **both debug and release** — the distinction matters here, since two of these defects only manifest under one profile or the other.

## Verification

```
cargo test --workspace            # 301 passed
cargo test --workspace --release  # 301 passed
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --all --check
cargo build --release --examples
make doc
```
