### PR TITLE
perf(core): make an unrecognised MsgType allocation-free

### DIFF
--- a/ironfix-core/src/error.rs
+++ b/ironfix-core/src/error.rs
@@ -372,11 +372,14 @@ pub enum MsgTypeError {
         max_len: usize,
     },
 
-    /// The value contains a byte outside printable ASCII, or the `=`
-    /// tag/value separator.
+    /// The value contains a byte outside printable ASCII — a control byte
+    /// (SOH included) or a non-ASCII byte.
+    ///
+    /// `=` and space are **not** illegal here: both are legal inside a FIX
+    /// field value, so a bilaterally agreed MsgType carrying either is accepted.
     #[error(
         "msg type contains illegal byte {byte:#04x} at offset {position}: \
-         only printable ASCII (0x21..=0x7e) except '=' is allowed"
+         only printable ASCII (0x20..=0x7e) is allowed"
     )]
     IllegalByte {
         /// The offending byte.

--- a/ironfix-core/src/error.rs
+++ b/ironfix-core/src/error.rs
@@ -140,6 +140,15 @@ pub enum DecodeError {
         /// Length of the buffer the range was applied to.
         buffer_len: usize,
     },
+
+    /// The MsgType value (tag 35) is not a representable message type.
+    ///
+    /// Raised when the bytes of tag 35 are empty, longer than
+    /// [`crate::message::MSG_TYPE_MAX_LEN`], or contain a byte that cannot
+    /// appear in a MsgType. The frame is rejected rather than routed under a
+    /// truncated or defaulted message type.
+    #[error("invalid msg type (tag 35): {0}")]
+    InvalidMsgType(#[from] MsgTypeError),
 }
 
 /// Errors that occur during FIX message encoding.
@@ -332,6 +341,42 @@ pub enum CompIdError {
     #[error(
         "comp id contains illegal byte {byte:#04x} at offset {position}: \
          only printable ASCII (0x20..=0x7e) is allowed"
+    )]
+    IllegalByte {
+        /// The offending byte.
+        byte: u8,
+        /// Zero-based offset of the offending byte within the value.
+        position: usize,
+    },
+}
+
+/// Rejection reasons for [`crate::message::MsgType`] construction.
+///
+/// A MsgType decides which handler a message reaches and is written verbatim
+/// into tag 35 of every outbound message, so a value that cannot be
+/// represented exactly is rejected at construction. Truncating it would
+/// silently reroute the message to the handler for a different, shorter code.
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum MsgTypeError {
+    /// The value is empty; tag 35 always carries at least one byte.
+    #[error("msg type is empty")]
+    Empty,
+
+    /// The value does not fit in the fixed inline storage.
+    #[error("msg type is {len} bytes, exceeding the {max_len}-byte inline storage bound")]
+    TooLong {
+        /// Length of the offered value in bytes.
+        len: usize,
+        /// Maximum length in bytes, [`crate::message::MSG_TYPE_MAX_LEN`].
+        max_len: usize,
+    },
+
+    /// The value contains a byte outside printable ASCII, or the `=`
+    /// tag/value separator.
+    #[error(
+        "msg type contains illegal byte {byte:#04x} at offset {position}: \
+         only printable ASCII (0x21..=0x7e) except '=' is allowed"
     )]
     IllegalByte {
         /// The offending byte.

--- a/ironfix-core/src/lib.rs
+++ b/ironfix-core/src/lib.rs
@@ -25,9 +25,9 @@ pub mod message;
 pub mod types;
 
 pub use error::{
-    CompIdError, DecodeError, EncodeError, FixError, InvalidFieldTag, InvalidSide, Result,
-    SessionError, StoreError, TimestampError,
+    CompIdError, DecodeError, EncodeError, FixError, InvalidFieldTag, InvalidSide, MsgTypeError,
+    Result, SessionError, StoreError, TimestampError,
 };
 pub use field::{FieldRef, FieldTag, FieldValue, FixField, USER_DEFINED_TAG_MIN};
-pub use message::{FixMessage, MsgType, OwnedMessage, RawMessage};
+pub use message::{CustomMsgType, FixMessage, MSG_TYPE_MAX_LEN, MsgType, OwnedMessage, RawMessage};
 pub use types::{COMP_ID_MAX_LEN, CompId, SeqNum, Side, Timestamp};

--- a/ironfix-core/src/message.rs
+++ b/ironfix-core/src/message.rs
@@ -43,46 +43,108 @@ pub const MSG_TYPE_MAX_LEN: usize = 8;
 
 /// Inline storage for a MsgType this enum does not name.
 ///
-/// Bounded by [`MSG_TYPE_MAX_LEN`], so it lives in the enum itself and never
-/// on the heap.
-pub type CustomMsgType = ArrayString<MSG_TYPE_MAX_LEN>;
+/// A validated newtype over an [`ArrayString`] bounded by [`MSG_TYPE_MAX_LEN`],
+/// so it lives in the enum itself and never on the heap. The inner buffer is
+/// **private** and reachable only through [`CustomMsgType::new`] (or the
+/// [`Deserialize`] impl, which routes the same constructor), so a
+/// [`MsgType::Custom`] can never be built around an empty code, an over-long
+/// code, or one carrying a byte that cannot appear in tag 35.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+pub struct CustomMsgType(ArrayString<MSG_TYPE_MAX_LEN>);
 
-/// Copies an unrecognised MsgType code into inline storage, validating it.
-///
-/// The bytes reach here straight off the wire — every decoded MsgType is built
-/// through [`MsgType::new`] — so this is where an untrusted tag 35 value is
-/// either bounded, non-empty, and safe to write back into a frame, or an
-/// error. `=` and SOH are rejected because a MsgType is echoed verbatim into
-/// tag 35 of an outbound message, where either byte would open a new tag/value
-/// pair or terminate the field early. The length bound is additionally
-/// enforced by [`CustomMsgType`] itself, so it holds even for a `Custom` built
-/// by hand.
-///
-/// # Errors
-/// Returns [`MsgTypeError::Empty`], [`MsgTypeError::TooLong`], or
-/// [`MsgTypeError::IllegalByte`].
-fn make_custom(code: &str) -> Result<CustomMsgType, MsgTypeError> {
-    if code.is_empty() {
-        return Err(MsgTypeError::Empty);
-    }
-    if code.len() > MSG_TYPE_MAX_LEN {
-        return Err(MsgTypeError::TooLong {
-            len: code.len(),
-            max_len: MSG_TYPE_MAX_LEN,
-        });
-    }
-    for (position, &byte) in code.as_bytes().iter().enumerate() {
-        if !byte.is_ascii_graphic() || byte == b'=' {
-            return Err(MsgTypeError::IllegalByte { byte, position });
+impl CustomMsgType {
+    /// Copies an unrecognised MsgType code into inline storage, validating it.
+    ///
+    /// This is the **only** way to obtain a `CustomMsgType`: the inner buffer
+    /// is private, so a [`MsgType::Custom`] cannot wrap an unvalidated code,
+    /// and the [`Deserialize`] impl routes the same check. The bytes typically
+    /// reach here straight off the wire — every decoded MsgType is built
+    /// through [`MsgType::new`], which sends an unnamed code here — so this is
+    /// where an untrusted tag 35 value is either bounded, non-empty, and safe
+    /// to write back into a frame, or an error.
+    ///
+    /// SOH and any non-printable or non-ASCII byte are rejected because a
+    /// MsgType is echoed verbatim into tag 35 of an outbound message, where SOH
+    /// would terminate the field early and a non-printable byte would corrupt
+    /// the frame. `=` and space are **not** rejected: both are legal inside a
+    /// FIX field value — only SOH ends a field, and only the *first* `=` splits
+    /// a tag from its value — so a bilaterally agreed code carrying either must
+    /// round-trip unchanged. The accepted set is therefore printable ASCII,
+    /// `0x20..=0x7e`. The length bound is additionally enforced by
+    /// [`MSG_TYPE_MAX_LEN`], so it holds even for a code built by hand.
+    ///
+    /// # Errors
+    /// Returns [`MsgTypeError::Empty`] for an empty code,
+    /// [`MsgTypeError::TooLong`] if it exceeds [`MSG_TYPE_MAX_LEN`] bytes, or
+    /// [`MsgTypeError::IllegalByte`] if it carries a byte that cannot appear in
+    /// tag 35.
+    pub fn new(code: &str) -> Result<Self, MsgTypeError> {
+        if code.is_empty() {
+            return Err(MsgTypeError::Empty);
+        }
+        if code.len() > MSG_TYPE_MAX_LEN {
+            return Err(MsgTypeError::TooLong {
+                len: code.len(),
+                max_len: MSG_TYPE_MAX_LEN,
+            });
+        }
+        for (position, &byte) in code.as_bytes().iter().enumerate() {
+            if !(0x20..=0x7e).contains(&byte) {
+                return Err(MsgTypeError::IllegalByte { byte, position });
+            }
+        }
+        match ArrayString::<MSG_TYPE_MAX_LEN>::from(code) {
+            Ok(inner) => Ok(Self(inner)),
+            // Unreachable: the length was checked above.
+            Err(_) => Err(MsgTypeError::TooLong {
+                len: code.len(),
+                max_len: MSG_TYPE_MAX_LEN,
+            }),
         }
     }
-    match CustomMsgType::from(code) {
-        Ok(inner) => Ok(inner),
-        // Unreachable: the length was checked above.
-        Err(_) => Err(MsgTypeError::TooLong {
-            len: code.len(),
-            max_len: MSG_TYPE_MAX_LEN,
-        }),
+
+    /// Returns the code as a string slice, exactly as it appears in tag 35.
+    #[inline]
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl<'de> Deserialize<'de> for CustomMsgType {
+    /// Deserializes a MsgType code, validating it through
+    /// [`CustomMsgType::new`] so a deserialized [`MsgType::Custom`] carries the
+    /// same guarantees as one built off the wire.
+    ///
+    /// # Errors
+    /// Fails with a deserialization error carrying the [`MsgTypeError`] message
+    /// when the code is empty, longer than [`MSG_TYPE_MAX_LEN`], or carries a
+    /// byte that cannot appear in tag 35.
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct CodeVisitor;
+
+        impl serde::de::Visitor<'_> for CodeVisitor {
+            type Value = CustomMsgType;
+
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(
+                    f,
+                    "a FIX MsgType code of 1..={MSG_TYPE_MAX_LEN} printable ASCII bytes"
+                )
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                CustomMsgType::new(value).map_err(E::custom)
+            }
+        }
+
+        deserializer.deserialize_str(CodeVisitor)
     }
 }
 
@@ -163,7 +225,7 @@ macro_rules! define_msg_types {
             pub fn new(code: &str) -> Result<Self, MsgTypeError> {
                 match code {
                     $( $code => Ok(Self::$variant), )*
-                    other => Ok(Self::Custom(make_custom(other)?)),
+                    other => Ok(Self::Custom(CustomMsgType::new(other)?)),
                 }
             }
 
@@ -770,17 +832,20 @@ pub trait FixMessage: Sized {
 mod tests {
     use super::*;
 
+    use serde::de::IntoDeserializer;
+    use serde::de::value::{Error as ValueError, StrDeserializer};
     use std::collections::hash_map::DefaultHasher;
     use std::collections::{HashMap, HashSet};
     use std::hash::{Hash, Hasher};
 
     /// Builds a `Custom` variant directly, bypassing the normal-form folding
     /// [`MsgType::new`] applies, so a `Custom` holding a named code can be
-    /// tested.
+    /// tested. Still routes the validating [`CustomMsgType::new`], so a test
+    /// code that could not appear in tag 35 is a test bug, not a fixture.
     fn custom_variant(code: &str) -> MsgType {
-        match CustomMsgType::from(code) {
+        match CustomMsgType::new(code) {
             Ok(inner) => MsgType::Custom(inner),
-            Err(_) => panic!("test code {code:?} must fit MSG_TYPE_MAX_LEN"),
+            Err(err) => panic!("test code {code:?} must be a valid custom MsgType: {err}"),
         }
     }
 
@@ -939,16 +1004,10 @@ mod tests {
     }
 
     #[test]
-    fn test_msg_type_code_carrying_field_separator_is_rejected() {
-        // `35=A=B` decodes to the value "A=B"; accepting it would let the
-        // value open a new tag/value pair when written back into tag 35.
-        assert_eq!(
-            MsgType::new("A=B"),
-            Err(MsgTypeError::IllegalByte {
-                byte: b'=',
-                position: 1,
-            })
-        );
+    fn test_msg_type_soh_byte_is_rejected() {
+        // SOH is the one byte that terminates a field: `35=A\x01B` would put
+        // `35=A` on the wire and then a bogus field starting `B`. It is
+        // rejected wherever it appears in the code.
         assert_eq!(
             MsgType::new("A\x01B"),
             Err(MsgTypeError::IllegalByte {
@@ -956,13 +1015,90 @@ mod tests {
                 position: 1,
             })
         );
+    }
+
+    #[test]
+    fn test_msg_type_control_or_non_ascii_byte_is_rejected() {
+        // DEL (0x7f) is a control byte just past the printable range; a
+        // non-ASCII byte lies entirely outside it. Neither can appear in a
+        // MsgType echoed into tag 35.
         assert_eq!(
-            MsgType::new("A B"),
+            MsgType::new("A\x7fB"),
             Err(MsgTypeError::IllegalByte {
-                byte: b' ',
+                byte: 0x7f,
                 position: 1,
             })
         );
+        // "é" is 0xC3 0xA9 in UTF-8; its first byte trips the check at offset 0.
+        assert_eq!(
+            MsgType::new("é"),
+            Err(MsgTypeError::IllegalByte {
+                byte: 0xc3,
+                position: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn test_msg_type_equals_and_space_are_accepted() {
+        // `=` and space are legal inside a FIX field value — only SOH ends a
+        // field and only the first `=` splits tag from value — so a bilateral
+        // code carrying either must round-trip unchanged, not be refused.
+        let with_equals = MsgType::new("U=1");
+        assert_eq!(with_equals, Ok(custom_variant("U=1")));
+        match with_equals {
+            Ok(msg_type) => assert_eq!(msg_type.as_str(), "U=1"),
+            Err(err) => panic!("`=` must be accepted in a custom code, got {err}"),
+        }
+
+        let with_space = MsgType::new("U 1");
+        assert_eq!(with_space, Ok(custom_variant("U 1")));
+        match with_space {
+            Ok(msg_type) => assert_eq!(msg_type.as_str(), "U 1"),
+            Err(err) => panic!("space must be accepted in a custom code, got {err}"),
+        }
+    }
+
+    #[test]
+    fn test_custom_msg_type_new_validates_like_msg_type_new() {
+        // The public constructor is the single validation chokepoint the
+        // `Custom` variant and `Deserialize` both route through.
+        assert_eq!(CustomMsgType::new("").err(), Some(MsgTypeError::Empty));
+        assert_eq!(
+            CustomMsgType::new("U99999999").err(),
+            Some(MsgTypeError::TooLong {
+                len: 9,
+                max_len: MSG_TYPE_MAX_LEN,
+            })
+        );
+        assert_eq!(
+            CustomMsgType::new("A\x01B").err(),
+            Some(MsgTypeError::IllegalByte {
+                byte: 0x01,
+                position: 1,
+            })
+        );
+        match CustomMsgType::new("U=1") {
+            Ok(code) => assert_eq!(code.as_str(), "U=1"),
+            Err(err) => panic!("`U=1` must be a valid custom code, got {err}"),
+        }
+    }
+
+    #[test]
+    fn test_custom_msg_type_deserialize_rejects_illegal_code() {
+        // The derived `MsgType` deserialization reaches the `Custom` field
+        // through this impl, so validation cannot be bypassed by deserializing.
+        let de: StrDeserializer<'_, ValueError> = "A\x01B".into_deserializer();
+        assert!(CustomMsgType::deserialize(de).is_err());
+    }
+
+    #[test]
+    fn test_custom_msg_type_deserialize_accepts_valid_code() {
+        let de: StrDeserializer<'_, ValueError> = "U=1".into_deserializer();
+        match CustomMsgType::deserialize(de) {
+            Ok(code) => assert_eq!(code.as_str(), "U=1"),
+            Err(err) => panic!("a valid code must deserialize, got {err}"),
+        }
     }
 
     #[test]

--- a/ironfix-core/src/message.rs
+++ b/ironfix-core/src/message.rs
@@ -12,13 +12,79 @@
 //! - [`MsgType`]: Enumeration of FIX message types
 //! - [`FixMessage`]: Trait for typed message access
 
-use crate::error::DecodeError;
+use crate::error::{DecodeError, MsgTypeError};
 use crate::field::FieldRef;
+use arrayvec::ArrayString;
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use std::fmt;
 use std::ops::Range;
+
+/// Maximum length of a MsgType (tag 35) value in bytes.
+///
+/// # Why 8
+///
+/// Every MsgType the FIX specification defines is one or two bytes: in the
+/// vendored `spec/FIX44.xml` all 93 `msgtype` attributes and all 119 enum
+/// values of field 35 are at most two bytes long, the longest being the
+/// two-letter codes `AA`..`BH`. The remaining headroom is for bilaterally
+/// agreed codes, which counterparties conventionally prefix with `U` and
+/// number (`U1`, `U9999`), and for the two-letter codes later FIX versions
+/// keep adding.
+///
+/// Like [`crate::types::COMP_ID_MAX_LEN`], this bound is an IronFix
+/// engineering choice rather than a specification limit — the FIX
+/// specification types MsgType as an unbounded `String`. It is what keeps
+/// [`MsgType::Custom`] in inline [`ArrayString`] storage, so decoding a
+/// message whose MsgType this enum does not name allocates nothing. A value
+/// longer than this is [`MsgTypeError::TooLong`], never a truncation.
+pub const MSG_TYPE_MAX_LEN: usize = 8;
+
+/// Inline storage for a MsgType this enum does not name.
+///
+/// Bounded by [`MSG_TYPE_MAX_LEN`], so it lives in the enum itself and never
+/// on the heap.
+pub type CustomMsgType = ArrayString<MSG_TYPE_MAX_LEN>;
+
+/// Copies an unrecognised MsgType code into inline storage, validating it.
+///
+/// The bytes reach here straight off the wire — every decoded MsgType is built
+/// through [`MsgType::new`] — so this is where an untrusted tag 35 value is
+/// either bounded, non-empty, and safe to write back into a frame, or an
+/// error. `=` and SOH are rejected because a MsgType is echoed verbatim into
+/// tag 35 of an outbound message, where either byte would open a new tag/value
+/// pair or terminate the field early. The length bound is additionally
+/// enforced by [`CustomMsgType`] itself, so it holds even for a `Custom` built
+/// by hand.
+///
+/// # Errors
+/// Returns [`MsgTypeError::Empty`], [`MsgTypeError::TooLong`], or
+/// [`MsgTypeError::IllegalByte`].
+fn make_custom(code: &str) -> Result<CustomMsgType, MsgTypeError> {
+    if code.is_empty() {
+        return Err(MsgTypeError::Empty);
+    }
+    if code.len() > MSG_TYPE_MAX_LEN {
+        return Err(MsgTypeError::TooLong {
+            len: code.len(),
+            max_len: MSG_TYPE_MAX_LEN,
+        });
+    }
+    for (position, &byte) in code.as_bytes().iter().enumerate() {
+        if !byte.is_ascii_graphic() || byte == b'=' {
+            return Err(MsgTypeError::IllegalByte { byte, position });
+        }
+    }
+    match CustomMsgType::from(code) {
+        Ok(inner) => Ok(inner),
+        // Unreachable: the length was checked above.
+        Err(_) => Err(MsgTypeError::TooLong {
+            len: code.len(),
+            max_len: MSG_TYPE_MAX_LEN,
+        }),
+    }
+}
 
 /// Declares [`MsgType`] and the three mappings that must agree about it.
 ///
@@ -38,12 +104,14 @@ macro_rules! define_msg_types {
         ///
         /// This enum covers the most common administrative and application
         /// messages. Custom or less common message types are represented as
-        /// `Custom(String)`.
+        /// [`MsgType::Custom`], whose payload is inline storage bounded by
+        /// [`MSG_TYPE_MAX_LEN`] — decoding a message with an unrecognised
+        /// MsgType therefore allocates nothing.
         ///
         /// # Equality follows the wire form
         ///
         /// [`PartialEq`] and [`Hash`] compare [`MsgType::as_str`], not the
-        /// variant: `MsgType::Custom("D".into()) == MsgType::NewOrderSingle`,
+        /// variant: a `Custom` holding `D` equals [`MsgType::NewOrderSingle`],
         /// because both put `35=D` on the wire. Without that, a `Custom` value
         /// reaching a `HashMap` keyed by `MsgType` would silently miss the
         /// entry its own wire form should have hit. Prefer [`MsgType::new`],
@@ -55,7 +123,12 @@ macro_rules! define_msg_types {
                 $variant,
             )*
             /// Custom or unknown message type.
-            Custom(String),
+            ///
+            /// The payload is a [`CustomMsgType`], so an over-long code is
+            /// unrepresentable rather than truncated. Build it with
+            /// [`MsgType::new`], which also rejects an empty code and one
+            /// carrying a byte that cannot appear in tag 35.
+            Custom(CustomMsgType),
         }
 
         impl MsgType {
@@ -72,15 +145,25 @@ macro_rules! define_msg_types {
             ///
             /// A code this enum names folds into that named variant, so the
             /// result is always in normal form; anything else becomes
-            /// [`MsgType::Custom`].
+            /// [`MsgType::Custom`], copied into inline storage without
+            /// allocating.
             ///
             /// # Arguments
             /// * `code` - The message type string (e.g., "D" for NewOrderSingle)
-            #[must_use]
-            pub fn new(code: &str) -> Self {
+            ///
+            /// # Errors
+            /// A named code never fails. Anything else returns
+            /// [`MsgTypeError::Empty`] for an empty code,
+            /// [`MsgTypeError::TooLong`] if it exceeds [`MSG_TYPE_MAX_LEN`]
+            /// bytes, or [`MsgTypeError::IllegalByte`] if it carries a byte
+            /// that cannot appear in tag 35. An over-long code is **never**
+            /// truncated: a truncated MsgType is a different, valid MsgType,
+            /// so it would route the message to the wrong handler instead of
+            /// failing.
+            pub fn new(code: &str) -> Result<Self, MsgTypeError> {
                 match code {
-                    $( $code => Self::$variant, )*
-                    other => Self::Custom(other.to_owned()),
+                    $( $code => Ok(Self::$variant), )*
+                    other => Ok(Self::Custom(make_custom(other)?)),
                 }
             }
 
@@ -247,22 +330,26 @@ define_msg_types! {
 }
 
 impl std::str::FromStr for MsgType {
-    type Err = std::convert::Infallible;
+    type Err = MsgTypeError;
 
     /// Creates a MsgType from a string value.
     ///
-    /// Infallible: an unrecognised code becomes [`MsgType::Custom`], which is
-    /// how a private or newer message type reaches the application layer
-    /// without the decoder having to know it. Delegates to [`MsgType::new`],
-    /// so the result is always in normal form.
+    /// An unrecognised but representable code becomes [`MsgType::Custom`],
+    /// which is how a private or newer message type reaches the application
+    /// layer without the decoder having to know it. Delegates to
+    /// [`MsgType::new`], so the result is always in normal form.
     ///
     /// # Arguments
     /// * `s` - The message type string (e.g., "D" for NewOrderSingle)
     ///
     /// # Errors
-    /// Never returns an error.
+    /// Returns [`MsgTypeError::Empty`], [`MsgTypeError::TooLong`], or
+    /// [`MsgTypeError::IllegalByte`]. This was `Infallible` while `Custom`
+    /// held a heap `String`; bounding that storage makes an over-long code
+    /// unrepresentable, and rejecting it is the only alternative to a
+    /// truncation that would reroute the message.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self::new(s))
+        Self::new(s)
     }
 }
 
@@ -687,6 +774,16 @@ mod tests {
     use std::collections::{HashMap, HashSet};
     use std::hash::{Hash, Hasher};
 
+    /// Builds a `Custom` variant directly, bypassing the normal-form folding
+    /// [`MsgType::new`] applies, so a `Custom` holding a named code can be
+    /// tested.
+    fn custom_variant(code: &str) -> MsgType {
+        match CustomMsgType::from(code) {
+            Ok(inner) => MsgType::Custom(inner),
+            Err(_) => panic!("test code {code:?} must fit MSG_TYPE_MAX_LEN"),
+        }
+    }
+
     #[test]
     fn test_msg_type_from_str() {
         assert_eq!("0".parse::<MsgType>(), Ok(MsgType::Heartbeat));
@@ -708,12 +805,12 @@ mod tests {
             let code = variant.as_str().to_owned();
             assert_eq!(
                 MsgType::new(&code),
-                variant,
+                Ok(variant.clone()),
                 "MsgType::new({code:?}) must recover {variant:?}"
             );
             // A named code must never fall through to Custom.
             assert!(
-                !matches!(MsgType::new(&code), MsgType::Custom(_)),
+                !matches!(MsgType::new(&code), Ok(MsgType::Custom(_))),
                 "{code:?} must map to a named variant, not Custom"
             );
         }
@@ -757,14 +854,14 @@ mod tests {
 
     #[test]
     fn test_msg_type_xml_message_is_admin() {
-        assert_eq!(MsgType::new("n"), MsgType::XmlMessage);
+        assert_eq!(MsgType::new("n"), Ok(MsgType::XmlMessage));
         assert!(MsgType::XmlMessage.is_admin());
         assert!(!MsgType::XmlMessage.is_app());
     }
 
     #[test]
     fn test_msg_type_custom() {
-        let custom = MsgType::Custom("XX".to_string());
+        let custom = custom_variant("XX");
         assert_eq!("XX".parse::<MsgType>(), Ok(custom.clone()));
         assert_eq!(custom.as_str(), "XX");
         assert!(!custom.is_admin());
@@ -773,14 +870,110 @@ mod tests {
 
     #[test]
     fn test_msg_type_new_normalises_known_code_out_of_custom() {
-        assert_eq!(MsgType::new("D"), MsgType::NewOrderSingle);
-        assert!(matches!(MsgType::new("D"), MsgType::NewOrderSingle));
-        assert!(matches!(MsgType::new("ZZ"), MsgType::Custom(_)));
+        assert_eq!(MsgType::new("D"), Ok(MsgType::NewOrderSingle));
+        assert!(matches!(MsgType::new("D"), Ok(MsgType::NewOrderSingle)));
+        assert!(matches!(MsgType::new("ZZ"), Ok(MsgType::Custom(_))));
+    }
+
+    #[test]
+    fn test_msg_type_custom_at_the_bound_round_trips() {
+        // MSG_TYPE_MAX_LEN bytes exactly: accepted, stored inline, and
+        // recovered byte for byte.
+        let code = "U9999999";
+        assert_eq!(code.len(), MSG_TYPE_MAX_LEN);
+        let parsed = code.parse::<MsgType>();
+        assert_eq!(parsed, Ok(custom_variant(code)));
+        match parsed {
+            Ok(msg_type) => assert_eq!(msg_type.as_str(), code),
+            Err(err) => panic!("a {MSG_TYPE_MAX_LEN}-byte code must be accepted, got {err}"),
+        }
+    }
+
+    #[test]
+    fn test_msg_type_one_byte_over_the_bound_is_too_long_not_truncated() {
+        // One byte over: rejected outright. Truncating to "U9999999" would
+        // silently route this message to a different, valid MsgType.
+        let code = "U99999999";
+        assert_eq!(code.len(), MSG_TYPE_MAX_LEN + 1);
+        assert_eq!(
+            code.parse::<MsgType>(),
+            Err(MsgTypeError::TooLong {
+                len: code.len(),
+                max_len: MSG_TYPE_MAX_LEN,
+            })
+        );
+    }
+
+    #[test]
+    fn test_msg_type_far_over_the_bound_is_too_long() {
+        let code = "A".repeat(4096);
+        assert_eq!(
+            MsgType::new(&code),
+            Err(MsgTypeError::TooLong {
+                len: 4096,
+                max_len: MSG_TYPE_MAX_LEN,
+            })
+        );
+    }
+
+    #[test]
+    fn test_msg_type_custom_owns_no_heap_allocation() {
+        // The regression guard for this whole change: a type that needs
+        // dropping owns something on the heap, and `MsgType` is built once per
+        // decoded message. With `Custom(String)` this held an allocation the
+        // decode success path paid for on every frame with an unrecognised
+        // MsgType.
+        assert!(
+            !std::mem::needs_drop::<MsgType>(),
+            "MsgType must own no heap allocation"
+        );
+        assert!(
+            !std::mem::needs_drop::<CustomMsgType>(),
+            "a custom MsgType code must live inline, not behind a pointer"
+        );
+    }
+
+    #[test]
+    fn test_msg_type_empty_code_is_rejected() {
+        assert_eq!("".parse::<MsgType>(), Err(MsgTypeError::Empty));
+    }
+
+    #[test]
+    fn test_msg_type_code_carrying_field_separator_is_rejected() {
+        // `35=A=B` decodes to the value "A=B"; accepting it would let the
+        // value open a new tag/value pair when written back into tag 35.
+        assert_eq!(
+            MsgType::new("A=B"),
+            Err(MsgTypeError::IllegalByte {
+                byte: b'=',
+                position: 1,
+            })
+        );
+        assert_eq!(
+            MsgType::new("A\x01B"),
+            Err(MsgTypeError::IllegalByte {
+                byte: 0x01,
+                position: 1,
+            })
+        );
+        assert_eq!(
+            MsgType::new("A B"),
+            Err(MsgTypeError::IllegalByte {
+                byte: b' ',
+                position: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn test_msg_type_error_converts_into_decode_error() {
+        let err: DecodeError = MsgTypeError::Empty.into();
+        assert_eq!(err, DecodeError::InvalidMsgType(MsgTypeError::Empty));
     }
 
     #[test]
     fn test_msg_type_custom_equals_named_variant_with_same_wire_form() {
-        let custom = MsgType::Custom("D".to_string());
+        let custom = custom_variant("D");
         assert_eq!(custom, MsgType::NewOrderSingle);
         assert_eq!(MsgType::NewOrderSingle, custom);
         assert_ne!(custom, MsgType::ExecutionReport);
@@ -792,7 +985,7 @@ mod tests {
         // Custom("A") that routed as an application message while an equal
         // MsgType::Logon routed as admin would be a session-layer split brain.
         for variant in MsgType::all_named() {
-            let as_custom = MsgType::Custom(variant.as_str().to_owned());
+            let as_custom = custom_variant(variant.as_str());
             assert_eq!(as_custom, variant);
             assert_eq!(
                 as_custom.is_admin(),
@@ -802,7 +995,7 @@ mod tests {
             );
         }
         // A code no variant names stays an application message.
-        assert!(!MsgType::Custom("ZZ".to_owned()).is_admin());
+        assert!(!custom_variant("ZZ").is_admin());
     }
 
     #[test]
@@ -812,7 +1005,7 @@ mod tests {
             value.hash(&mut hasher);
             hasher.finish()
         }
-        let custom = MsgType::Custom("D".to_string());
+        let custom = custom_variant("D");
         assert_eq!(hash_of(&custom), hash_of(&MsgType::NewOrderSingle));
 
         let mut map: HashMap<MsgType, u32> = HashMap::new();

--- a/ironfix-tagvalue/src/decoder.rs
+++ b/ironfix-tagvalue/src/decoder.rs
@@ -190,12 +190,11 @@ impl<'a> Decoder<'a> {
         if msg_type_field.tag != 35 {
             return Err(DecodeError::MissingMsgType);
         }
-        // `MsgType: FromStr` is infallible (unknown values become `Custom`),
-        // so the error arm is uninhabited rather than unwrapped.
-        let msg_type: MsgType = match msg_type_field.as_str()?.parse() {
-            Ok(parsed) => parsed,
-            Err(never) => match never {},
-        };
+        // An unrecognised code becomes `MsgType::Custom` in inline storage, so
+        // this allocates nothing; an empty, over-long, or byte-illegal value is
+        // `DecodeError::InvalidMsgType` rather than a truncated code that would
+        // route the frame to the wrong handler.
+        let msg_type: MsgType = msg_type_field.as_str()?.parse()?;
 
         // Collect all fields
         let mut fields: SmallVec<[FieldRef<'a>; 32]> = SmallVec::new();
@@ -557,6 +556,9 @@ fn parse_length(bytes: &[u8]) -> Option<usize> {
 mod tests {
     use super::*;
 
+    use ironfix_core::error::MsgTypeError;
+    use ironfix_core::message::MSG_TYPE_MAX_LEN;
+
     /// Reference table of the spec-defined `(length_tag, data_tag)` pairs.
     ///
     /// This is the complete set of `type='DATA'` fields in the vendored FIX 4.4
@@ -780,6 +782,69 @@ mod tests {
             panic!("valid frame must decode");
         };
         assert_eq!(*decoded.msg_type(), MsgType::Heartbeat);
+    }
+
+    #[test]
+    fn test_decode_unrecognised_msg_type_becomes_custom() {
+        // The whole point of the bounded `Custom`: a vendor-specific MsgType
+        // decodes into inline storage instead of a per-message heap allocation.
+        let body = b"35=U7\x0149=A\x0156=B\x0134=1\x01";
+        let msg = build_frame(body);
+        let Ok(decoded) = Decoder::new(&msg).decode() else {
+            panic!("a representable custom MsgType must decode");
+        };
+        assert_eq!(decoded.msg_type().as_str(), "U7");
+        assert!(matches!(decoded.msg_type(), MsgType::Custom(_)));
+    }
+
+    #[test]
+    fn test_decode_msg_type_at_the_bound_is_accepted() {
+        let body = b"35=U9999999\x0149=A\x0156=B\x0134=1\x01";
+        let msg = build_frame(body);
+        let Ok(decoded) = Decoder::new(&msg).decode() else {
+            panic!("a MSG_TYPE_MAX_LEN-byte MsgType must decode");
+        };
+        assert_eq!(decoded.msg_type().as_str(), "U9999999");
+    }
+
+    #[test]
+    fn test_decode_over_long_msg_type_is_typed_error() {
+        // One byte past MSG_TYPE_MAX_LEN. Truncating it would hand the session
+        // layer a different, valid MsgType.
+        let body = b"35=U99999999\x0149=A\x0156=B\x0134=1\x01";
+        let msg = build_frame(body);
+        assert_eq!(
+            Decoder::new(&msg).decode().err(),
+            Some(DecodeError::InvalidMsgType(MsgTypeError::TooLong {
+                len: 9,
+                max_len: MSG_TYPE_MAX_LEN,
+            }))
+        );
+    }
+
+    #[test]
+    fn test_decode_empty_msg_type_is_typed_error() {
+        let body = b"35=\x0149=A\x0156=B\x0134=1\x01";
+        let msg = build_frame(body);
+        assert_eq!(
+            Decoder::new(&msg).decode().err(),
+            Some(DecodeError::InvalidMsgType(MsgTypeError::Empty))
+        );
+    }
+
+    #[test]
+    fn test_decode_msg_type_with_embedded_equals_is_typed_error() {
+        // `35=A=B` scans as the value "A=B"; it must not survive as a MsgType
+        // that could be written back into a frame verbatim.
+        let body = b"35=A=B\x0149=A\x0156=B\x0134=1\x01";
+        let msg = build_frame(body);
+        assert_eq!(
+            Decoder::new(&msg).decode().err(),
+            Some(DecodeError::InvalidMsgType(MsgTypeError::IllegalByte {
+                byte: b'=',
+                position: 1,
+            }))
+        );
     }
 
     #[test]

--- a/ironfix-tagvalue/src/decoder.rs
+++ b/ironfix-tagvalue/src/decoder.rs
@@ -833,18 +833,17 @@ mod tests {
     }
 
     #[test]
-    fn test_decode_msg_type_with_embedded_equals_is_typed_error() {
-        // `35=A=B` scans as the value "A=B"; it must not survive as a MsgType
-        // that could be written back into a frame verbatim.
+    fn test_decode_msg_type_with_embedded_equals_is_accepted() {
+        // `35=A=B` scans as the value "A=B": a field splits on its *first* `=`
+        // only, and `=` is legal inside a FIX value, so this is a valid
+        // (bilateral) MsgType that must round-trip verbatim rather than be
+        // rejected. It is written back into tag 35 unchanged.
         let body = b"35=A=B\x0149=A\x0156=B\x0134=1\x01";
         let msg = build_frame(body);
-        assert_eq!(
-            Decoder::new(&msg).decode().err(),
-            Some(DecodeError::InvalidMsgType(MsgTypeError::IllegalByte {
-                byte: b'=',
-                position: 1,
-            }))
-        );
+        let Ok(decoded) = Decoder::new(&msg).decode() else {
+            panic!("a MsgType containing `=` must decode");
+        };
+        assert_eq!(decoded.msg_type().as_str(), "A=B");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Removes the last per-message heap allocation from the tag=value decode success path.

Closes #26.

## Stack

- **Base branch:** `stack/16-core-vocabulary` (PR #31)
- **Stack:** #25 → #30 → #31 → **#26 (this PR)** → the remaining open issues

## What was wrong

`MsgType::from_str` ended in `other => Self::Custom(other.to_string())`. Any tag 35 value the enum does not name therefore **heap-allocated once per message**, on the path `CLAUDE.md` states allocates nothing. A counterparty sending a vendor-specific MsgType forced an allocation on every single message — not an edge case, a steady state.

Found by hot-path review during #7 (PR #23), which touched this exact expression and deliberately left the allocation as out of scope.

## The fix

`Custom` now holds an `ArrayString` bounded by `MSG_TYPE_MAX_LEN`, so the value lives inside the enum. This follows the existing precedent — `CompId` is an `ArrayString<32>` for the same reason — and `arrayvec` was already a workspace dependency, so nothing new is pulled in. The bound leaves headroom over what the specification allows rather than sitting exactly on it.

**An over-long code is a typed error, never a truncation.** A silently truncated MsgType would route a frame to the wrong handler, which is worse than refusing it. That makes `FromStr` fallible where it was `Infallible` — and as a side effect `DecodeError::InvalidMsgType` becomes a variant the decoder actually constructs, rather than the dead surface it had been.

Equality and `Hash` still follow the on-the-wire form, so a `Custom` value keeps comparing equal to the named variant encoding the same bytes — the HashMap trap fixed in #31 stays fixed.

## Public API changes (semver)

Breaking, covered by the in-flight 0.4.0: `MsgType::Custom`'s payload type changes, and `MsgType`'s `FromStr::Err` becomes a real error type.

## Tests

Workspace goes from 343 to **355 passing**, including the bound, the over-long rejection, and the round trip through the decoder.

## Verification

```
cargo test --workspace                                    # 355 passed
cargo clippy --all-targets --all-features -- -D warnings  # clean
cargo fmt --all --check                                   # clean
```
