### PR TITLE
refactor(core): give the FIX version mapping a single home

### DIFF
--- a/doc/fix_operations.md
+++ b/doc/fix_operations.md
@@ -930,10 +930,13 @@ session with `EngineError::UnsupportedVersion` before dialling; configure
 `FIX.5.0`, `FIX.5.0SP1` or `FIX.5.0SP2` instead. An unrecognised version string
 is refused the same way, rather than being passed through onto the wire.
 
-This table is duplicated from `ironfix_dictionary::schema::Version`, because
-`ironfix-engine` does not and must not depend on `ironfix-dictionary`. The two
-can drift apart and no test can cross-check them without taking that
-dependency; unifying them into `ironfix-core` is follow-up work.
+This table exists exactly once in the workspace, as `ironfix_core::FixVersion`
+(`ironfix-core/src/version.rs`). `ironfix-dictionary` re-exports it as
+`schema::Version` and `ironfix-engine` resolves the configured string to it in
+`wire::wire_version`, so the two consumers cannot drift — which matters because
+`ironfix-engine` does not and must not depend on `ironfix-dictionary`. Note the
+distinction the type draws: `FixVersion::as_str` is the version's own name
+(`FIX.5.0SP2`), `FixVersion::begin_string` is what goes in tag 8 (`FIXT.1.1`).
 
 **Not implemented for 5.0:** no application-version-driven validation of any
 kind. The `ApplVerID` values are stamped, not enforced, and the engine never

--- a/ironfix-core/src/error.rs
+++ b/ironfix-core/src/error.rs
@@ -471,6 +471,36 @@ impl InvalidSide {
     }
 }
 
+/// A string that names no [`FixVersion`](crate::version::FixVersion).
+///
+/// An unrecognised version cannot be framed: its `BeginString` (8) and, for a
+/// FIXT session, its `DefaultApplVerID` (1137) are unknown. Callers must
+/// surface this rather than substitute a default, which would put a fabricated
+/// version on the wire.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[error("'{value}' is not a known FIX version")]
+pub struct UnknownFixVersion {
+    value: String,
+}
+
+impl UnknownFixVersion {
+    /// Creates the error for an offending version string.
+    #[inline]
+    #[must_use]
+    pub fn new(value: &str) -> Self {
+        Self {
+            value: value.to_owned(),
+        }
+    }
+
+    /// Returns the offending version string.
+    #[inline]
+    #[must_use]
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/ironfix-core/src/lib.rs
+++ b/ironfix-core/src/lib.rs
@@ -13,6 +13,8 @@
 //! - **Field types**: `FieldTag`, `FieldValue`, and the `FixField` trait
 //! - **Message types**: `RawMessage`, `OwnedMessage`, and the `FixMessage` trait
 //! - **Core types**: `SeqNum`, `Timestamp`, `CompID`, `MsgType`
+//! - **Protocol versions**: `FixVersion`, the single mapping from a FIX
+//!   version to its `BeginString` (8) and `ApplVerID` (1128 / 1137)
 //!
 //! ## Zero-Copy Design
 //!
@@ -23,11 +25,13 @@ pub mod error;
 pub mod field;
 pub mod message;
 pub mod types;
+pub mod version;
 
 pub use error::{
     CompIdError, DecodeError, EncodeError, FixError, InvalidFieldTag, InvalidSide, MsgTypeError,
-    Result, SessionError, StoreError, TimestampError,
+    Result, SessionError, StoreError, TimestampError, UnknownFixVersion,
 };
 pub use field::{FieldRef, FieldTag, FieldValue, FixField, USER_DEFINED_TAG_MIN};
 pub use message::{CustomMsgType, FixMessage, MSG_TYPE_MAX_LEN, MsgType, OwnedMessage, RawMessage};
 pub use types::{COMP_ID_MAX_LEN, CompId, SeqNum, Side, Timestamp};
+pub use version::FixVersion;

--- a/ironfix-core/src/version.rs
+++ b/ironfix-core/src/version.rs
@@ -1,0 +1,284 @@
+/******************************************************************************
+   Author: Joaquín Béjar García
+   Email: jb@taunais.com
+   Date: 21/7/26
+******************************************************************************/
+
+//! FIX protocol versions and their on-the-wire representation.
+//!
+//! [`FixVersion`] is the **single** place in the workspace that maps a FIX
+//! version to the two values that carry it on the wire: `BeginString` (tag 8)
+//! and, for the 5.0 family, the application version stamped into
+//! `DefaultApplVerID` (1137) on the Logon and `ApplVerID` (1128) on
+//! application messages.
+//!
+//! It lives in `ironfix-core` because two crates need the same answer and
+//! neither may depend on the other: `ironfix-dictionary` re-exports it as
+//! `Version` for schema loading, and `ironfix-engine` uses it to stamp the
+//! standard header. `ironfix-engine` must not depend on `ironfix-dictionary`
+//! (a hard DAG invariant, see `CLAUDE.md`), so before this type existed the
+//! table was duplicated in both and could drift apart untested.
+//!
+//! ## The FIXT.1.1 split
+//!
+//! FIX 5.0 separates the transport (session) version from the application
+//! version. A 5.0 session is framed as a FIXT.1.1 session — `BeginString` is
+//! always `FIXT.1.1` — and the application version travels in 1137 / 1128
+//! (FIXT 1.1 specification, "Standard Message Header"; see also
+//! `doc/fix_operations.md`, "FIX 5.0 / FIXT.1.1"). Putting `FIX.5.0*` in tag 8
+//! is rejected outright by conforming counterparties.
+//!
+//! Consequently [`FixVersion::as_str`] (the version's own name, e.g.
+//! `FIX.5.0SP2`) and [`FixVersion::begin_string`] (what goes in tag 8, e.g.
+//! `FIXT.1.1`) are different questions and must not be confused.
+
+use crate::error::UnknownFixVersion;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+
+/// A FIX protocol version.
+///
+/// The canonical name of a variant is [`FixVersion::as_str`], which is also
+/// the string [`FromStr`] accepts. Its wire framing is
+/// [`FixVersion::begin_string`] plus [`FixVersion::appl_ver_id`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum FixVersion {
+    /// FIX 4.0
+    Fix40,
+    /// FIX 4.1
+    Fix41,
+    /// FIX 4.2
+    Fix42,
+    /// FIX 4.3
+    Fix43,
+    /// FIX 4.4
+    Fix44,
+    /// FIX 5.0, framed as a FIXT.1.1 session.
+    Fix50,
+    /// FIX 5.0 SP1, framed as a FIXT.1.1 session.
+    Fix50Sp1,
+    /// FIX 5.0 SP2, framed as a FIXT.1.1 session.
+    Fix50Sp2,
+    /// FIXT 1.1, the transport version used by FIX 5.0 and later.
+    ///
+    /// On its own it names no application version, so it has no
+    /// [`FixVersion::appl_ver_id`]: a session that must stamp
+    /// `DefaultApplVerID` (1137) cannot be described by this variant alone.
+    Fixt11,
+}
+
+impl FixVersion {
+    /// Every version this workspace knows, in ascending order.
+    ///
+    /// Iterating this is the way to assert the version mapping exhaustively
+    /// from a single place, rather than restating the table in a consumer.
+    pub const ALL: [Self; 9] = [
+        Self::Fix40,
+        Self::Fix41,
+        Self::Fix42,
+        Self::Fix43,
+        Self::Fix44,
+        Self::Fix50,
+        Self::Fix50Sp1,
+        Self::Fix50Sp2,
+        Self::Fixt11,
+    ];
+
+    /// Returns the version's canonical name, e.g. `FIX.5.0SP2`.
+    ///
+    /// This is the version's own identity — the string a session is
+    /// configured with and the string [`FromStr`] parses. For the 5.0 family
+    /// it is **not** what goes in `BeginString`; see
+    /// [`FixVersion::begin_string`].
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Fix40 => "FIX.4.0",
+            Self::Fix41 => "FIX.4.1",
+            Self::Fix42 => "FIX.4.2",
+            Self::Fix43 => "FIX.4.3",
+            Self::Fix44 => "FIX.4.4",
+            Self::Fix50 => "FIX.5.0",
+            Self::Fix50Sp1 => "FIX.5.0SP1",
+            Self::Fix50Sp2 => "FIX.5.0SP2",
+            Self::Fixt11 => "FIXT.1.1",
+        }
+    }
+
+    /// Returns the value stamped into `BeginString` (tag 8).
+    ///
+    /// Pre-5.0 versions carry their own name. FIX 5.0 and later are framed as
+    /// FIXT.1.1 sessions and carry `FIXT.1.1`, with the application version
+    /// in 1137 / 1128 instead.
+    #[must_use]
+    pub const fn begin_string(self) -> &'static str {
+        match self {
+            Self::Fix40 => "FIX.4.0",
+            Self::Fix41 => "FIX.4.1",
+            Self::Fix42 => "FIX.4.2",
+            Self::Fix43 => "FIX.4.3",
+            Self::Fix44 => "FIX.4.4",
+            Self::Fix50 | Self::Fix50Sp1 | Self::Fix50Sp2 | Self::Fixt11 => "FIXT.1.1",
+        }
+    }
+
+    /// Returns the application version to stamp into `DefaultApplVerID`
+    /// (1137) on the Logon and `ApplVerID` (1128) on application messages,
+    /// or `None` for a session that carries neither field.
+    ///
+    /// The codes are the `ApplVerID` enumeration: `7` = FIX.5.0,
+    /// `8` = FIX.5.0SP1, `9` = FIX.5.0SP2. That enumeration also defines
+    /// codes for pre-5.0 versions (`2` = FIX.4.0 … `6` = FIX.4.4), but they
+    /// are not returned here: a pre-5.0 session is not a FIXT session and
+    /// never carries 1137 or 1128, so the honest answer is `None`.
+    ///
+    /// [`FixVersion::Fixt11`] is also `None` — it names the transport version
+    /// only. A caller that must stamp the **required** 1137 has to reject
+    /// that combination rather than guess an application version.
+    pub const fn appl_ver_id(self) -> Option<&'static str> {
+        match self {
+            Self::Fix50 => Some("7"),
+            Self::Fix50Sp1 => Some("8"),
+            Self::Fix50Sp2 => Some("9"),
+            Self::Fix40 | Self::Fix41 | Self::Fix42 | Self::Fix43 | Self::Fix44 | Self::Fixt11 => {
+                None
+            }
+        }
+    }
+
+    /// Returns `true` when this version is framed as a FIXT.1.1 session,
+    /// i.e. FIX 5.0 and later plus FIXT.1.1 itself.
+    #[must_use]
+    pub const fn uses_fixt(self) -> bool {
+        matches!(
+            self,
+            Self::Fix50 | Self::Fix50Sp1 | Self::Fix50Sp2 | Self::Fixt11
+        )
+    }
+}
+
+impl fmt::Display for FixVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for FixVersion {
+    type Err = UnknownFixVersion;
+
+    /// Parses a version's canonical name, e.g. `FIX.4.4` or `FIX.5.0SP2`.
+    ///
+    /// Matching is exact: FIX version strings travel on the wire verbatim and
+    /// are case-sensitive, so a lenient parse here would accept a value that
+    /// no counterparty would.
+    ///
+    /// # Errors
+    /// Returns [`UnknownFixVersion`] when the string names no version in
+    /// [`FixVersion::ALL`].
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .into_iter()
+            .find(|version| version.as_str() == value)
+            .ok_or_else(|| UnknownFixVersion::new(value))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The one table in the workspace, asserted entry by entry. Both
+    /// `ironfix-dictionary` and `ironfix-engine` derive their answer from
+    /// these methods, so this covers the mapping for every consumer.
+    #[test]
+    fn test_fix_version_mapping_is_exhaustive_and_exact() {
+        let expected = [
+            (FixVersion::Fix40, "FIX.4.0", "FIX.4.0", None, false),
+            (FixVersion::Fix41, "FIX.4.1", "FIX.4.1", None, false),
+            (FixVersion::Fix42, "FIX.4.2", "FIX.4.2", None, false),
+            (FixVersion::Fix43, "FIX.4.3", "FIX.4.3", None, false),
+            (FixVersion::Fix44, "FIX.4.4", "FIX.4.4", None, false),
+            (FixVersion::Fix50, "FIX.5.0", "FIXT.1.1", Some("7"), true),
+            (
+                FixVersion::Fix50Sp1,
+                "FIX.5.0SP1",
+                "FIXT.1.1",
+                Some("8"),
+                true,
+            ),
+            (
+                FixVersion::Fix50Sp2,
+                "FIX.5.0SP2",
+                "FIXT.1.1",
+                Some("9"),
+                true,
+            ),
+            (FixVersion::Fixt11, "FIXT.1.1", "FIXT.1.1", None, true),
+        ];
+
+        assert_eq!(
+            expected.len(),
+            FixVersion::ALL.len(),
+            "every version must be covered"
+        );
+        for (version, name, begin_string, appl_ver_id, uses_fixt) in expected {
+            assert!(
+                FixVersion::ALL.contains(&version),
+                "{version:?} is missing from FixVersion::ALL"
+            );
+            assert_eq!(version.as_str(), name);
+            assert_eq!(version.begin_string(), begin_string);
+            assert_eq!(version.appl_ver_id(), appl_ver_id);
+            assert_eq!(version.uses_fixt(), uses_fixt);
+        }
+    }
+
+    #[test]
+    fn test_fix_version_roundtrips_through_its_canonical_name() {
+        for version in FixVersion::ALL {
+            assert_eq!(version.as_str().parse(), Ok(version));
+            assert_eq!(version.to_string(), version.as_str());
+        }
+    }
+
+    #[test]
+    fn test_fix_version_names_are_unique() {
+        for (index, version) in FixVersion::ALL.into_iter().enumerate() {
+            let duplicates = FixVersion::ALL
+                .into_iter()
+                .enumerate()
+                .filter(|(other_index, other)| {
+                    *other_index != index && other.as_str() == version.as_str()
+                })
+                .count();
+            assert_eq!(duplicates, 0, "{version:?} shares its name with another");
+        }
+    }
+
+    #[test]
+    fn test_fix_version_from_str_unknown_is_typed_error() {
+        match "FIX.9.9".parse::<FixVersion>() {
+            Err(err) => assert_eq!(err.value(), "FIX.9.9"),
+            Ok(version) => unreachable!("FIX.9.9 is not a version, got {version:?}"),
+        }
+    }
+
+    #[test]
+    fn test_fix_version_from_str_is_case_sensitive() {
+        assert!("fix.4.4".parse::<FixVersion>().is_err());
+        assert!("FIX.5.0sp2".parse::<FixVersion>().is_err());
+    }
+
+    #[test]
+    fn test_fix_version_only_fifty_family_carries_appl_ver_id() {
+        for version in FixVersion::ALL {
+            if version.appl_ver_id().is_some() {
+                assert!(
+                    version.uses_fixt(),
+                    "{version:?} stamps an ApplVerID but is not a FIXT session"
+                );
+            }
+        }
+    }
+}

--- a/ironfix-dictionary/src/loader.rs
+++ b/ironfix-dictionary/src/loader.rs
@@ -591,6 +591,53 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_version_covers_every_known_version() {
+        // The XML attribute table here is a separate mapping from the wire
+        // mapping in `ironfix_core::FixVersion`, so it can only be kept
+        // exhaustive by driving it from the same list of versions.
+        let attrs_for = |version: Version| -> Vec<(&'static str, &'static str)> {
+            match version {
+                Version::Fix40 => vec![("type", "FIX"), ("major", "4"), ("minor", "0")],
+                Version::Fix41 => vec![("type", "FIX"), ("major", "4"), ("minor", "1")],
+                Version::Fix42 => vec![("type", "FIX"), ("major", "4"), ("minor", "2")],
+                Version::Fix43 => vec![("type", "FIX"), ("major", "4"), ("minor", "3")],
+                Version::Fix44 => vec![("type", "FIX"), ("major", "4"), ("minor", "4")],
+                Version::Fix50 => vec![
+                    ("type", "FIX"),
+                    ("major", "5"),
+                    ("minor", "0"),
+                    ("servicepack", "0"),
+                ],
+                Version::Fix50Sp1 => vec![
+                    ("type", "FIX"),
+                    ("major", "5"),
+                    ("minor", "0"),
+                    ("servicepack", "1"),
+                ],
+                Version::Fix50Sp2 => vec![
+                    ("type", "FIX"),
+                    ("major", "5"),
+                    ("minor", "0"),
+                    ("servicepack", "2"),
+                ],
+                Version::Fixt11 => vec![("type", "FIXT"), ("major", "1"), ("minor", "1")],
+            }
+        };
+
+        for version in Version::ALL {
+            let attrs: HashMap<String, String> = attrs_for(version)
+                .into_iter()
+                .map(|(key, value)| (key.to_string(), value.to_string()))
+                .collect();
+            assert_eq!(
+                parse_version(&attrs),
+                Ok(version),
+                "{version} is not loadable from its QuickFIX XML attributes"
+            );
+        }
+    }
+
+    #[test]
     fn test_unsupported_version() {
         let xml = "<fix type='FIX' major='9' minor='9'><fields></fields></fix>";
         let err = Dictionary::from_quickfix_xml(xml).unwrap_err();

--- a/ironfix-dictionary/src/schema.rs
+++ b/ironfix-dictionary/src/schema.rs
@@ -17,68 +17,19 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// FIX protocol version.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum Version {
-    /// FIX 4.0
-    Fix40,
-    /// FIX 4.1
-    Fix41,
-    /// FIX 4.2
-    Fix42,
-    /// FIX 4.3
-    Fix43,
-    /// FIX 4.4
-    Fix44,
-    /// FIX 5.0
-    Fix50,
-    /// FIX 5.0 SP1
-    Fix50Sp1,
-    /// FIX 5.0 SP2
-    Fix50Sp2,
-    /// FIXT 1.1 (transport layer for FIX 5.0+)
-    Fixt11,
-}
-
-impl Version {
-    /// Returns the BeginString value for this version.
-    #[must_use]
-    pub const fn begin_string(&self) -> &'static str {
-        match self {
-            Self::Fix40 => "FIX.4.0",
-            Self::Fix41 => "FIX.4.1",
-            Self::Fix42 => "FIX.4.2",
-            Self::Fix43 => "FIX.4.3",
-            Self::Fix44 => "FIX.4.4",
-            Self::Fix50 | Self::Fix50Sp1 | Self::Fix50Sp2 | Self::Fixt11 => "FIXT.1.1",
-        }
-    }
-
-    /// Returns the ApplVerID for FIX 5.0+ versions.
-    #[must_use]
-    pub const fn appl_ver_id(&self) -> Option<&'static str> {
-        match self {
-            Self::Fix50 => Some("7"),
-            Self::Fix50Sp1 => Some("8"),
-            Self::Fix50Sp2 => Some("9"),
-            _ => None,
-        }
-    }
-
-    /// Returns true if this version uses FIXT transport.
-    #[must_use]
-    pub const fn uses_fixt(&self) -> bool {
-        matches!(
-            self,
-            Self::Fix50 | Self::Fix50Sp1 | Self::Fix50Sp2 | Self::Fixt11
-        )
-    }
-}
-
-impl std::fmt::Display for Version {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.begin_string())
-    }
-}
+///
+/// This is [`ironfix_core::FixVersion`], re-exported under the name this
+/// crate has always published. The version-to-wire mapping (`BeginString`
+/// tag 8, and `ApplVerID` for the 5.0 family) lives in `ironfix-core` because
+/// `ironfix-engine` needs the same answer and must not depend on
+/// `ironfix-dictionary`; keeping a second copy here let the two drift with no
+/// test able to cross-check them.
+///
+/// Note that `Display` and [`FixVersion::as_str`](ironfix_core::FixVersion::as_str)
+/// render the version's own name (`FIX.5.0SP2`), which for the 5.0 family is
+/// **not** its
+/// [`begin_string`](ironfix_core::FixVersion::begin_string) (`FIXT.1.1`).
+pub use ironfix_core::FixVersion as Version;
 
 /// FIX field data type.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -476,6 +427,17 @@ mod tests {
         assert_eq!(Version::Fix44.appl_ver_id(), None);
         assert_eq!(Version::Fix50.appl_ver_id(), Some("7"));
         assert_eq!(Version::Fix50Sp2.appl_ver_id(), Some("9"));
+    }
+
+    #[test]
+    fn test_version_is_the_core_type_not_a_copy() {
+        // `Version` is a re-export of `ironfix_core::FixVersion`, so the
+        // version-to-wire table exists exactly once in the workspace and
+        // cannot drift from the copy `ironfix-engine` consumes. Assigning
+        // across the two names only compiles while that holds.
+        let from_core: Version = ironfix_core::FixVersion::Fix50Sp2;
+        assert_eq!(from_core, Version::Fix50Sp2);
+        assert_eq!(Version::ALL.len(), ironfix_core::FixVersion::ALL.len());
     }
 
     #[test]

--- a/ironfix-engine/src/initiator.rs
+++ b/ironfix-engine/src/initiator.rs
@@ -70,10 +70,11 @@
 use crate::application::{Application, NoOpApplication, RejectReason, SessionId};
 use crate::connection::{Command, Connection, SessionRuntime};
 use crate::error::EngineError;
-use crate::wire::{self, MessageFactory, PeerIdentity, UnsupportedVersion, WireVersion};
+use crate::wire::{self, MessageFactory, PeerIdentity, UnsupportedVersion};
 use bytes::BytesMut;
 use futures_util::{SinkExt, StreamExt};
 use ironfix_core::message::{MsgType, RawMessage};
+use ironfix_core::version::FixVersion;
 use ironfix_session::heartbeat::generate_test_req_id;
 use ironfix_session::sequence::{SequenceExhausted, SequenceResult};
 use ironfix_session::{
@@ -109,9 +110,9 @@ pub struct Initiator<A: Application = NoOpApplication> {
     application: Arc<A>,
     /// Session identifier derived from the configuration.
     session_id: SessionId,
-    /// Wire representation (BeginString + ApplVerID) of the configured
-    /// FIX version.
-    version: Result<WireVersion, UnsupportedVersion>,
+    /// The configured FIX version, or why it cannot be framed. Resolved once
+    /// at construction and reported by [`Initiator::connect`] before dialling.
+    version: Result<FixVersion, UnsupportedVersion>,
     /// TCP connect timeout.
     connect_timeout: Duration,
     /// Initial (sender, target) sequence numbers for session continuity.

--- a/ironfix-engine/src/wire.rs
+++ b/ironfix-engine/src/wire.rs
@@ -17,38 +17,9 @@ use bytes::BytesMut;
 use ironfix_core::error::DecodeError;
 use ironfix_core::message::{OwnedMessage, RawMessage};
 use ironfix_core::types::Timestamp;
+use ironfix_core::version::FixVersion;
 use ironfix_session::SessionConfig;
 use ironfix_tagvalue::{Decoder, Encoder};
-
-/// How a configured FIX version is carried on the wire.
-///
-/// FIX 5.0 and later split the transport version from the application
-/// version: the frame is always a FIXT.1.1 frame (`BeginString` = FIXT.1.1)
-/// and the application version travels in `DefaultApplVerID` (1137) on the
-/// Logon and `ApplVerID` (1128) on application messages
-/// (`doc/fix_operations.md`, "FIX 5.0 / FIXT.1.1"). Putting `FIX.5.0*` in
-/// tag 8 is rejected outright by conforming acceptors.
-///
-/// `ironfix_dictionary::schema::Version` encodes exactly the same mapping in
-/// its `begin_string` / `appl_ver_id` methods, but `ironfix-engine` must not
-/// depend on `ironfix-dictionary` (a hard DAG invariant, see `CLAUDE.md`), so
-/// the mapping is duplicated here in a small spec-derived table. Unifying the
-/// two belongs in `ironfix-core`, which both crates already depend on; that is
-/// follow-up work.
-///
-/// The cost of that duplication is that the two tables can drift apart and no
-/// test can cross-check them without taking the forbidden dependency. Both are
-/// derived from the same fixed clause of the specification and neither changes
-/// unless a new FIX version ships, so the exposure is small — but it is the
-/// reason unifying them is worth doing rather than a permanent arrangement.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct WireVersion {
-    /// Value stamped into `BeginString` (8).
-    pub(crate) begin_string: &'static str,
-    /// Application version for `DefaultApplVerID` (1137) and `ApplVerID`
-    /// (1128), or `None` for a pre-5.0 session that has neither.
-    pub(crate) appl_ver_id: Option<&'static str>,
-}
 
 /// A configured `BeginString` the engine cannot frame conformantly.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -60,55 +31,58 @@ pub(crate) struct UnsupportedVersion {
     pub(crate) detail: String,
 }
 
-/// Resolves the configured version string to its on-the-wire representation.
+/// Resolves the configured version string to the [`FixVersion`] whose wire
+/// representation the header stamper uses.
 ///
-/// Well-known versions map to interned constants; anything else is leaked
-/// once (bounded: once per `Initiator`), because the tag-value `Encoder`
-/// requires a `&'static str` BeginString. An unrecognized version is passed
-/// through verbatim with no application version, which is the only honest
-/// answer available without a dictionary.
+/// The version-to-wire mapping — `BeginString` (8), and the application
+/// version for `DefaultApplVerID` (1137) and `ApplVerID` (1128) — belongs to
+/// [`FixVersion`] in `ironfix-core`, which is the workspace's single copy of
+/// it. This function only decides whether a configured string names a version
+/// the engine can frame; it does not restate the table.
 ///
-/// A session configured as `FIXT.1.1` gets no `ApplVerID`: FIXT.1.1 names the
-/// transport version only and does not identify an application version.
-/// Configure `FIX.5.0`, `FIX.5.0SP1` or `FIX.5.0SP2` to have 1137 and 1128
-/// stamped.
-pub(crate) fn wire_version(value: &str) -> Result<WireVersion, UnsupportedVersion> {
-    let (begin_string, appl_ver_id) = match value {
-        "FIX.4.0" => ("FIX.4.0", None),
-        "FIX.4.1" => ("FIX.4.1", None),
-        "FIX.4.2" => ("FIX.4.2", None),
-        "FIX.4.3" => ("FIX.4.3", None),
-        "FIX.4.4" => ("FIX.4.4", None),
-        "FIX.5.0" => ("FIXT.1.1", Some("7")),
-        "FIX.5.0SP1" => ("FIXT.1.1", Some("8")),
-        "FIX.5.0SP2" => ("FIXT.1.1", Some("9")),
-        // FIXT.1.1 names the transport version only. A FIXT Logon must carry
-        // DefaultApplVerID (1137), which is required, and nothing here can
-        // supply it: the application version is exactly what this string
-        // failed to state. Defaulting it would put a guessed version on the
-        // wire, so the session is refused instead.
-        "FIXT.1.1" => {
-            return Err(UnsupportedVersion {
-                version: value.to_owned(),
-                detail: "FIXT.1.1 names only the transport version and carries no application \
-                         version for DefaultApplVerID (1137), which a FIXT Logon requires; \
-                         configure FIX.5.0, FIX.5.0SP1 or FIX.5.0SP2 instead"
-                    .to_owned(),
-            });
-        }
-        other => {
-            return Err(UnsupportedVersion {
-                version: other.to_owned(),
-                detail: "not a FIX version this engine can frame; supported values are FIX.4.0 \
-                         through FIX.4.4 and FIX.5.0, FIX.5.0SP1, FIX.5.0SP2"
-                    .to_owned(),
-            });
-        }
-    };
-    Ok(WireVersion {
-        begin_string,
-        appl_ver_id,
-    })
+/// Two strings are refused:
+///
+/// - one that names no version at all, which has no `BeginString` to stamp;
+/// - bare `FIXT.1.1`, which names the transport version only. A FIXT Logon
+///   must carry `DefaultApplVerID` (1137), which is **required**, and the
+///   application version is exactly what this string failed to state.
+///   Defaulting it would put a guessed version on the wire, so the session is
+///   refused instead — configure `FIX.5.0`, `FIX.5.0SP1` or `FIX.5.0SP2`.
+///
+/// # Errors
+/// Returns [`UnsupportedVersion`] in either of those cases.
+pub(crate) fn wire_version(value: &str) -> Result<FixVersion, UnsupportedVersion> {
+    let version: FixVersion = value.parse().map_err(|_| UnsupportedVersion {
+        version: value.to_owned(),
+        detail: format!(
+            "not a FIX version this engine can frame; supported values are {}",
+            framable_versions()
+        ),
+    })?;
+
+    if version.uses_fixt() && version.appl_ver_id().is_none() {
+        return Err(UnsupportedVersion {
+            version: value.to_owned(),
+            detail: format!(
+                "{version} names only the transport version and carries no application version \
+                 for DefaultApplVerID (1137), which a FIXT Logon requires; supported values are {}",
+                framable_versions()
+            ),
+        });
+    }
+
+    Ok(version)
+}
+
+/// Lists the versions [`wire_version`] accepts, derived from [`FixVersion`] so
+/// the message cannot go stale when a version is added.
+fn framable_versions() -> String {
+    FixVersion::ALL
+        .into_iter()
+        .filter(|version| !(version.uses_fixt() && version.appl_ver_id().is_none()))
+        .map(FixVersion::as_str)
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 /// A mismatch between an inbound message's identity fields and the
@@ -223,7 +197,7 @@ pub(crate) fn owned_from_frame(frame: &[u8]) -> Result<OwnedMessage, DecodeError
 /// Builds outbound frames with the session header stamped.
 #[derive(Debug)]
 pub(crate) struct MessageFactory {
-    version: WireVersion,
+    version: FixVersion,
     sender_comp_id: String,
     target_comp_id: String,
     sender_sub_id: Option<String>,
@@ -233,7 +207,7 @@ pub(crate) struct MessageFactory {
 impl MessageFactory {
     /// Creates a factory from the session configuration.
     #[must_use]
-    pub(crate) fn new(config: &SessionConfig, version: WireVersion) -> Self {
+    pub(crate) fn new(config: &SessionConfig, version: FixVersion) -> Self {
         Self {
             version,
             sender_comp_id: config.sender_comp_id.as_str().to_string(),
@@ -266,7 +240,7 @@ impl MessageFactory {
         poss_dup: bool,
         appl_ver_id: Option<&str>,
     ) -> Encoder {
-        let mut encoder = Encoder::new(self.version.begin_string);
+        let mut encoder = Encoder::new(self.version.begin_string());
         encoder.put_str(35, msg_type);
         if let Some(appl_ver_id) = appl_ver_id {
             encoder.put_str(1128, appl_ver_id);
@@ -300,7 +274,7 @@ impl MessageFactory {
         if reset_seq {
             encoder.put_bool(141, true);
         }
-        if let Some(appl_ver_id) = self.version.appl_ver_id {
+        if let Some(appl_ver_id) = self.version.appl_ver_id() {
             encoder.put_str(1137, appl_ver_id);
         }
         encoder.finish()
@@ -380,7 +354,7 @@ impl MessageFactory {
             message.msg_type().as_str(),
             seq,
             false,
-            self.version.appl_ver_id,
+            self.version.appl_ver_id(),
         );
         for (tag, value) in message.fields() {
             encoder.put_raw(*tag, value);
@@ -478,13 +452,46 @@ mod tests {
 
     #[test]
     fn test_wire_version_pre_fixt_passthrough() {
-        assert_eq!(
-            wire_version("FIX.4.4"),
-            Ok(WireVersion {
-                begin_string: "FIX.4.4",
-                appl_ver_id: None,
-            })
-        );
+        assert_eq!(wire_version("FIX.4.4"), Ok(FixVersion::Fix44));
+    }
+
+    /// The mapping now lives once, in `ironfix_core::FixVersion`. This walks
+    /// every version from that single list and asserts the engine frames each
+    /// one exactly as the core table says — the cross-check that was
+    /// impossible while the engine kept its own copy, since asserting against
+    /// `ironfix-dictionary` would have taken a forbidden dependency.
+    #[test]
+    fn test_wire_version_matches_core_table_for_every_version() {
+        for version in FixVersion::ALL {
+            let resolved = wire_version(version.as_str());
+
+            // Only a FIXT session with no application version is refused; it
+            // cannot supply the required DefaultApplVerID (1137).
+            if version.uses_fixt() && version.appl_ver_id().is_none() {
+                match resolved {
+                    Err(err) => assert_eq!(err.version, version.as_str()),
+                    Ok(framable) => {
+                        unreachable!("{version} must be refused, got {framable:?}")
+                    }
+                }
+                continue;
+            }
+
+            assert_eq!(resolved, Ok(version));
+
+            let frame = factory_for(version.as_str()).logon(1, 30, false);
+            let raw = decode(&frame);
+            assert_eq!(
+                raw.begin_string(),
+                Ok(version.begin_string()),
+                "{version} framed the wrong BeginString"
+            );
+            assert_eq!(
+                raw.get_field_str(1137),
+                version.appl_ver_id(),
+                "{version} framed the wrong DefaultApplVerID"
+            );
+        }
     }
 
     #[test]
@@ -517,27 +524,17 @@ mod tests {
 
     #[test]
     fn test_wire_version_fix50_maps_to_fixt() {
-        assert_eq!(
-            wire_version("FIX.5.0"),
-            Ok(WireVersion {
-                begin_string: "FIXT.1.1",
-                appl_ver_id: Some("7"),
-            })
-        );
-        assert_eq!(
-            wire_version("FIX.5.0SP1"),
-            Ok(WireVersion {
-                begin_string: "FIXT.1.1",
-                appl_ver_id: Some("8"),
-            })
-        );
-        assert_eq!(
-            wire_version("FIX.5.0SP2"),
-            Ok(WireVersion {
-                begin_string: "FIXT.1.1",
-                appl_ver_id: Some("9"),
-            })
-        );
+        for (configured, appl_ver_id) in
+            [("FIX.5.0", "7"), ("FIX.5.0SP1", "8"), ("FIX.5.0SP2", "9")]
+        {
+            match wire_version(configured) {
+                Ok(version) => {
+                    assert_eq!(version.begin_string(), "FIXT.1.1");
+                    assert_eq!(version.appl_ver_id(), Some(appl_ver_id));
+                }
+                Err(err) => unreachable!("{configured} must be framable: {err}"),
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Gives the FIX version → wire-form mapping a single home, removing a duplication that no test could detect drifting.

Closes #28.

## Stack

- **Base branch:** `stack/26-msgtype-alloc` (PR #32)
- **Stack:** #25 → #30 → #31 → #32 → **#28 (this PR)**

## What was wrong

The map from a configured FIX version to its wire form — `BeginString` (tag 8), and `ApplVerID` for the 5.0 family — existed in **two** places:

- `ironfix-dictionary/src/schema.rs`, in `Version::begin_string` / `Version::appl_ver_id`
- `ironfix-engine/src/wire.rs`, in a `pub(crate)` table added when FIXT.1.1 support landed in #25

The duplication was deliberate, not sloppiness: `ironfix-engine` must not depend on `ironfix-dictionary` (a hard DAG invariant), so it could not reuse the dictionary's answer. But it meant the two tables could drift apart silently, and **no test could cross-check them** without taking exactly the dependency the invariant forbids. Getting this wrong is not cosmetic — a wrong BeginString is rejected outright by a conforming acceptor.

## The fix

Both crates already depend on `ironfix-core`, so the mapping lives there and both derive from it. One table, one place, and the cross-check is now an ordinary test.

The engine's behaviour from #25 is preserved: a version it cannot frame conformantly — an unknown string, or bare `FIXT.1.1`, which names a transport version but no application version for the **required** `DefaultApplVerID` (1137) — is refused before dialling rather than guessed onto the wire.

## Crate DAG

Unchanged and verified: `ironfix-engine` still depends on core, session, store, transport and tagvalue, and **not** on `ironfix-dictionary`. `ironfix-core` still depends on nothing internal.

## Public API changes (semver)

Adding a public type to `ironfix-core` is a semver event for all 11 crates; the workspace is already at 0.4.0, which covers it.

## Tests

Workspace goes to **367 passing**, including the mapping assertion that was previously impossible to write from a single place.

## Verification

```
cargo test --workspace                                    # 367 passed
cargo clippy --all-targets --all-features -- -D warnings  # clean
cargo fmt --all --check                                   # clean
make doc                                                  # clean
```
