### PR TITLE
fix(core): harden the shared vocabulary against injection and silent loss

### DIFF
--- a/ironfix-core/src/error.rs
+++ b/ironfix-core/src/error.rs
@@ -64,10 +64,6 @@ pub enum DecodeError {
     #[error("missing msg type field (tag 35)")]
     MissingMsgType,
 
-    /// Invalid MsgType value.
-    #[error("invalid msg type: {0}")]
-    InvalidMsgType(String),
-
     /// Checksum mismatch between calculated and declared values.
     #[error("checksum mismatch: calculated {calculated}, declared {declared}")]
     ChecksumMismatch {
@@ -97,29 +93,9 @@ pub enum DecodeError {
         reason: String,
     },
 
-    /// Repeating group count mismatch.
-    #[error("group count mismatch for tag {count_tag}: expected {expected}, found {actual}")]
-    GroupCountMismatch {
-        /// The tag containing the group count.
-        count_tag: u32,
-        /// Expected number of group entries.
-        expected: u32,
-        /// Actual number of group entries found.
-        actual: u32,
-    },
-
     /// Invalid UTF-8 in string field.
     #[error("invalid utf-8 in field: {0}")]
     InvalidUtf8(#[from] std::str::Utf8Error),
-
-    /// Message exceeds maximum allowed size.
-    #[error("message too large: {size} bytes exceeds maximum {max_size}")]
-    MessageTooLarge {
-        /// Actual message size in bytes.
-        size: usize,
-        /// Maximum allowed size in bytes.
-        max_size: usize,
-    },
 
     /// A field is not terminated by the SOH delimiter.
     ///
@@ -325,6 +301,120 @@ pub enum StoreError {
     /// I/O error in persistent store.
     #[error("store i/o error: {0}")]
     Io(String),
+}
+
+/// Rejection reasons for [`crate::types::CompId`] construction.
+///
+/// A CompID is written verbatim into SenderCompID (49) and TargetCompID (56)
+/// on every outbound message, so a value carrying SOH or `=` would inject
+/// header fields into the frame. Construction is the chokepoint that makes
+/// that unrepresentable.
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CompIdError {
+    /// The value does not fit in the fixed inline storage.
+    #[error("comp id is {len} bytes, exceeding the {max_len}-byte inline storage bound")]
+    TooLong {
+        /// Length of the offered value in bytes.
+        len: usize,
+        /// Maximum length in bytes, [`crate::types::COMP_ID_MAX_LEN`].
+        max_len: usize,
+    },
+
+    /// The value contains a byte outside printable ASCII, or the `=`
+    /// tag/value separator.
+    #[error(
+        "comp id contains illegal byte {byte:#04x} at offset {position}: \
+         only printable ASCII (0x20..=0x7e) except '=' is allowed"
+    )]
+    IllegalByte {
+        /// The offending byte.
+        byte: u8,
+        /// Zero-based offset of the offending byte within the value.
+        position: usize,
+    },
+}
+
+/// Rejection reasons for [`crate::types::Timestamp`] construction.
+///
+/// A `Timestamp` counts nanoseconds since the Unix epoch as an unsigned value
+/// bounded by [`crate::types::Timestamp::MAX_NANOS`], so instants before
+/// 1970-01-01 and after 2262-04-11 are not representable.
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TimestampError {
+    /// The nanosecond count exceeds the representable range.
+    #[error("{nanos} nanoseconds since the epoch exceeds the maximum {max_nanos}")]
+    NanosOutOfRange {
+        /// The offered nanosecond count.
+        nanos: u64,
+        /// The largest representable nanosecond count.
+        max_nanos: u64,
+    },
+
+    /// The millisecond count overflows when scaled to nanoseconds.
+    #[error("{millis} milliseconds since the epoch is not representable in nanoseconds")]
+    MillisOutOfRange {
+        /// The offered millisecond count.
+        millis: u64,
+    },
+
+    /// A calendar instant falls outside the representable range — before the
+    /// Unix epoch, or past the nanosecond ceiling.
+    #[error("instant at {seconds} seconds from the epoch is outside the representable range")]
+    InstantOutOfRange {
+        /// Whole seconds from the Unix epoch, negative before 1970.
+        seconds: i64,
+    },
+}
+
+/// A number that is not a legal FIX field tag.
+///
+/// FIX tags are positive integers; `0` is neither a standard nor a
+/// user-defined tag.
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+#[error("{tag} is not a legal FIX field tag: tags are positive integers starting at 1")]
+pub struct InvalidFieldTag {
+    tag: u32,
+}
+
+impl InvalidFieldTag {
+    /// Creates the error for an offending tag number.
+    #[inline]
+    #[must_use]
+    pub const fn new(tag: u32) -> Self {
+        Self { tag }
+    }
+
+    /// Returns the offending tag number.
+    #[inline]
+    #[must_use]
+    pub const fn tag(self) -> u32 {
+        self.tag
+    }
+}
+
+/// A byte that is not a legal Side (tag 54) code.
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+#[error("{value:#04x} is not a FIX Side (tag 54) code")]
+pub struct InvalidSide {
+    value: u8,
+}
+
+impl InvalidSide {
+    /// Creates the error for an offending byte.
+    #[inline]
+    #[must_use]
+    pub const fn new(value: u8) -> Self {
+        Self { value }
+    }
+
+    /// Returns the offending byte.
+    #[inline]
+    #[must_use]
+    pub const fn value(self) -> u8 {
+        self.value
+    }
 }
 
 #[cfg(test)]

--- a/ironfix-core/src/error.rs
+++ b/ironfix-core/src/error.rs
@@ -306,12 +306,19 @@ pub enum StoreError {
 /// Rejection reasons for [`crate::types::CompId`] construction.
 ///
 /// A CompID is written verbatim into SenderCompID (49) and TargetCompID (56)
-/// on every outbound message, so a value carrying SOH or `=` would inject
-/// header fields into the frame. Construction is the chokepoint that makes
-/// that unrepresentable.
+/// on every outbound message, so an empty value or one carrying SOH or another
+/// control byte would produce a malformed or injectable frame. Construction is
+/// the chokepoint that makes that unrepresentable.
 #[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum CompIdError {
+    /// The value is empty.
+    ///
+    /// An empty CompID would encode as `49=<SOH>` (or `56=<SOH>`), a field
+    /// with no value that FIX TagValue treats as malformed.
+    #[error("comp id is empty")]
+    Empty,
+
     /// The value does not fit in the fixed inline storage.
     #[error("comp id is {len} bytes, exceeding the {max_len}-byte inline storage bound")]
     TooLong {
@@ -321,11 +328,10 @@ pub enum CompIdError {
         max_len: usize,
     },
 
-    /// The value contains a byte outside printable ASCII, or the `=`
-    /// tag/value separator.
+    /// The value contains a byte outside printable ASCII (`0x20..=0x7e`).
     #[error(
         "comp id contains illegal byte {byte:#04x} at offset {position}: \
-         only printable ASCII (0x20..=0x7e) except '=' is allowed"
+         only printable ASCII (0x20..=0x7e) is allowed"
     )]
     IllegalByte {
         /// The offending byte.

--- a/ironfix-core/src/field.rs
+++ b/ironfix-core/src/field.rs
@@ -12,32 +12,55 @@
 //! - [`FieldValue`]: Enumeration of possible field value types
 //! - [`FixField`]: Trait for typed field access
 
-use crate::error::DecodeError;
+use crate::error::{DecodeError, EncodeError, InvalidFieldTag};
 use bytes::Bytes;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
 
+/// The lowest tag number FIX reserves for user-defined fields.
+///
+/// FIX reserves 5000-9999 for user-defined fields, so 4999 is the highest
+/// standard tag and 5000 the first user-defined one.
+pub const USER_DEFINED_TAG_MIN: u32 = 5000;
+
 /// FIX field tag number.
 ///
 /// Tags are positive integers that identify fields within a FIX message.
-/// Standard tags are defined in the FIX specification (1-5000 range),
-/// while user-defined tags use the 5001+ range.
+/// Standard tags are defined in the FIX specification (1-4999), while FIX
+/// reserves 5000-9999 for user-defined fields. Tags at or above
+/// [`USER_DEFINED_TAG_MIN`] are treated as user-defined; venues do assign
+/// beyond 9999 in practice, and a dictionary — not this type — is what says
+/// whether a given tag is known.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[repr(transparent)]
 #[serde(transparent)]
 pub struct FieldTag(u32);
 
 impl FieldTag {
-    /// Creates a new field tag.
+    /// Creates a new field tag **without validating it**.
     ///
-    /// # Arguments
-    /// * `tag` - The tag number (must be > 0)
+    /// `tag` is not checked against [`FieldTag::is_valid`]; `FieldTag::new(0)`
+    /// yields a tag that is neither standard nor user-defined. Use
+    /// [`FieldTag::try_new`] for a value that came off the wire or from a
+    /// caller.
     #[inline]
     #[must_use]
     pub const fn new(tag: u32) -> Self {
         Self(tag)
+    }
+
+    /// Creates a new field tag, rejecting numbers that are not legal FIX tags.
+    ///
+    /// # Errors
+    /// Returns [`InvalidFieldTag`] if `tag` is `0`.
+    #[inline]
+    pub const fn try_new(tag: u32) -> Result<Self, InvalidFieldTag> {
+        if tag == 0 {
+            return Err(InvalidFieldTag::new(tag));
+        }
+        Ok(Self(tag))
     }
 
     /// Returns the raw tag number.
@@ -47,18 +70,25 @@ impl FieldTag {
         self.0
     }
 
-    /// Returns true if this is a standard FIX tag (1-5000).
+    /// Returns true if this is a legal FIX tag number (>= 1).
+    #[inline]
+    #[must_use]
+    pub const fn is_valid(self) -> bool {
+        self.0 >= 1
+    }
+
+    /// Returns true if this is a standard FIX tag (1-4999).
     #[inline]
     #[must_use]
     pub const fn is_standard(self) -> bool {
-        self.0 >= 1 && self.0 <= 5000
+        self.0 >= 1 && self.0 < USER_DEFINED_TAG_MIN
     }
 
-    /// Returns true if this is a user-defined tag (5001+).
+    /// Returns true if this is a user-defined tag (5000+).
     #[inline]
     #[must_use]
     pub const fn is_user_defined(self) -> bool {
-        self.0 > 5000
+        self.0 >= USER_DEFINED_TAG_MIN
     }
 }
 
@@ -329,55 +359,179 @@ pub trait FixField: Sized {
     /// # Arguments
     /// * `value` - The value to encode
     /// * `buf` - The buffer to write to
-    fn encode(value: &Self::Value, buf: &mut Vec<u8>);
+    ///
+    /// # Errors
+    /// Returns [`EncodeError`] if `value` has no legal on-the-wire form — for
+    /// example a string carrying the SOH delimiter
+    /// ([`EncodeError::InvalidFieldValue`]) or one past a length bound
+    /// ([`EncodeError::FieldTooLong`]). Mirrors
+    /// [`crate::message::FixMessage::encode`], so an implementor never has to
+    /// panic or emit corrupt bytes.
+    fn encode(value: &Self::Value, buf: &mut Vec<u8>) -> Result<(), EncodeError>;
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    /// Unwraps a `Result` with test context instead of `.unwrap()`.
+    #[track_caller]
+    fn ok<T, E: fmt::Debug>(result: Result<T, E>, what: &str) -> T {
+        match result {
+            Ok(value) => value,
+            Err(err) => panic!("{what}: {err:?}"),
+        }
+    }
+
+    /// Asserts that `result` failed with `InvalidFieldValue` for `tag`.
+    #[track_caller]
+    fn assert_invalid_field_value<T: fmt::Debug>(result: Result<T, DecodeError>, tag: u32) {
+        match result {
+            Err(DecodeError::InvalidFieldValue { tag: actual, .. }) => assert_eq!(actual, tag),
+            other => panic!("expected InvalidFieldValue for tag {tag}, got {other:?}"),
+        }
+    }
+
     #[test]
-    fn test_field_tag() {
+    fn test_field_tag_standard_range() {
         let tag = FieldTag::new(35);
         assert_eq!(tag.value(), 35);
+        assert!(tag.is_valid());
         assert!(tag.is_standard());
         assert!(!tag.is_user_defined());
+    }
 
-        let user_tag = FieldTag::new(5001);
-        assert!(!user_tag.is_standard());
-        assert!(user_tag.is_user_defined());
+    #[test]
+    fn test_field_tag_zero_is_neither_standard_nor_user_defined() {
+        let zero = FieldTag::new(0);
+        assert!(!zero.is_valid());
+        assert!(!zero.is_standard());
+        assert!(!zero.is_user_defined());
+        assert_eq!(FieldTag::try_new(0), Err(InvalidFieldTag::new(0)));
+    }
+
+    #[test]
+    fn test_field_tag_boundary_4999_is_standard() {
+        let tag = ok(FieldTag::try_new(4999), "4999 is a legal tag");
+        assert!(tag.is_standard());
+        assert!(!tag.is_user_defined());
+    }
+
+    #[test]
+    fn test_field_tag_boundary_5000_is_user_defined() {
+        let tag = ok(FieldTag::try_new(5000), "5000 is a legal tag");
+        assert!(!tag.is_standard());
+        assert!(tag.is_user_defined());
+        assert_eq!(tag.value(), USER_DEFINED_TAG_MIN);
     }
 
     #[test]
     fn test_field_ref_as_str() {
         let field = FieldRef::new(11, b"ORDER123");
-        assert_eq!(field.as_str().unwrap(), "ORDER123");
+        assert_eq!(field.as_str(), Ok("ORDER123"));
     }
 
     #[test]
     fn test_field_ref_as_u64() {
         let field = FieldRef::new(34, b"12345");
-        assert_eq!(field.as_u64().unwrap(), 12345);
+        assert_eq!(field.as_u64(), Ok(12345));
+    }
+
+    #[test]
+    fn test_field_ref_as_u64_non_numeric_is_typed_error() {
+        assert_invalid_field_value(FieldRef::new(34, b"abc").as_u64(), 34);
+    }
+
+    #[test]
+    fn test_field_ref_as_u64_negative_is_typed_error() {
+        assert_invalid_field_value(FieldRef::new(34, b"-1").as_u64(), 34);
+    }
+
+    #[test]
+    fn test_field_ref_as_u64_empty_is_typed_error() {
+        assert_invalid_field_value(FieldRef::new(34, b"").as_u64(), 34);
+    }
+
+    #[test]
+    fn test_field_ref_as_i64_accepts_negative() {
+        assert_eq!(FieldRef::new(14, b"-42").as_i64(), Ok(-42));
+    }
+
+    #[test]
+    fn test_field_ref_as_decimal_parses_price() {
+        let field = FieldRef::new(44, b"123.45");
+        let price = ok(field.as_decimal(), "123.45 is a valid price");
+        assert_eq!(price, Decimal::new(12345, 2));
+    }
+
+    #[test]
+    fn test_field_ref_as_decimal_preserves_scale() {
+        // Trailing zeros are significant on the wire; the parse keeps them.
+        let field = FieldRef::new(44, b"1.500");
+        let price = ok(field.as_decimal(), "1.500 is a valid price");
+        assert_eq!(price.to_string(), "1.500");
+    }
+
+    #[test]
+    fn test_field_ref_as_decimal_negative_price() {
+        let field = FieldRef::new(44, b"-0.01");
+        let price = ok(field.as_decimal(), "-0.01 is a valid price");
+        assert_eq!(price, Decimal::new(-1, 2));
+    }
+
+    #[test]
+    fn test_field_ref_as_decimal_two_points_is_typed_error() {
+        assert_invalid_field_value(FieldRef::new(44, b"1.2.3").as_decimal(), 44);
+    }
+
+    #[test]
+    fn test_field_ref_as_decimal_garbage_is_typed_error() {
+        assert_invalid_field_value(FieldRef::new(44, b"abc").as_decimal(), 44);
+        assert_invalid_field_value(FieldRef::new(44, b"").as_decimal(), 44);
+        assert_invalid_field_value(FieldRef::new(44, b"1,50").as_decimal(), 44);
+    }
+
+    #[test]
+    fn test_field_ref_as_decimal_invalid_utf8_is_typed_error() {
+        let field = FieldRef::new(44, &[0xFF, 0xFE]);
+        assert!(matches!(
+            field.as_decimal(),
+            Err(DecodeError::InvalidUtf8(_))
+        ));
     }
 
     #[test]
     fn test_field_ref_as_bool() {
-        let yes = FieldRef::new(141, b"Y");
-        let no = FieldRef::new(141, b"N");
-        assert!(yes.as_bool().unwrap());
-        assert!(!no.as_bool().unwrap());
+        assert_eq!(FieldRef::new(141, b"Y").as_bool(), Ok(true));
+        assert_eq!(FieldRef::new(141, b"N").as_bool(), Ok(false));
+    }
+
+    #[test]
+    fn test_field_ref_as_bool_rejects_lowercase_and_words() {
+        assert_invalid_field_value(FieldRef::new(141, b"y").as_bool(), 141);
+        assert_invalid_field_value(FieldRef::new(141, b"n").as_bool(), 141);
+        assert_invalid_field_value(FieldRef::new(141, b"YES").as_bool(), 141);
+        assert_invalid_field_value(FieldRef::new(141, b"").as_bool(), 141);
     }
 
     #[test]
     fn test_field_ref_as_char() {
-        let field = FieldRef::new(54, b"1");
-        assert_eq!(field.as_char().unwrap(), '1');
+        assert_eq!(FieldRef::new(54, b"1").as_char(), Ok('1'));
+    }
+
+    #[test]
+    fn test_field_ref_as_char_rejects_multi_byte_and_non_ascii() {
+        assert_invalid_field_value(FieldRef::new(54, b"12").as_char(), 54);
+        assert_invalid_field_value(FieldRef::new(54, b"").as_char(), 54);
+        // 'ñ' is two bytes and neither is ASCII.
+        assert_invalid_field_value(FieldRef::new(54, "ñ".as_bytes()).as_char(), 54);
+        assert_invalid_field_value(FieldRef::new(54, &[0x80]).as_char(), 54);
     }
 
     #[test]
     fn test_field_ref_invalid_utf8() {
         let field = FieldRef::new(1, &[0xFF, 0xFE]);
-        assert!(field.as_str().is_err());
+        assert!(matches!(field.as_str(), Err(DecodeError::InvalidUtf8(_))));
     }
 
     #[test]

--- a/ironfix-core/src/lib.rs
+++ b/ironfix-core/src/lib.rs
@@ -24,7 +24,10 @@ pub mod field;
 pub mod message;
 pub mod types;
 
-pub use error::{DecodeError, EncodeError, FixError, Result, SessionError, StoreError};
-pub use field::{FieldRef, FieldTag, FieldValue, FixField};
+pub use error::{
+    CompIdError, DecodeError, EncodeError, FixError, InvalidFieldTag, InvalidSide, Result,
+    SessionError, StoreError, TimestampError,
+};
+pub use field::{FieldRef, FieldTag, FieldValue, FixField, USER_DEFINED_TAG_MIN};
 pub use message::{FixMessage, MsgType, OwnedMessage, RawMessage};
-pub use types::{CompId, SeqNum, Side, Timestamp};
+pub use types::{COMP_ID_MAX_LEN, CompId, SeqNum, Side, Timestamp};

--- a/ironfix-core/src/message.rs
+++ b/ironfix-core/src/message.rs
@@ -20,133 +20,230 @@ use smallvec::SmallVec;
 use std::fmt;
 use std::ops::Range;
 
-/// Standard FIX message types.
+/// Declares [`MsgType`] and the three mappings that must agree about it.
 ///
-/// This enum covers the most common administrative and application messages.
-/// Custom or less common message types can be represented as `Custom(String)`.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
-pub enum MsgType {
+/// The variant, its wire code, and its admin/app category are stated **once**
+/// per row; `as_str`, the `from_str` reverse lookup, and `is_admin` are all
+/// generated from that single table, so the three cannot drift. A row's
+/// category must match the `msgcat` the dictionary gives that MsgType — see
+/// [`MsgType::is_admin`].
+macro_rules! define_msg_types {
+    (
+        $(
+            $(#[$variant_meta:meta])*
+            $variant:ident = $code:literal, admin = $admin:literal;
+        )*
+    ) => {
+        /// Standard FIX message types.
+        ///
+        /// This enum covers the most common administrative and application
+        /// messages. Custom or less common message types are represented as
+        /// `Custom(String)`.
+        ///
+        /// # Equality follows the wire form
+        ///
+        /// [`PartialEq`] and [`Hash`] compare [`MsgType::as_str`], not the
+        /// variant: `MsgType::Custom("D".into()) == MsgType::NewOrderSingle`,
+        /// because both put `35=D` on the wire. Without that, a `Custom` value
+        /// reaching a `HashMap` keyed by `MsgType` would silently miss the
+        /// entry its own wire form should have hit. Prefer [`MsgType::new`],
+        /// which folds a known code into its named variant.
+        #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+        pub enum MsgType {
+            $(
+                $(#[$variant_meta])*
+                $variant,
+            )*
+            /// Custom or unknown message type.
+            Custom(String),
+        }
+
+        impl MsgType {
+            /// Returns the string representation of this message type.
+            #[must_use]
+            pub fn as_str(&self) -> &str {
+                match self {
+                    $( Self::$variant => $code, )*
+                    Self::Custom(s) => s.as_str(),
+                }
+            }
+
+            /// Creates a MsgType from its on-the-wire code.
+            ///
+            /// A code this enum names folds into that named variant, so the
+            /// result is always in normal form; anything else becomes
+            /// [`MsgType::Custom`].
+            ///
+            /// # Arguments
+            /// * `code` - The message type string (e.g., "D" for NewOrderSingle)
+            #[must_use]
+            pub fn new(code: &str) -> Self {
+                match code {
+                    $( $code => Self::$variant, )*
+                    other => Self::Custom(other.to_owned()),
+                }
+            }
+
+            /// Returns true if this is an administrative (session-level)
+            /// message.
+            ///
+            /// The classification is the `msgcat` attribute the FIX dictionary
+            /// gives each MsgType, and this list must agree with it. Note that
+            /// XMLnonFIX (`n`) is `msgcat='admin'` in `FIX44.xml`, so it is
+            /// administrative despite not being one of the seven classic
+            /// session messages.
+            ///
+            /// A [`MsgType::Custom`] carrying a code this table names is
+            /// classified by that code, so two values that compare equal
+            /// always agree here. A genuinely unrecognised code is treated as
+            /// an application message: nothing here knows a private code's
+            /// category, and routing an unknown message through the session
+            /// path would let a counterparty reach session handling with a
+            /// type this engine cannot interpret.
+            #[must_use]
+            pub fn is_admin(&self) -> bool {
+                match self {
+                    $( Self::$variant => $admin, )*
+                    // Same table, reached by wire code rather than by
+                    // discriminant; borrows the code, never allocates.
+                    Self::Custom(code) => match code.as_str() {
+                        $( $code => $admin, )*
+                        _ => false,
+                    },
+                }
+            }
+        }
+
+        #[cfg(test)]
+        impl MsgType {
+            /// Every named variant, for exhaustive round-trip tests.
+            fn all_named() -> Vec<Self> {
+                vec![ $( Self::$variant, )* ]
+            }
+        }
+    };
+}
+
+define_msg_types! {
     /// Heartbeat (0) - Session level.
     #[default]
-    Heartbeat,
+    Heartbeat = "0", admin = true;
     /// Test Request (1) - Session level.
-    TestRequest,
+    TestRequest = "1", admin = true;
     /// Resend Request (2) - Session level.
-    ResendRequest,
+    ResendRequest = "2", admin = true;
     /// Reject (3) - Session level.
-    Reject,
+    Reject = "3", admin = true;
     /// Sequence Reset (4) - Session level.
-    SequenceReset,
+    SequenceReset = "4", admin = true;
     /// Logout (5) - Session level.
-    Logout,
+    Logout = "5", admin = true;
     /// Indication of Interest (6).
-    IndicationOfInterest,
+    IndicationOfInterest = "6", admin = false;
     /// Advertisement (7).
-    Advertisement,
+    Advertisement = "7", admin = false;
     /// Execution Report (8).
-    ExecutionReport,
+    ExecutionReport = "8", admin = false;
     /// Order Cancel Reject (9).
-    OrderCancelReject,
+    OrderCancelReject = "9", admin = false;
     /// Logon (A) - Session level.
-    Logon,
+    Logon = "A", admin = true;
     /// News (B).
-    News,
+    News = "B", admin = false;
     /// Email (C).
-    Email,
+    Email = "C", admin = false;
     /// New Order Single (D).
-    NewOrderSingle,
+    NewOrderSingle = "D", admin = false;
     /// New Order List (E).
-    NewOrderList,
+    NewOrderList = "E", admin = false;
     /// Order Cancel Request (F).
-    OrderCancelRequest,
+    OrderCancelRequest = "F", admin = false;
     /// Order Cancel/Replace Request (G).
-    OrderCancelReplaceRequest,
+    OrderCancelReplaceRequest = "G", admin = false;
     /// Order Status Request (H).
-    OrderStatusRequest,
+    OrderStatusRequest = "H", admin = false;
     /// Allocation Instruction (J).
-    AllocationInstruction,
+    AllocationInstruction = "J", admin = false;
     /// List Cancel Request (K).
-    ListCancelRequest,
+    ListCancelRequest = "K", admin = false;
     /// List Execute (L).
-    ListExecute,
+    ListExecute = "L", admin = false;
     /// List Status Request (M).
-    ListStatusRequest,
+    ListStatusRequest = "M", admin = false;
     /// List Status (N).
-    ListStatus,
+    ListStatus = "N", admin = false;
     /// Allocation Instruction Ack (P).
-    AllocationInstructionAck,
+    AllocationInstructionAck = "P", admin = false;
     /// Don't Know Trade (Q).
-    DontKnowTrade,
+    DontKnowTrade = "Q", admin = false;
     /// Quote Request (R).
-    QuoteRequest,
+    QuoteRequest = "R", admin = false;
     /// Quote (S).
-    Quote,
+    Quote = "S", admin = false;
     /// Settlement Instructions (T).
-    SettlementInstructions,
+    SettlementInstructions = "T", admin = false;
     /// Market Data Request (V).
-    MarketDataRequest,
+    MarketDataRequest = "V", admin = false;
     /// Market Data Snapshot/Full Refresh (W).
-    MarketDataSnapshotFullRefresh,
+    MarketDataSnapshotFullRefresh = "W", admin = false;
     /// Market Data Incremental Refresh (X).
-    MarketDataIncrementalRefresh,
+    MarketDataIncrementalRefresh = "X", admin = false;
     /// Market Data Request Reject (Y).
-    MarketDataRequestReject,
+    MarketDataRequestReject = "Y", admin = false;
     /// Quote Cancel (Z).
-    QuoteCancel,
+    QuoteCancel = "Z", admin = false;
     /// Quote Status Request (a).
-    QuoteStatusRequest,
+    QuoteStatusRequest = "a", admin = false;
     /// Mass Quote Acknowledgement (b).
-    MassQuoteAcknowledgement,
+    MassQuoteAcknowledgement = "b", admin = false;
     /// Security Definition Request (c).
-    SecurityDefinitionRequest,
+    SecurityDefinitionRequest = "c", admin = false;
     /// Security Definition (d).
-    SecurityDefinition,
+    SecurityDefinition = "d", admin = false;
     /// Security Status Request (e).
-    SecurityStatusRequest,
+    SecurityStatusRequest = "e", admin = false;
     /// Security Status (f).
-    SecurityStatus,
+    SecurityStatus = "f", admin = false;
     /// Trading Session Status Request (g).
-    TradingSessionStatusRequest,
+    TradingSessionStatusRequest = "g", admin = false;
     /// Trading Session Status (h).
-    TradingSessionStatus,
+    TradingSessionStatus = "h", admin = false;
     /// Mass Quote (i).
-    MassQuote,
+    MassQuote = "i", admin = false;
     /// Business Message Reject (j).
-    BusinessMessageReject,
+    BusinessMessageReject = "j", admin = false;
     /// Bid Request (k).
-    BidRequest,
+    BidRequest = "k", admin = false;
     /// Bid Response (l).
-    BidResponse,
+    BidResponse = "l", admin = false;
     /// List Strike Price (m).
-    ListStrikePrice,
-    /// XML Message (n).
-    XmlMessage,
+    ListStrikePrice = "m", admin = false;
+    /// XML Message, XMLnonFIX (n) - `msgcat='admin'` in the FIX dictionary.
+    XmlMessage = "n", admin = true;
     /// Registration Instructions (o).
-    RegistrationInstructions,
+    RegistrationInstructions = "o", admin = false;
     /// Registration Instructions Response (p).
-    RegistrationInstructionsResponse,
+    RegistrationInstructionsResponse = "p", admin = false;
     /// Order Mass Cancel Request (q).
-    OrderMassCancelRequest,
+    OrderMassCancelRequest = "q", admin = false;
     /// Order Mass Cancel Report (r).
-    OrderMassCancelReport,
+    OrderMassCancelReport = "r", admin = false;
     /// New Order Cross (s).
-    NewOrderCross,
+    NewOrderCross = "s", admin = false;
     /// Cross Order Cancel/Replace Request (t).
-    CrossOrderCancelReplaceRequest,
+    CrossOrderCancelReplaceRequest = "t", admin = false;
     /// Cross Order Cancel Request (u).
-    CrossOrderCancelRequest,
+    CrossOrderCancelRequest = "u", admin = false;
     /// Security Type Request (v).
-    SecurityTypeRequest,
+    SecurityTypeRequest = "v", admin = false;
     /// Security Types (w).
-    SecurityTypes,
+    SecurityTypes = "w", admin = false;
     /// Security List Request (x).
-    SecurityListRequest,
+    SecurityListRequest = "x", admin = false;
     /// Security List (y).
-    SecurityList,
+    SecurityList = "y", admin = false;
     /// Derivative Security List Request (z).
-    DerivativeSecurityListRequest,
-    /// Custom or unknown message type.
-    Custom(String),
+    DerivativeSecurityListRequest = "z", admin = false;
 }
 
 impl std::str::FromStr for MsgType {
@@ -154,161 +251,46 @@ impl std::str::FromStr for MsgType {
 
     /// Creates a MsgType from a string value.
     ///
+    /// Infallible: an unrecognised code becomes [`MsgType::Custom`], which is
+    /// how a private or newer message type reaches the application layer
+    /// without the decoder having to know it. Delegates to [`MsgType::new`],
+    /// so the result is always in normal form.
+    ///
     /// # Arguments
     /// * `s` - The message type string (e.g., "D" for NewOrderSingle)
+    ///
+    /// # Errors
+    /// Never returns an error.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(match s {
-            "0" => Self::Heartbeat,
-            "1" => Self::TestRequest,
-            "2" => Self::ResendRequest,
-            "3" => Self::Reject,
-            "4" => Self::SequenceReset,
-            "5" => Self::Logout,
-            "6" => Self::IndicationOfInterest,
-            "7" => Self::Advertisement,
-            "8" => Self::ExecutionReport,
-            "9" => Self::OrderCancelReject,
-            "A" => Self::Logon,
-            "B" => Self::News,
-            "C" => Self::Email,
-            "D" => Self::NewOrderSingle,
-            "E" => Self::NewOrderList,
-            "F" => Self::OrderCancelRequest,
-            "G" => Self::OrderCancelReplaceRequest,
-            "H" => Self::OrderStatusRequest,
-            "J" => Self::AllocationInstruction,
-            "K" => Self::ListCancelRequest,
-            "L" => Self::ListExecute,
-            "M" => Self::ListStatusRequest,
-            "N" => Self::ListStatus,
-            "P" => Self::AllocationInstructionAck,
-            "Q" => Self::DontKnowTrade,
-            "R" => Self::QuoteRequest,
-            "S" => Self::Quote,
-            "T" => Self::SettlementInstructions,
-            "V" => Self::MarketDataRequest,
-            "W" => Self::MarketDataSnapshotFullRefresh,
-            "X" => Self::MarketDataIncrementalRefresh,
-            "Y" => Self::MarketDataRequestReject,
-            "Z" => Self::QuoteCancel,
-            "a" => Self::QuoteStatusRequest,
-            "b" => Self::MassQuoteAcknowledgement,
-            "c" => Self::SecurityDefinitionRequest,
-            "d" => Self::SecurityDefinition,
-            "e" => Self::SecurityStatusRequest,
-            "f" => Self::SecurityStatus,
-            "g" => Self::TradingSessionStatusRequest,
-            "h" => Self::TradingSessionStatus,
-            "i" => Self::MassQuote,
-            "j" => Self::BusinessMessageReject,
-            "k" => Self::BidRequest,
-            "l" => Self::BidResponse,
-            "m" => Self::ListStrikePrice,
-            "n" => Self::XmlMessage,
-            "o" => Self::RegistrationInstructions,
-            "p" => Self::RegistrationInstructionsResponse,
-            "q" => Self::OrderMassCancelRequest,
-            "r" => Self::OrderMassCancelReport,
-            "s" => Self::NewOrderCross,
-            "t" => Self::CrossOrderCancelReplaceRequest,
-            "u" => Self::CrossOrderCancelRequest,
-            "v" => Self::SecurityTypeRequest,
-            "w" => Self::SecurityTypes,
-            "x" => Self::SecurityListRequest,
-            "y" => Self::SecurityList,
-            "z" => Self::DerivativeSecurityListRequest,
-            other => Self::Custom(other.to_string()),
-        })
+        Ok(Self::new(s))
     }
 }
 
 impl MsgType {
-    /// Returns the string representation of this message type.
-    #[must_use]
-    pub fn as_str(&self) -> &str {
-        match self {
-            Self::Heartbeat => "0",
-            Self::TestRequest => "1",
-            Self::ResendRequest => "2",
-            Self::Reject => "3",
-            Self::SequenceReset => "4",
-            Self::Logout => "5",
-            Self::IndicationOfInterest => "6",
-            Self::Advertisement => "7",
-            Self::ExecutionReport => "8",
-            Self::OrderCancelReject => "9",
-            Self::Logon => "A",
-            Self::News => "B",
-            Self::Email => "C",
-            Self::NewOrderSingle => "D",
-            Self::NewOrderList => "E",
-            Self::OrderCancelRequest => "F",
-            Self::OrderCancelReplaceRequest => "G",
-            Self::OrderStatusRequest => "H",
-            Self::AllocationInstruction => "J",
-            Self::ListCancelRequest => "K",
-            Self::ListExecute => "L",
-            Self::ListStatusRequest => "M",
-            Self::ListStatus => "N",
-            Self::AllocationInstructionAck => "P",
-            Self::DontKnowTrade => "Q",
-            Self::QuoteRequest => "R",
-            Self::Quote => "S",
-            Self::SettlementInstructions => "T",
-            Self::MarketDataRequest => "V",
-            Self::MarketDataSnapshotFullRefresh => "W",
-            Self::MarketDataIncrementalRefresh => "X",
-            Self::MarketDataRequestReject => "Y",
-            Self::QuoteCancel => "Z",
-            Self::QuoteStatusRequest => "a",
-            Self::MassQuoteAcknowledgement => "b",
-            Self::SecurityDefinitionRequest => "c",
-            Self::SecurityDefinition => "d",
-            Self::SecurityStatusRequest => "e",
-            Self::SecurityStatus => "f",
-            Self::TradingSessionStatusRequest => "g",
-            Self::TradingSessionStatus => "h",
-            Self::MassQuote => "i",
-            Self::BusinessMessageReject => "j",
-            Self::BidRequest => "k",
-            Self::BidResponse => "l",
-            Self::ListStrikePrice => "m",
-            Self::XmlMessage => "n",
-            Self::RegistrationInstructions => "o",
-            Self::RegistrationInstructionsResponse => "p",
-            Self::OrderMassCancelRequest => "q",
-            Self::OrderMassCancelReport => "r",
-            Self::NewOrderCross => "s",
-            Self::CrossOrderCancelReplaceRequest => "t",
-            Self::CrossOrderCancelRequest => "u",
-            Self::SecurityTypeRequest => "v",
-            Self::SecurityTypes => "w",
-            Self::SecurityListRequest => "x",
-            Self::SecurityList => "y",
-            Self::DerivativeSecurityListRequest => "z",
-            Self::Custom(s) => s.as_str(),
-        }
-    }
-
-    /// Returns true if this is an administrative message.
-    #[must_use]
-    pub fn is_admin(&self) -> bool {
-        matches!(
-            self,
-            Self::Heartbeat
-                | Self::TestRequest
-                | Self::ResendRequest
-                | Self::Reject
-                | Self::SequenceReset
-                | Self::Logout
-                | Self::Logon
-        )
-    }
-
     /// Returns true if this is an application message.
     #[must_use]
     pub fn is_app(&self) -> bool {
         !self.is_admin()
+    }
+}
+
+/// Compares the on-the-wire form, not the variant.
+///
+/// `Custom("D")` and `NewOrderSingle` both encode `35=D`, so they compare
+/// equal; anything else would make a `Custom` value miss its own entry in a
+/// `MsgType`-keyed map.
+impl PartialEq for MsgType {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl Eq for MsgType {}
+
+/// Hashes the on-the-wire form, keeping `Hash` consistent with [`PartialEq`].
+impl std::hash::Hash for MsgType {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.as_str().hash(state);
     }
 }
 
@@ -545,20 +527,37 @@ pub struct OwnedMessage {
 impl OwnedMessage {
     /// Creates an OwnedMessage from a RawMessage.
     ///
+    /// # Borrow invariant
+    ///
+    /// Field offsets are recovered by subtracting the buffer's address from
+    /// each field value's address, so **every `FieldRef` in `raw` must borrow
+    /// from `raw.buffer()`** — which is what a decoder that produced both
+    /// guarantees. A field pointing anywhere else has no offset in this
+    /// buffer; rather than computing a wrapped or out-of-range one, it is
+    /// **dropped**, and `field_count()` on the result is correspondingly
+    /// lower. Such a `RawMessage` is a construction bug in whatever produced
+    /// it, not an input this type can repair.
+    ///
     /// # Arguments
     /// * `raw` - The raw message to copy
     #[must_use]
     pub fn from_raw(raw: &RawMessage<'_>) -> Self {
         let buffer = Bytes::copy_from_slice(raw.buffer);
-        let field_offsets = raw
-            .fields
-            .iter()
-            .map(|f| {
-                let start = f.value.as_ptr() as usize - raw.buffer.as_ptr() as usize;
-                let end = start + f.value.len();
-                (f.tag, start..end)
-            })
-            .collect();
+        let buffer_start = raw.buffer.as_ptr() as usize;
+        let buffer_len = raw.buffer.len();
+
+        let mut field_offsets = Vec::with_capacity(raw.fields.len());
+        for field in &raw.fields {
+            let offset = (field.value.as_ptr() as usize)
+                .checked_sub(buffer_start)
+                .and_then(|start| {
+                    let end = start.checked_add(field.value.len())?;
+                    (end <= buffer_len).then_some(start..end)
+                });
+            if let Some(range) = offset {
+                field_offsets.push((field.tag, range));
+            }
+        }
 
         Self {
             buffer,
@@ -684,6 +683,10 @@ pub trait FixMessage: Sized {
 mod tests {
     use super::*;
 
+    use std::collections::hash_map::DefaultHasher;
+    use std::collections::{HashMap, HashSet};
+    use std::hash::{Hash, Hasher};
+
     #[test]
     fn test_msg_type_from_str() {
         assert_eq!("0".parse::<MsgType>(), Ok(MsgType::Heartbeat));
@@ -700,6 +703,34 @@ mod tests {
     }
 
     #[test]
+    fn test_msg_type_every_variant_round_trips_through_its_code() {
+        for variant in MsgType::all_named() {
+            let code = variant.as_str().to_owned();
+            assert_eq!(
+                MsgType::new(&code),
+                variant,
+                "MsgType::new({code:?}) must recover {variant:?}"
+            );
+            // A named code must never fall through to Custom.
+            assert!(
+                !matches!(MsgType::new(&code), MsgType::Custom(_)),
+                "{code:?} must map to a named variant, not Custom"
+            );
+        }
+    }
+
+    #[test]
+    fn test_msg_type_codes_are_unique() {
+        let named = MsgType::all_named();
+        let codes: HashSet<&str> = named.iter().map(MsgType::as_str).collect();
+        assert_eq!(
+            codes.len(),
+            named.len(),
+            "two variants share one wire code, so the reverse lookup is ambiguous"
+        );
+    }
+
+    #[test]
     fn test_msg_type_is_admin() {
         assert!(MsgType::Heartbeat.is_admin());
         assert!(MsgType::Logon.is_admin());
@@ -709,10 +740,84 @@ mod tests {
     }
 
     #[test]
+    fn test_msg_type_is_admin_matches_dictionary_msgcat() {
+        // The eight msgtype values marked msgcat='admin' in FIX44.xml.
+        const ADMIN_CODES: [&str; 8] = ["0", "1", "2", "3", "4", "5", "A", "n"];
+        for variant in MsgType::all_named() {
+            let expected = ADMIN_CODES.contains(&variant.as_str());
+            assert_eq!(
+                variant.is_admin(),
+                expected,
+                "{variant:?} ({}) disagrees with the dictionary msgcat",
+                variant.as_str()
+            );
+            assert_eq!(variant.is_app(), !expected);
+        }
+    }
+
+    #[test]
+    fn test_msg_type_xml_message_is_admin() {
+        assert_eq!(MsgType::new("n"), MsgType::XmlMessage);
+        assert!(MsgType::XmlMessage.is_admin());
+        assert!(!MsgType::XmlMessage.is_app());
+    }
+
+    #[test]
     fn test_msg_type_custom() {
         let custom = MsgType::Custom("XX".to_string());
         assert_eq!("XX".parse::<MsgType>(), Ok(custom.clone()));
         assert_eq!(custom.as_str(), "XX");
+        assert!(!custom.is_admin());
+        assert!(custom.is_app());
+    }
+
+    #[test]
+    fn test_msg_type_new_normalises_known_code_out_of_custom() {
+        assert_eq!(MsgType::new("D"), MsgType::NewOrderSingle);
+        assert!(matches!(MsgType::new("D"), MsgType::NewOrderSingle));
+        assert!(matches!(MsgType::new("ZZ"), MsgType::Custom(_)));
+    }
+
+    #[test]
+    fn test_msg_type_custom_equals_named_variant_with_same_wire_form() {
+        let custom = MsgType::Custom("D".to_string());
+        assert_eq!(custom, MsgType::NewOrderSingle);
+        assert_eq!(MsgType::NewOrderSingle, custom);
+        assert_ne!(custom, MsgType::ExecutionReport);
+    }
+
+    #[test]
+    fn test_msg_type_equal_values_agree_on_is_admin() {
+        // Equality follows the wire form, so classification must too — a
+        // Custom("A") that routed as an application message while an equal
+        // MsgType::Logon routed as admin would be a session-layer split brain.
+        for variant in MsgType::all_named() {
+            let as_custom = MsgType::Custom(variant.as_str().to_owned());
+            assert_eq!(as_custom, variant);
+            assert_eq!(
+                as_custom.is_admin(),
+                variant.is_admin(),
+                "Custom({:?}) must classify like {variant:?}",
+                variant.as_str()
+            );
+        }
+        // A code no variant names stays an application message.
+        assert!(!MsgType::Custom("ZZ".to_owned()).is_admin());
+    }
+
+    #[test]
+    fn test_msg_type_hash_follows_wire_form() {
+        fn hash_of(value: &MsgType) -> u64 {
+            let mut hasher = DefaultHasher::new();
+            value.hash(&mut hasher);
+            hasher.finish()
+        }
+        let custom = MsgType::Custom("D".to_string());
+        assert_eq!(hash_of(&custom), hash_of(&MsgType::NewOrderSingle));
+
+        let mut map: HashMap<MsgType, u32> = HashMap::new();
+        map.insert(MsgType::NewOrderSingle, 1);
+        assert_eq!(map.get(&custom), Some(&1));
     }
 
     /// Builds the field list for a one-field `RawMessage` over `buffer`.
@@ -792,6 +897,51 @@ mod tests {
         let buffer = Bytes::from_static(b"8=FIX.4.4\x01");
         let msg = OwnedMessage::new(buffer, MsgType::Heartbeat, vec![(8, 2..64)]);
         assert_eq!(msg.get_field(8), None);
+    }
+
+    #[test]
+    fn test_owned_message_from_raw_recovers_buffer_offsets() {
+        let buffer: &[u8] = b"8=FIX.4.4\x0135=D\x0149=SENDER\x01";
+        let mut fields: SmallVec<[FieldRef<'_>; 32]> = SmallVec::new();
+        let Some(begin) = buffer.get(2..9) else {
+            panic!("fixture buffer is long enough")
+        };
+        let Some(sender) = buffer.get(18..24) else {
+            panic!("fixture buffer is long enough")
+        };
+        fields.push(FieldRef::new(8, begin));
+        fields.push(FieldRef::new(49, sender));
+        let Ok(raw) = RawMessage::new(buffer, 2..9, 10..24, MsgType::NewOrderSingle, fields) else {
+            panic!("in-bounds ranges must be accepted");
+        };
+
+        let owned = OwnedMessage::from_raw(&raw);
+        assert_eq!(owned.field_count(), 2);
+        assert_eq!(owned.get_field_str(8), Some("FIX.4.4"));
+        assert_eq!(owned.get_field_str(49), Some("SENDER"));
+    }
+
+    #[test]
+    fn test_owned_message_from_raw_drops_field_not_borrowing_from_buffer() {
+        let buffer: &[u8] = b"8=FIX.4.4\x0135=D\x01";
+        // Deliberately borrowed from a different allocation: the offset of
+        // this value inside `buffer` does not exist, and the old pointer
+        // subtraction would have wrapped into a huge range.
+        let foreign: &[u8] = b"FOREIGN";
+        let mut fields: SmallVec<[FieldRef<'_>; 32]> = SmallVec::new();
+        let Some(begin) = buffer.get(2..9) else {
+            panic!("fixture buffer is long enough")
+        };
+        fields.push(FieldRef::new(8, begin));
+        fields.push(FieldRef::new(49, foreign));
+        let Ok(raw) = RawMessage::new(buffer, 2..9, 10..15, MsgType::NewOrderSingle, fields) else {
+            panic!("in-bounds ranges must be accepted");
+        };
+
+        let owned = OwnedMessage::from_raw(&raw);
+        assert_eq!(owned.field_count(), 1);
+        assert_eq!(owned.get_field_str(8), Some("FIX.4.4"));
+        assert_eq!(owned.get_field(49), None);
     }
 
     #[test]

--- a/ironfix-core/src/types.rs
+++ b/ironfix-core/src/types.rs
@@ -103,7 +103,7 @@ impl fmt::Display for SeqNum {
 /// representable and are rejected by the fallible constructors rather than
 /// wrapped or zeroed. Because the bound is enforced at construction,
 /// [`Timestamp::to_datetime`] and the `format_*` methods are total.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 pub struct Timestamp {
     /// Nanoseconds since Unix epoch (1970-01-01 00:00:00 UTC).
     nanos_since_epoch: u64,
@@ -313,6 +313,28 @@ impl fmt::Display for Timestamp {
     }
 }
 
+impl<'de> Deserialize<'de> for Timestamp {
+    /// Deserializes a timestamp, routing the raw nanosecond count through
+    /// [`Timestamp::from_nanos`] so the [`Timestamp::MAX_NANOS`] bound is
+    /// enforced. A serialized value whose `nanos_since_epoch` exceeds the
+    /// ceiling is a deserialization error, not a silently clamped or wrapped
+    /// instant — that is what keeps [`Timestamp::to_datetime`] total by
+    /// construction even for values that arrive over serde.
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Mirrors the field-per-struct shape the derived `Serialize` emits, so
+        // the pair round-trips, but re-validates instead of trusting the input.
+        #[derive(Deserialize)]
+        struct Raw {
+            nanos_since_epoch: u64,
+        }
+        let raw = Raw::deserialize(deserializer)?;
+        Self::from_nanos(raw.nanos_since_epoch).map_err(serde::de::Error::custom)
+    }
+}
+
 /// Component identifier for FIX sessions.
 ///
 /// Used for SenderCompID (tag 49), TargetCompID (tag 56), and related fields.
@@ -326,13 +348,17 @@ impl fmt::Display for Timestamp {
 ///
 /// # Charset
 ///
-/// Only printable ASCII (`0x20..=0x7e`) except `=` is accepted. A CompID is
-/// written verbatim into tags 49 and 56 on every outbound message, so SOH
-/// would terminate the field early and `=` would open a new tag/value pair:
-/// either byte lets a hostile CompID inject header fields or corrupt framing.
-/// Rejecting them at construction is the chokepoint that makes such a value
-/// unrepresentable rather than escaping it at every encode site.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+/// Only printable ASCII (`0x20..=0x7e`) is accepted, and the value must not be
+/// empty. A CompID is written verbatim into tags 49 and 56 on every outbound
+/// message, so a SOH or any other control byte would terminate the field early
+/// and let a hostile CompID inject header fields or corrupt framing; an empty
+/// value would emit `49=<SOH>`, a field FIX TagValue treats as malformed.
+/// Rejecting those at construction is the chokepoint that makes such a value
+/// unrepresentable rather than escaping it at every encode site. The `=` byte
+/// is deliberately **not** rejected: it is a legal FIX String value byte (only
+/// the first `=` of a field separates tag from value, and a CompID is a value,
+/// never a tag), so a counterparty identifier may legitimately contain it.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 #[repr(transparent)]
 #[serde(transparent)]
 pub struct CompId(ArrayString<COMP_ID_MAX_LEN>);
@@ -344,10 +370,13 @@ impl CompId {
     /// * `s` - The component identifier string
     ///
     /// # Errors
-    /// Returns [`CompIdError::TooLong`] if `s` exceeds [`COMP_ID_MAX_LEN`]
-    /// bytes, or [`CompIdError::IllegalByte`] if it contains any byte outside
-    /// printable ASCII, or the `=` tag/value separator.
+    /// Returns [`CompIdError::Empty`] if `s` is empty, [`CompIdError::TooLong`]
+    /// if `s` exceeds [`COMP_ID_MAX_LEN`] bytes, or [`CompIdError::IllegalByte`]
+    /// if it contains any byte outside printable ASCII (`0x20..=0x7e`).
     pub fn new(s: &str) -> Result<Self, CompIdError> {
+        if s.is_empty() {
+            return Err(CompIdError::Empty);
+        }
         if s.len() > COMP_ID_MAX_LEN {
             return Err(CompIdError::TooLong {
                 len: s.len(),
@@ -356,7 +385,7 @@ impl CompId {
         }
         for (position, &byte) in s.as_bytes().iter().enumerate() {
             let printable = byte.is_ascii_graphic() || byte == b' ';
-            if !printable || byte == b'=' {
+            if !printable {
                 return Err(CompIdError::IllegalByte { byte, position });
             }
         }
@@ -407,13 +436,32 @@ impl fmt::Display for CompId {
 impl FromStr for CompId {
     type Err = CompIdError;
 
-    /// Parses a CompID, applying the same length and charset checks as
-    /// [`CompId::new`].
+    /// Parses a CompID, applying the same emptiness, length, and charset checks
+    /// as [`CompId::new`].
     ///
     /// # Errors
-    /// Returns [`CompIdError::TooLong`] or [`CompIdError::IllegalByte`].
+    /// Returns [`CompIdError::Empty`], [`CompIdError::TooLong`], or
+    /// [`CompIdError::IllegalByte`].
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Self::new(s)
+    }
+}
+
+impl<'de> Deserialize<'de> for CompId {
+    /// Deserializes a CompID by routing the raw string through [`CompId::new`],
+    /// so the emptiness, length, and charset invariants hold for a value that
+    /// arrives over serde exactly as they do for one built in code. The derived
+    /// `Serialize` is transparent, so a serialized CompID is just its string;
+    /// re-validating it here stops a hand-crafted payload (an embedded SOH, a
+    /// control byte, an over-length or empty value) from reconstructing a
+    /// `CompId` that never passed the constructor and then being written
+    /// verbatim into tags 49 and 56.
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = String::deserialize(deserializer)?;
+        Self::new(&raw).map_err(serde::de::Error::custom)
     }
 }
 
@@ -667,6 +715,36 @@ mod tests {
     }
 
     #[test]
+    fn test_timestamp_deserialize_out_of_range_nanos_is_rejected() {
+        use serde::de::value::{Error as ValueError, MapDeserializer};
+
+        // A payload one nanosecond past MAX_NANOS must not rebuild a Timestamp
+        // that skipped `from_nanos` and would trip `to_datetime`'s bound.
+        let de = MapDeserializer::new(std::iter::once((
+            "nanos_since_epoch",
+            Timestamp::MAX_NANOS + 1,
+        )));
+        let result: Result<Timestamp, ValueError> = Timestamp::deserialize(de);
+        assert!(
+            result.is_err(),
+            "nanos past MAX_NANOS must fail to deserialize"
+        );
+    }
+
+    #[test]
+    fn test_timestamp_deserialize_in_range_nanos_round_trips() {
+        use serde::de::value::{Error as ValueError, MapDeserializer};
+
+        let de = MapDeserializer::new(std::iter::once((
+            "nanos_since_epoch",
+            1_700_000_000_123_456_789_u64,
+        )));
+        let result: Result<Timestamp, ValueError> = Timestamp::deserialize(de);
+        let ts = ok(result, "in-range nanos deserializes");
+        assert_eq!(ts.as_nanos(), 1_700_000_000_123_456_789);
+    }
+
+    #[test]
     fn test_comp_id_accepts_plain_value() {
         let id = ok(CompId::new("SENDER"), "SENDER is a valid CompId");
         assert_eq!(id.as_str(), "SENDER");
@@ -706,14 +784,35 @@ mod tests {
     }
 
     #[test]
-    fn test_comp_id_rejects_equals() {
-        assert_eq!(
-            CompId::new("SEND=ER"),
-            Err(CompIdError::IllegalByte {
-                byte: b'=',
-                position: 4,
-            })
+    fn test_comp_id_accepts_equals() {
+        // `=` is a legal FIX String value byte: only the first `=` of a field
+        // separates tag from value, and a CompID is a value, never a tag.
+        let id = ok(CompId::new("SEND=ER"), "'=' is legal inside a CompId value");
+        assert_eq!(id.as_str(), "SEND=ER");
+    }
+
+    #[test]
+    fn test_comp_id_new_empty_is_rejected() {
+        assert_eq!(CompId::new(""), Err(CompIdError::Empty));
+    }
+
+    #[test]
+    fn test_comp_id_deserialize_with_soh_is_rejected() {
+        // A serialized CompID is transparently its string; a hand-crafted value
+        // carrying SOH must not rebuild a CompId that skipped `CompId::new`.
+        let de = serde::de::value::StrDeserializer::<serde::de::value::Error>::new("SEND\u{1}ER");
+        let result = CompId::deserialize(de);
+        assert!(
+            result.is_err(),
+            "SOH-bearing CompId must fail to deserialize"
         );
+    }
+
+    #[test]
+    fn test_comp_id_deserialize_valid_round_trips() {
+        let de = serde::de::value::StrDeserializer::<serde::de::value::Error>::new("SENDER");
+        let id = ok(CompId::deserialize(de), "SENDER is a valid CompId");
+        assert_eq!(id.as_str(), "SENDER");
     }
 
     #[test]

--- a/ironfix-core/src/types.rs
+++ b/ironfix-core/src/types.rs
@@ -12,6 +12,7 @@
 //! - [`CompId`]: Component identifier (SenderCompID, TargetCompID)
 //! - [`Side`]: Order side enumeration
 
+use crate::error::{CompIdError, InvalidSide, TimestampError};
 use arrayvec::ArrayString;
 use chrono::{DateTime, Utc};
 use num_derive::{FromPrimitive, ToPrimitive};
@@ -92,6 +93,16 @@ impl fmt::Display for SeqNum {
 ///
 /// Timestamps in FIX are formatted as `YYYYMMDD-HH:MM:SS.sss` (milliseconds)
 /// or `YYYYMMDD-HH:MM:SS.ssssss` (microseconds) or `YYYYMMDD-HH:MM:SS.sssssssss` (nanoseconds).
+///
+/// # Representable range
+///
+/// The count is unsigned nanoseconds since the Unix epoch, bounded by
+/// [`Timestamp::MAX_NANOS`]. The representable interval is therefore
+/// `1970-01-01T00:00:00.000000000Z ..= 2262-04-11T23:47:16.854775807Z`
+/// inclusive. Instants before the epoch and past that ceiling are **not**
+/// representable and are rejected by the fallible constructors rather than
+/// wrapped or zeroed. Because the bound is enforced at construction,
+/// [`Timestamp::to_datetime`] and the `format_*` methods are total.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct Timestamp {
     /// Nanoseconds since Unix epoch (1970-01-01 00:00:00 UTC).
@@ -99,38 +110,109 @@ pub struct Timestamp {
 }
 
 impl Timestamp {
+    /// The largest representable nanosecond count, `i64::MAX` nanoseconds.
+    ///
+    /// Equals `2262-04-11T23:47:16.854775807Z`. The bound is `i64`-shaped
+    /// because a `chrono::DateTime` counts nanoseconds in an `i64`; keeping
+    /// the invariant here is what makes [`Timestamp::to_datetime`] total.
+    pub const MAX_NANOS: u64 = 9_223_372_036_854_775_807;
+
+    /// The Unix epoch, `1970-01-01T00:00:00.000000000Z`.
+    pub const EPOCH: Self = Self {
+        nanos_since_epoch: 0,
+    };
+
     /// Creates a timestamp from nanoseconds since Unix epoch.
     ///
     /// # Arguments
     /// * `nanos` - Nanoseconds since 1970-01-01 00:00:00 UTC
+    ///
+    /// # Errors
+    /// Returns [`TimestampError::NanosOutOfRange`] if `nanos` exceeds
+    /// [`Timestamp::MAX_NANOS`].
     #[inline]
-    #[must_use]
-    pub const fn from_nanos(nanos: u64) -> Self {
-        Self {
-            nanos_since_epoch: nanos,
+    pub const fn from_nanos(nanos: u64) -> Result<Self, TimestampError> {
+        if nanos > Self::MAX_NANOS {
+            return Err(TimestampError::NanosOutOfRange {
+                nanos,
+                max_nanos: Self::MAX_NANOS,
+            });
         }
+        Ok(Self {
+            nanos_since_epoch: nanos,
+        })
     }
 
     /// Creates a timestamp from milliseconds since Unix epoch.
     ///
     /// # Arguments
     /// * `millis` - Milliseconds since 1970-01-01 00:00:00 UTC
+    ///
+    /// # Errors
+    /// Returns [`TimestampError::MillisOutOfRange`] if scaling `millis` to
+    /// nanoseconds overflows, or [`TimestampError::NanosOutOfRange`] if the
+    /// result exceeds [`Timestamp::MAX_NANOS`].
     #[inline]
-    #[must_use]
-    pub const fn from_millis(millis: u64) -> Self {
-        Self {
-            nanos_since_epoch: millis * 1_000_000,
+    pub const fn from_millis(millis: u64) -> Result<Self, TimestampError> {
+        match millis.checked_mul(1_000_000) {
+            Some(nanos) => Self::from_nanos(nanos),
+            None => Err(TimestampError::MillisOutOfRange { millis }),
+        }
+    }
+
+    /// Converts a calendar instant to a timestamp.
+    ///
+    /// # Errors
+    /// Returns [`TimestampError::InstantOutOfRange`] if `dt` lies before the
+    /// Unix epoch or past [`Timestamp::MAX_NANOS`].
+    fn from_datetime(dt: DateTime<Utc>) -> Result<Self, TimestampError> {
+        let out_of_range = || TimestampError::InstantOutOfRange {
+            seconds: dt.timestamp(),
+        };
+        let Some(nanos) = dt.timestamp_nanos_opt() else {
+            return Err(out_of_range());
+        };
+        match u64::try_from(nanos) {
+            Ok(nanos) => Self::from_nanos(nanos),
+            Err(_) => Err(out_of_range()),
+        }
+    }
+
+    /// Converts a calendar instant to a timestamp, clamping an unrepresentable
+    /// instant to [`Timestamp::EPOCH`].
+    fn clamp_datetime(dt: DateTime<Utc>) -> Self {
+        match Self::from_datetime(dt) {
+            Ok(ts) => ts,
+            Err(_) => Self::EPOCH,
         }
     }
 
     /// Returns the current UTC timestamp.
+    ///
+    /// # Clamping
+    ///
+    /// This reads the system clock, which is not untrusted input, and is
+    /// infallible so that header stamping cannot fail. A system clock outside
+    /// the representable range (before 1970 or after 2262) yields
+    /// [`Timestamp::EPOCH`], which formats as `19700101-00:00:00.000` — an
+    /// obviously wrong SendingTime a counterparty will reject, not a plausible
+    /// substitute. Use [`Timestamp::try_now`] to observe that condition as a
+    /// typed error instead.
     #[inline]
     #[must_use]
     pub fn now() -> Self {
-        let dt = Utc::now();
-        Self {
-            nanos_since_epoch: dt.timestamp_nanos_opt().unwrap_or(0) as u64,
-        }
+        Self::clamp_datetime(Utc::now())
+    }
+
+    /// Returns the current UTC timestamp, or an error if the system clock is
+    /// outside the representable range.
+    ///
+    /// # Errors
+    /// Returns [`TimestampError::InstantOutOfRange`] if the system clock reads
+    /// before the Unix epoch or past [`Timestamp::MAX_NANOS`].
+    #[inline]
+    pub fn try_now() -> Result<Self, TimestampError> {
+        Self::from_datetime(Utc::now())
     }
 
     /// Returns nanoseconds since Unix epoch.
@@ -155,9 +237,22 @@ impl Timestamp {
     }
 
     /// Converts to a chrono `DateTime<Utc>`.
+    ///
+    /// Total by construction: every constructor bounds the nanosecond count to
+    /// [`Timestamp::MAX_NANOS`], which is exactly what an `i64` nanosecond
+    /// count can hold.
     #[must_use]
     pub fn to_datetime(self) -> DateTime<Utc> {
-        DateTime::from_timestamp_nanos(self.nanos_since_epoch as i64)
+        debug_assert!(
+            self.nanos_since_epoch <= Self::MAX_NANOS,
+            "Timestamp constructors bound nanos_since_epoch to MAX_NANOS"
+        );
+        match i64::try_from(self.nanos_since_epoch) {
+            Ok(nanos) => DateTime::from_timestamp_nanos(nanos),
+            // Unreachable while the constructor invariant holds; still typed
+            // rather than a panic, since the release profile aborts.
+            Err(_) => DateTime::from_timestamp_nanos(i64::MAX),
+        }
     }
 
     /// Formats the timestamp in FIX format with millisecond precision.
@@ -195,11 +290,20 @@ impl Default for Timestamp {
     }
 }
 
-impl From<DateTime<Utc>> for Timestamp {
-    fn from(dt: DateTime<Utc>) -> Self {
-        Self {
-            nanos_since_epoch: dt.timestamp_nanos_opt().unwrap_or(0) as u64,
-        }
+impl TryFrom<DateTime<Utc>> for Timestamp {
+    type Error = TimestampError;
+
+    /// Converts a calendar instant to a timestamp.
+    ///
+    /// This is the landing point for a parsed SendingTime (tag 52), so an
+    /// instant outside the representable range is an error rather than a
+    /// silently zeroed or wrapped value.
+    ///
+    /// # Errors
+    /// Returns [`TimestampError::InstantOutOfRange`] if `dt` lies before the
+    /// Unix epoch or past [`Timestamp::MAX_NANOS`].
+    fn try_from(dt: DateTime<Utc>) -> Result<Self, Self::Error> {
+        Self::from_datetime(dt)
     }
 }
 
@@ -212,7 +316,22 @@ impl fmt::Display for Timestamp {
 /// Component identifier for FIX sessions.
 ///
 /// Used for SenderCompID (tag 49), TargetCompID (tag 56), and related fields.
-/// Maximum length is 32 characters as per FIX specification.
+///
+/// # Bounds
+///
+/// The value is at most [`COMP_ID_MAX_LEN`] **bytes**. That bound is an
+/// IronFix engineering choice — it is what keeps a CompID in inline
+/// [`ArrayString`] storage instead of a heap allocation. The FIX specification
+/// types CompID as an unbounded `String` and does not bound its length.
+///
+/// # Charset
+///
+/// Only printable ASCII (`0x20..=0x7e`) except `=` is accepted. A CompID is
+/// written verbatim into tags 49 and 56 on every outbound message, so SOH
+/// would terminate the field early and `=` would open a new tag/value pair:
+/// either byte lets a hostile CompID inject header fields or corrupt framing.
+/// Rejecting them at construction is the chokepoint that makes such a value
+/// unrepresentable rather than escaping it at every encode site.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[repr(transparent)]
 #[serde(transparent)]
@@ -224,11 +343,31 @@ impl CompId {
     /// # Arguments
     /// * `s` - The component identifier string
     ///
-    /// # Returns
-    /// `Some(CompId)` if the string fits within the maximum length, `None` otherwise.
-    #[must_use]
-    pub fn new(s: &str) -> Option<Self> {
-        ArrayString::from(s).ok().map(Self)
+    /// # Errors
+    /// Returns [`CompIdError::TooLong`] if `s` exceeds [`COMP_ID_MAX_LEN`]
+    /// bytes, or [`CompIdError::IllegalByte`] if it contains any byte outside
+    /// printable ASCII, or the `=` tag/value separator.
+    pub fn new(s: &str) -> Result<Self, CompIdError> {
+        if s.len() > COMP_ID_MAX_LEN {
+            return Err(CompIdError::TooLong {
+                len: s.len(),
+                max_len: COMP_ID_MAX_LEN,
+            });
+        }
+        for (position, &byte) in s.as_bytes().iter().enumerate() {
+            let printable = byte.is_ascii_graphic() || byte == b' ';
+            if !printable || byte == b'=' {
+                return Err(CompIdError::IllegalByte { byte, position });
+            }
+        }
+        match ArrayString::from(s) {
+            Ok(inner) => Ok(Self(inner)),
+            // Unreachable: the length was checked above.
+            Err(_) => Err(CompIdError::TooLong {
+                len: s.len(),
+                max_len: COMP_ID_MAX_LEN,
+            }),
+        }
     }
 
     /// Returns the CompId as a string slice.
@@ -266,12 +405,15 @@ impl fmt::Display for CompId {
 }
 
 impl FromStr for CompId {
-    type Err = arrayvec::CapacityError<()>;
+    type Err = CompIdError;
 
+    /// Parses a CompID, applying the same length and charset checks as
+    /// [`CompId::new`].
+    ///
+    /// # Errors
+    /// Returns [`CompIdError::TooLong`] or [`CompIdError::IllegalByte`].
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        ArrayString::try_from(s)
-            .map(Self)
-            .map_err(|_| arrayvec::CapacityError::new(()))
+        Self::new(s)
     }
 }
 
@@ -376,10 +518,15 @@ impl fmt::Display for Side {
 }
 
 impl TryFrom<u8> for Side {
-    type Error = ();
+    type Error = InvalidSide;
 
+    /// Converts a wire byte to a `Side`.
+    ///
+    /// # Errors
+    /// Returns [`InvalidSide`] if `value` is not one of the Side (tag 54)
+    /// codes.
     fn try_from(value: u8) -> Result<Self, Self::Error> {
-        Self::from_char(value as char).ok_or(())
+        Self::from_char(char::from(value)).ok_or(InvalidSide::new(value))
     }
 }
 
@@ -402,33 +549,202 @@ mod tests {
         assert_eq!(seq.value(), 1);
     }
 
+    /// Unwraps a `Result` with test context instead of `.unwrap()`.
+    #[track_caller]
+    fn ok<T, E: fmt::Debug>(result: Result<T, E>, what: &str) -> T {
+        match result {
+            Ok(value) => value,
+            Err(err) => panic!("{what}: {err:?}"),
+        }
+    }
+
     #[test]
-    fn test_timestamp_conversions() {
-        let ts = Timestamp::from_millis(1000);
+    fn test_timestamp_from_millis_converts() {
+        let ts = ok(Timestamp::from_millis(1000), "1000ms is representable");
         assert_eq!(ts.as_millis(), 1000);
         assert_eq!(ts.as_micros(), 1_000_000);
         assert_eq!(ts.as_nanos(), 1_000_000_000);
     }
 
     #[test]
-    fn test_timestamp_format() {
-        let ts = Timestamp::from_millis(0);
-        let formatted = ts.format_millis();
-        assert!(formatted.starts_with("19700101-00:00:00"));
+    fn test_timestamp_from_millis_overflow_is_typed_error() {
+        // u64::MAX ms scaled to nanoseconds overflows the multiply itself.
+        assert_eq!(
+            Timestamp::from_millis(u64::MAX),
+            Err(TimestampError::MillisOutOfRange { millis: u64::MAX })
+        );
     }
 
     #[test]
-    fn test_comp_id() {
-        let id = CompId::new("SENDER").unwrap();
+    fn test_timestamp_from_millis_past_ceiling_is_typed_error() {
+        // Multiplies cleanly within u64 but lands past MAX_NANOS (year 2262).
+        let millis = 10_000_000_000_000_u64;
+        assert_eq!(
+            Timestamp::from_millis(millis),
+            Err(TimestampError::NanosOutOfRange {
+                nanos: 10_000_000_000_000_000_000,
+                max_nanos: Timestamp::MAX_NANOS,
+            })
+        );
+    }
+
+    #[test]
+    fn test_timestamp_from_nanos_boundaries() {
+        let max = ok(
+            Timestamp::from_nanos(Timestamp::MAX_NANOS),
+            "MAX_NANOS is representable",
+        );
+        assert_eq!(max.as_nanos(), Timestamp::MAX_NANOS);
+        assert_eq!(
+            Timestamp::from_nanos(Timestamp::MAX_NANOS + 1),
+            Err(TimestampError::NanosOutOfRange {
+                nanos: Timestamp::MAX_NANOS + 1,
+                max_nanos: Timestamp::MAX_NANOS,
+            })
+        );
+    }
+
+    #[test]
+    fn test_timestamp_try_from_pre_epoch_datetime_is_typed_error() {
+        let Some(dt) = DateTime::from_timestamp(-1, 0) else {
+            panic!("1969-12-31T23:59:59Z is a valid chrono instant");
+        };
+        assert_eq!(
+            Timestamp::try_from(dt),
+            Err(TimestampError::InstantOutOfRange { seconds: -1 })
+        );
+    }
+
+    #[test]
+    fn test_timestamp_clamp_datetime_pre_epoch_yields_epoch() {
+        let Some(dt) = DateTime::from_timestamp(-86_400, 0) else {
+            panic!("1969-12-31T00:00:00Z is a valid chrono instant");
+        };
+        assert_eq!(Timestamp::clamp_datetime(dt), Timestamp::EPOCH);
+        assert_eq!(Timestamp::EPOCH.as_nanos(), 0);
+    }
+
+    #[test]
+    fn test_timestamp_clamp_datetime_in_range_is_exact() {
+        let Some(dt) = DateTime::from_timestamp(1_700_000_000, 123_456_789) else {
+            panic!("2023-11-14T22:13:20Z is a valid chrono instant");
+        };
+        assert_eq!(
+            Timestamp::clamp_datetime(dt).as_nanos(),
+            1_700_000_000_123_456_789
+        );
+    }
+
+    #[test]
+    fn test_timestamp_try_now_is_representable() {
+        let now = ok(Timestamp::try_now(), "the system clock is in range");
+        assert!(now.as_nanos() > 0);
+    }
+
+    #[test]
+    fn test_timestamp_format_millis_at_epoch() {
+        let ts = ok(Timestamp::from_millis(0), "0ms is representable");
+        assert_eq!(ts.format_millis().as_str(), "19700101-00:00:00.000");
+    }
+
+    #[test]
+    fn test_timestamp_format_micros_at_known_instant() {
+        // 2023-11-14T22:13:20.123456Z
+        let ts = ok(
+            Timestamp::from_nanos(1_700_000_000_123_456_000),
+            "instant is representable",
+        );
+        assert_eq!(ts.format_micros().as_str(), "20231114-22:13:20.123456");
+    }
+
+    #[test]
+    fn test_timestamp_round_trips_through_datetime() {
+        let ts = ok(
+            Timestamp::from_nanos(1_700_000_000_123_456_789),
+            "instant is representable",
+        );
+        assert_eq!(Timestamp::try_from(ts.to_datetime()), Ok(ts));
+    }
+
+    #[test]
+    fn test_comp_id_accepts_plain_value() {
+        let id = ok(CompId::new("SENDER"), "SENDER is a valid CompId");
         assert_eq!(id.as_str(), "SENDER");
         assert_eq!(id.len(), 6);
         assert!(!id.is_empty());
     }
 
     #[test]
-    fn test_comp_id_too_long() {
-        let long_str = "A".repeat(COMP_ID_MAX_LEN + 1);
-        assert!(CompId::new(&long_str).is_none());
+    fn test_comp_id_at_exact_capacity_is_accepted() {
+        let exact = "A".repeat(COMP_ID_MAX_LEN);
+        let id = ok(CompId::new(&exact), "32 bytes is exactly the bound");
+        assert_eq!(id.len(), COMP_ID_MAX_LEN);
+        assert_eq!(id.as_str(), exact.as_str());
+    }
+
+    #[test]
+    fn test_comp_id_one_past_capacity_is_rejected() {
+        let long = "A".repeat(COMP_ID_MAX_LEN + 1);
+        assert_eq!(
+            CompId::new(&long),
+            Err(CompIdError::TooLong {
+                len: COMP_ID_MAX_LEN + 1,
+                max_len: COMP_ID_MAX_LEN,
+            })
+        );
+    }
+
+    #[test]
+    fn test_comp_id_rejects_soh() {
+        assert_eq!(
+            CompId::new("SEND\u{1}ER"),
+            Err(CompIdError::IllegalByte {
+                byte: 0x01,
+                position: 4,
+            })
+        );
+    }
+
+    #[test]
+    fn test_comp_id_rejects_equals() {
+        assert_eq!(
+            CompId::new("SEND=ER"),
+            Err(CompIdError::IllegalByte {
+                byte: b'=',
+                position: 4,
+            })
+        );
+    }
+
+    #[test]
+    fn test_comp_id_rejects_non_ascii() {
+        // 'ñ' is two bytes, 0xc3 0xb1; the first is reported.
+        assert_eq!(
+            CompId::new("SEÑOR"),
+            Err(CompIdError::IllegalByte {
+                byte: 0xc3,
+                position: 2,
+            })
+        );
+    }
+
+    #[test]
+    fn test_comp_id_rejects_control_bytes() {
+        assert_eq!(
+            CompId::new("SENDER\n"),
+            Err(CompIdError::IllegalByte {
+                byte: b'\n',
+                position: 6,
+            })
+        );
+    }
+
+    #[test]
+    fn test_comp_id_from_str_matches_new() {
+        let parsed = ok("SENDER".parse::<CompId>(), "SENDER is a valid CompId");
+        let built = ok(CompId::new("SENDER"), "SENDER is a valid CompId");
+        assert_eq!(parsed, built);
+        assert!("SEND\u{1}ER".parse::<CompId>().is_err());
     }
 
     #[test]
@@ -436,6 +752,44 @@ mod tests {
         assert_eq!(Side::from_char('1'), Some(Side::Buy));
         assert_eq!(Side::from_char('2'), Some(Side::Sell));
         assert_eq!(Side::from_char('X'), None);
+    }
+
+    #[test]
+    fn test_side_round_trips_every_variant() {
+        const ALL: [Side; 16] = [
+            Side::Buy,
+            Side::Sell,
+            Side::BuyMinus,
+            Side::SellPlus,
+            Side::SellShort,
+            Side::SellShortExempt,
+            Side::Undisclosed,
+            Side::Cross,
+            Side::CrossShort,
+            Side::CrossShortExempt,
+            Side::AsDefined,
+            Side::Opposite,
+            Side::Subscribe,
+            Side::Redeem,
+            Side::Lend,
+            Side::Borrow,
+        ];
+        for side in ALL {
+            assert_eq!(Side::from_char(side.as_char()), Some(side));
+            let byte = u8::try_from(side.as_char());
+            let byte = ok(byte, "every Side code is a single ASCII byte");
+            assert_eq!(Side::try_from(byte), Ok(side));
+        }
+    }
+
+    #[test]
+    fn test_side_try_from_unknown_byte_is_typed_error() {
+        assert_eq!(Side::try_from(b'X'), Err(InvalidSide::new(b'X')));
+        let Err(err) = Side::try_from(0xff) else {
+            panic!("0xff is not a Side code");
+        };
+        assert_eq!(err.value(), 0xff);
+        assert_eq!(err.to_string(), "0xff is not a FIX Side (tag 54) code");
     }
 
     #[test]

--- a/ironfix-derive/src/lib.rs
+++ b/ironfix-derive/src/lib.rs
@@ -93,7 +93,7 @@ pub fn derive_fix_field(input: TokenStream) -> TokenStream {
                 todo!("FixField::decode not yet implemented for {}", stringify!(#name))
             }
 
-            fn encode(value: &Self::Value, buf: &mut Vec<u8>) {
+            fn encode(value: &Self::Value, buf: &mut Vec<u8>) -> Result<(), EncodeError> {
                 todo!("FixField::encode not yet implemented for {}", stringify!(#name))
             }
         }

--- a/ironfix-engine/src/wire.rs
+++ b/ironfix-engine/src/wire.rs
@@ -396,10 +396,10 @@ mod tests {
     use ironfix_core::types::CompId;
 
     fn config_for(begin_string: &str) -> SessionConfig {
-        let Some(sender) = CompId::new("CLIENT") else {
+        let Ok(sender) = CompId::new("CLIENT") else {
             unreachable!("CLIENT is a valid CompId")
         };
-        let Some(target) = CompId::new("VENUE") else {
+        let Ok(target) = CompId::new("VENUE") else {
             unreachable!("VENUE is a valid CompId")
         };
         SessionConfig::new(sender, target, begin_string)

--- a/ironfix-engine/tests/initiator_tests.rs
+++ b/ironfix-engine/tests/initiator_tests.rs
@@ -48,7 +48,7 @@ fn some<T>(value: Option<T>, what: &str) -> T {
 /// Builds a CompID for the test fixtures.
 #[track_caller]
 fn comp_id(value: &str) -> CompId {
-    some(CompId::new(value), "test CompId must be valid")
+    ok(CompId::new(value), "test CompId must be valid")
 }
 
 /// Stub-acceptor side frame builder (VENUE -> CLIENT).


### PR DESCRIPTION
## Summary

A sweep of `ironfix-core` correctness and API hygiene. Core is the root of the crate DAG, so every one of these defects is reachable from every crate above it.

Closes #16.

## Stack

- **Base branch:** `fix/6-fast-primitive-codec` (PR #30)
- **Stack:** #25 → #30 → **#16 (this PR)** → the remaining open issues
- Review against the base branch; merge bottom-up.

## What was wrong

**Header injection via `CompId`.** The constructor checked only length, and the engine writes CompIds unescaped into tags 49/56 on **every outbound message**. A hostile identifier containing SOH or `=` therefore injected arbitrary header fields or corrupted framing. Now rejected with a typed error at the constructor — core is the right chokepoint, since validating downstream would leave every other caller exposed.

**`is_admin()` disagreed with the dictionary.** `XMLnonFIX` ('n') is `msgcat='admin'` in the vendored `FIX44.xml`, but the hard-coded list omitted it, so inbound 'n' routed through the application path instead of the session path.

**`Timestamp` lost data silently.** An out-of-range instant became zero — a forbidden silent default, on the type that carries a parsed SendingTime — negative values wrapped through a `u64` cast, and `from_millis` multiplied unchecked. The conversions are fallible now, with the representable range documented.

**`FieldTag`** put 5000 on the wrong side of the user-defined boundary (FIX reserves 5000–9999) and documented "must be > 0" without enforcing it.

**`OwnedMessage::from_raw`** computed field offsets by subtracting raw pointers, which wraps for any `FieldRef` that does not borrow from the message buffer.

**`FixField::encode` was infallible** while `FixMessage::encode` returns `Result`, so a value that cannot be legally encoded — SOH inside a string, a length bound exceeded, exactly what `EncodeError` exists for — had nowhere to report it. There are no implementors yet, so it becomes fallible now, before `ironfix-derive` and `ironfix-codegen` build on it.

**`MsgType` had a silent-drift risk and an equality trap.** `FromStr` and `as_str` duplicated a sixty-arm mapping that could drift undetected, because the fallback is `Custom` and `FromStr` is `Infallible`. Both directions now come from one table. Separately, `Custom("D")` compared unequal to `NewOrderSingle` despite encoding identical bytes, so a `Custom` value missed its own entry in any `MsgType`-keyed map; equality and `Hash` now follow the on-the-wire form.

Dead `DecodeError` variants are removed.

## Public API changes (semver)

Workspace is at 0.4.0, which covers all of it. Breaking: `CompId` construction is fallible; `Timestamp` epoch conversions are fallible; `FixField::encode` returns `Result`; `MsgType`'s `PartialEq`/`Hash` are hand-written rather than derived; dead `DecodeError` variants removed.

Fallout outside `ironfix-core` was mechanical and is limited to three call sites (`ironfix-derive`, `ironfix-engine/src/wire.rs`, and one engine test).

## Not in scope

`MsgType::Custom` still owns a `String`, so an unrecognised MsgType still allocates once per message. That is issue #26, deliberately kept separate so the two changes do not collide.

## Tests

Workspace goes from 304 to **343 passing**, including the previously untested money-critical accessors.

## Verification

```
cargo test --workspace                                    # 343 passed
cargo clippy --all-targets --all-features -- -D warnings  # clean
cargo fmt --all --check                                   # clean
make doc                                                  # clean
```
