### PR TITLE
fix(tagvalue): make every frame the encoder emits one its own decoder accepts

### DIFF
--- a/ironfix-engine/src/error.rs
+++ b/ironfix-engine/src/error.rs
@@ -6,7 +6,7 @@
 
 //! Engine error types.
 
-use ironfix_core::error::DecodeError;
+use ironfix_core::error::{DecodeError, EncodeError};
 use ironfix_session::sequence::SequenceExhausted;
 use ironfix_transport::CodecError;
 use std::time::Duration;
@@ -26,6 +26,15 @@ pub enum EngineError {
     /// Failure decoding a framed FIX message.
     #[error("decode error: {0}")]
     Decode(#[from] DecodeError),
+
+    /// A message could not be encoded into a legal frame.
+    ///
+    /// Raised when a field value has no on-the-wire form — a value carrying the
+    /// SOH delimiter, or an empty one. The encoder refuses to stamp such a
+    /// frame rather than emit one whose `BodyLength` and `CheckSum` are correct
+    /// for corrupted bytes.
+    #[error("encode error: {0}")]
+    Encode(#[from] EncodeError),
 
     /// TCP connect did not complete within the configured timeout.
     #[error("connect timed out after {0:?}")]

--- a/ironfix-engine/src/initiator.rs
+++ b/ironfix-engine/src/initiator.rs
@@ -678,26 +678,36 @@ impl<A: Application> Reactor<A> {
                     );
                     return Ok(phase);
                 }
-                let seq = match self.runtime.sequences.try_allocate_sender_seq() {
-                    Ok(seq) => seq.value(),
-                    Err(err) => return Err(exhausted(phase, err)),
-                };
+                // Build the frame against the sequence number that *would* be
+                // allocated next, without consuming it. An application may hand
+                // us a message with no legal wire form — an ordinary field
+                // carrying SOH, an empty value, a DATA half without its LENGTH.
+                // Validating before allocation makes that a clean drop that
+                // leaves the session and the sequence counter intact, rather
+                // than a teardown over a spent number the counterparty would
+                // have to resend over. The reactor is the sole allocator of the
+                // sender counter and does not await between this peek and the
+                // commit below, so the number it commits is the one framed here.
+                let seq = self.runtime.sequences.next_sender_seq().value();
                 let frame = match self.factory.application_message(seq, &message) {
                     Ok(frame) => frame,
                     Err(err) => {
-                        // The application handed us a value with no legal wire
-                        // form. The session is unharmed — the frame simply
-                        // never existed — but the sequence number allocated for
-                        // it is now spent, so the session cannot continue
-                        // without a gap the counterparty would have to resend
-                        // over.
-                        teardown(phase);
-                        return Err(closed(
-                            format!("cannot encode outbound message: {err}"),
-                            false,
-                        ));
+                        // The message never reached the wire and no number was
+                        // spent. The value itself is not logged: it may carry a
+                        // credential (554/925) or RawData.
+                        tracing::warn!(
+                            session = %self.session_id,
+                            msg_type = %message.msg_type(),
+                            error = %err,
+                            "dropping outbound message: cannot encode"
+                        );
+                        return Ok(phase);
                     }
                 };
+                // The frame encoded; commit the sequence number it carries.
+                if let Err(err) = self.runtime.sequences.try_allocate_sender_seq() {
+                    return Err(exhausted(phase, err));
+                }
                 if let Ok(mut owned) = wire::owned_from_frame(&frame) {
                     self.application.to_app(&mut owned, &self.session_id).await;
                 }

--- a/ironfix-engine/src/initiator.rs
+++ b/ironfix-engine/src/initiator.rs
@@ -73,6 +73,7 @@ use crate::error::EngineError;
 use crate::wire::{self, MessageFactory, PeerIdentity, UnsupportedVersion};
 use bytes::BytesMut;
 use futures_util::{SinkExt, StreamExt};
+use ironfix_core::error::EncodeError;
 use ironfix_core::message::{MsgType, RawMessage};
 use ironfix_core::version::FixVersion;
 use ironfix_session::heartbeat::generate_test_req_id;
@@ -275,7 +276,7 @@ impl<A: Application + 'static> Initiator<A> {
             seq,
             self.config.heartbeat_interval_secs(),
             self.config.reset_on_logon,
-        );
+        )?;
         if let Ok(mut owned) = wire::owned_from_frame(&logon) {
             self.application.to_admin(&mut owned, &session_id).await;
         }
@@ -352,19 +353,20 @@ impl<A: Application + 'static> Initiator<A> {
             if let Err(mismatch) = identity.validate(&raw) {
                 let detail = mismatch.to_string();
                 let reason = RejectReason::new(9, detail.clone()).with_ref_tag(mismatch.tag);
-                if let Ok(out_seq) = runtime.sequences.try_allocate_sender_seq() {
-                    let reject = factory.session_reject(
+                if let Ok(out_seq) = runtime.sequences.try_allocate_sender_seq()
+                    && let Ok(reject) = factory.session_reject(
                         out_seq.value(),
                         ack_seq,
                         MsgType::Logon.as_str(),
                         &reason,
-                    );
+                    )
+                {
                     let _ = framed.send(reject).await;
                 }
-                if let Ok(out_seq) = runtime.sequences.try_allocate_sender_seq() {
-                    let _ = framed
-                        .send(factory.logout(out_seq.value(), Some(&detail)))
-                        .await;
+                if let Ok(out_seq) = runtime.sequences.try_allocate_sender_seq()
+                    && let Ok(logout) = factory.logout(out_seq.value(), Some(&detail))
+                {
+                    let _ = framed.send(logout).await;
                 }
                 let _ = session.on_logon_reject();
                 return Err(EngineError::IdentityMismatch { detail });
@@ -372,11 +374,16 @@ impl<A: Application + 'static> Initiator<A> {
 
             if let Err(reason) = self.application.from_admin(&raw, &session_id).await {
                 match runtime.sequences.try_allocate_sender_seq() {
-                    Ok(seq) => {
-                        let _ = framed
-                            .send(factory.logout(seq.value(), Some(&reason.text)))
-                            .await;
-                    }
+                    Ok(seq) => match factory.logout(seq.value(), Some(&reason.text)) {
+                        Ok(logout) => {
+                            let _ = framed.send(logout).await;
+                        }
+                        Err(err) => tracing::warn!(
+                            session = %session_id,
+                            error = %err,
+                            "cannot encode Logout after from_admin rejection"
+                        ),
+                    },
                     Err(err) => tracing::warn!(
                         session = %session_id,
                         error = %err,
@@ -458,7 +465,7 @@ impl<A: Application + 'static> Initiator<A> {
         // A gap in the Logon ack means we missed messages: request a resend.
         if let Some(expected) = pending_resend {
             let seq = runtime.sequences.try_allocate_sender_seq()?.value();
-            let frame = factory.resend_request(seq, expected, 0);
+            let frame = factory.resend_request(seq, expected, 0)?;
             if let Ok(mut owned) = wire::owned_from_frame(&frame) {
                 self.application.to_admin(&mut owned, &session_id).await;
             }
@@ -635,7 +642,15 @@ async fn run_reactor<A: Application + 'static>(
 impl<A: Application> Reactor<A> {
     /// Sends an admin frame, running the `to_admin` callback and updating
     /// heartbeat bookkeeping.
-    async fn send_admin(&self, framed: &mut FixFramed, frame: BytesMut) -> Result<(), EngineError> {
+    async fn send_admin(
+        &self,
+        framed: &mut FixFramed,
+        frame: Result<BytesMut, EncodeError>,
+    ) -> Result<(), EngineError> {
+        // The frame arrives as the encoder's result so every caller reports an
+        // unencodable message through the path it already uses for a failed
+        // send, rather than each deciding for itself.
+        let frame = frame?;
         if let Ok(mut owned) = wire::owned_from_frame(&frame) {
             self.application
                 .to_admin(&mut owned, &self.session_id)
@@ -667,7 +682,22 @@ impl<A: Application> Reactor<A> {
                     Ok(seq) => seq.value(),
                     Err(err) => return Err(exhausted(phase, err)),
                 };
-                let frame = self.factory.application_message(seq, &message);
+                let frame = match self.factory.application_message(seq, &message) {
+                    Ok(frame) => frame,
+                    Err(err) => {
+                        // The application handed us a value with no legal wire
+                        // form. The session is unharmed — the frame simply
+                        // never existed — but the sequence number allocated for
+                        // it is now spent, so the session cannot continue
+                        // without a gap the counterparty would have to resend
+                        // over.
+                        teardown(phase);
+                        return Err(closed(
+                            format!("cannot encode outbound message: {err}"),
+                            false,
+                        ));
+                    }
+                };
                 if let Ok(mut owned) = wire::owned_from_frame(&frame) {
                     self.application.to_app(&mut owned, &self.session_id).await;
                 }
@@ -1216,7 +1246,12 @@ impl<A: Application> Reactor<A> {
                     Ok(out_seq) => out_seq.value(),
                     Err(err) => return Err(exhausted(phase, err)),
                 };
-                let frame = self.factory.heartbeat(out_seq, raw.get_field_str(112));
+                // `112=` with no value is a malformed TestRequest. There is
+                // nothing to echo, and an empty field has no legal wire form,
+                // so the Heartbeat is sent without TestReqID rather than the
+                // session being torn down over the peer's mistake.
+                let test_req_id = raw.get_field_str(112).filter(|id| !id.is_empty());
+                let frame = self.factory.heartbeat(out_seq, test_req_id);
                 if let Err(err) = self.send_admin(framed, frame).await {
                     teardown(phase);
                     return Err(closed(format!("send failed: {err}"), false));

--- a/ironfix-engine/src/lib.rs
+++ b/ironfix-engine/src/lib.rs
@@ -56,7 +56,7 @@ pub use builder::EngineBuilder;
 pub use connection::Connection;
 pub use error::EngineError;
 pub use initiator::Initiator;
-pub use outbound::OutboundMessage;
+pub use outbound::{OutboundField, OutboundMessage};
 
 // Re-exported for convenience: the per-session configuration consumed by
 // [`Initiator`].

--- a/ironfix-engine/src/outbound.rs
+++ b/ironfix-engine/src/outbound.rs
@@ -8,6 +8,36 @@
 
 use ironfix_core::message::MsgType;
 
+/// A single body field of an [`OutboundMessage`], in the form the encoder
+/// needs to stamp it.
+///
+/// Most fields are [`OutboundField::Raw`] and are written verbatim. A FIX
+/// `DATA` field (`RawData`/96, `Signature`/89, the `Encoded*` family) legally
+/// contains the SOH delimiter and `=`, so it is decodable only alongside its
+/// paired `LENGTH` field; those fields are [`OutboundField::Data`] and are
+/// emitted as a counted pair so the payload's SOH bytes are never read as field
+/// terminators.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OutboundField {
+    /// An ordinary field, written as `tag=value<SOH>`.
+    Raw {
+        /// The field tag number.
+        tag: u32,
+        /// The field value bytes.
+        value: Vec<u8>,
+    },
+    /// A counted `LENGTH`/`DATA` pair, written as
+    /// `length_tag=<value.len()><SOH>data_tag=<value><SOH>`.
+    Data {
+        /// The `LENGTH` field tag (e.g., 95 `RawDataLength`).
+        length_tag: u32,
+        /// The paired `DATA` field tag (e.g., 96 `RawData`).
+        data_tag: u32,
+        /// The raw payload, which may carry SOH and `=`.
+        value: Vec<u8>,
+    },
+}
+
 /// An outbound application message: a MsgType plus ordered body fields.
 ///
 /// The engine stamps the standard header (BeginString, BodyLength, MsgType,
@@ -19,7 +49,7 @@ pub struct OutboundMessage {
     /// Message type (tag 35).
     msg_type: MsgType,
     /// Body fields in insertion order.
-    fields: Vec<(u32, Vec<u8>)>,
+    fields: Vec<OutboundField>,
 }
 
 impl OutboundMessage {
@@ -47,7 +77,39 @@ impl OutboundMessage {
     /// * `tag` - The field tag number
     /// * `value` - The field value bytes
     pub fn push_raw(&mut self, tag: u32, value: impl Into<Vec<u8>>) -> &mut Self {
-        self.fields.push((tag, value.into()));
+        self.fields.push(OutboundField::Raw {
+            tag,
+            value: value.into(),
+        });
+        self
+    }
+
+    /// Appends a counted `LENGTH`/`DATA` field pair.
+    ///
+    /// A FIX `DATA` field (`RawData`/96, `Signature`/89, the `Encoded*` family)
+    /// legally contains SOH and `=`; it is decodable only because its paired
+    /// `LENGTH` field declares its byte count. The engine derives that count
+    /// from `value` when the message is encoded, so the two cannot disagree and
+    /// the payload's SOH bytes are never read as field terminators. Use this
+    /// instead of [`OutboundMessage::push_raw`] for any `DATA` field —
+    /// `push_raw` refuses a `LENGTH` or `DATA` tag precisely because writing one
+    /// half alone would corrupt the frame.
+    ///
+    /// # Arguments
+    /// * `length_tag` - The `LENGTH` field tag (e.g., 95 `RawDataLength`)
+    /// * `data_tag` - The paired `DATA` field tag (e.g., 96 `RawData`)
+    /// * `value` - The raw payload
+    pub fn push_data(
+        &mut self,
+        length_tag: u32,
+        data_tag: u32,
+        value: impl Into<Vec<u8>>,
+    ) -> &mut Self {
+        self.fields.push(OutboundField::Data {
+            length_tag,
+            data_tag,
+            value: value.into(),
+        });
         self
     }
 
@@ -100,7 +162,7 @@ impl OutboundMessage {
 
     /// Returns the body fields in insertion order.
     #[must_use]
-    pub fn fields(&self) -> &[(u32, Vec<u8>)] {
+    pub fn fields(&self) -> &[OutboundField] {
         &self.fields
     }
 }
@@ -120,10 +182,75 @@ mod tests {
 
         assert_eq!(msg.msg_type(), &MsgType::NewOrderSingle);
         let fields = msg.fields();
-        assert_eq!(fields[0], (11, b"ORDER-1".to_vec()));
-        assert_eq!(fields[1], (54, b"1".to_vec()));
-        assert_eq!(fields[2], (38, b"100".to_vec()));
-        assert_eq!(fields[3], (9999, b"-5".to_vec()));
-        assert_eq!(fields[4], (59, b"Y".to_vec()));
+        assert_eq!(
+            fields[0],
+            OutboundField::Raw {
+                tag: 11,
+                value: b"ORDER-1".to_vec()
+            }
+        );
+        assert_eq!(
+            fields[1],
+            OutboundField::Raw {
+                tag: 54,
+                value: b"1".to_vec()
+            }
+        );
+        assert_eq!(
+            fields[2],
+            OutboundField::Raw {
+                tag: 38,
+                value: b"100".to_vec()
+            }
+        );
+        assert_eq!(
+            fields[3],
+            OutboundField::Raw {
+                tag: 9999,
+                value: b"-5".to_vec()
+            }
+        );
+        assert_eq!(
+            fields[4],
+            OutboundField::Raw {
+                tag: 59,
+                value: b"Y".to_vec()
+            }
+        );
+    }
+
+    #[test]
+    fn test_outbound_message_push_data_records_a_counted_pair() {
+        // A RawData payload carrying an embedded SOH is expressed as a
+        // LENGTH/DATA pair, interleaved in insertion order with ordinary fields.
+        let mut msg = OutboundMessage::new(MsgType::NewOrderSingle);
+        msg.push_str(11, "ORDER-1")
+            .push_data(95, 96, b"a\x01b".to_vec())
+            .push_str(58, "after");
+
+        let fields = msg.fields();
+        assert_eq!(
+            fields[1],
+            OutboundField::Data {
+                length_tag: 95,
+                data_tag: 96,
+                value: b"a\x01b".to_vec()
+            }
+        );
+        // Insertion order is preserved across raw and data fields.
+        assert_eq!(
+            fields[0],
+            OutboundField::Raw {
+                tag: 11,
+                value: b"ORDER-1".to_vec()
+            }
+        );
+        assert_eq!(
+            fields[2],
+            OutboundField::Raw {
+                tag: 58,
+                value: b"after".to_vec()
+            }
+        );
     }
 }

--- a/ironfix-engine/src/wire.rs
+++ b/ironfix-engine/src/wire.rs
@@ -12,7 +12,7 @@
 //! consumers via [`OutboundMessage`] get the same header treatment.
 
 use crate::application::RejectReason;
-use crate::outbound::OutboundMessage;
+use crate::outbound::{OutboundField, OutboundMessage};
 use bytes::BytesMut;
 use ironfix_core::error::{DecodeError, EncodeError};
 use ironfix_core::message::{OwnedMessage, RawMessage};
@@ -395,8 +395,15 @@ impl MessageFactory {
             false,
             self.version.appl_ver_id(),
         );
-        for (tag, value) in message.fields() {
-            encoder.put_raw(*tag, value);
+        for field in message.fields() {
+            match field {
+                OutboundField::Raw { tag, value } => encoder.put_raw(*tag, value),
+                OutboundField::Data {
+                    length_tag,
+                    data_tag,
+                    value,
+                } => encoder.put_data(*length_tag, *data_tag, value),
+            }
         }
         into_frame(&mut encoder)
     }
@@ -496,6 +503,24 @@ mod tests {
         assert_eq!(raw.get_field_str(11), Some("ORDER-1"));
         assert_eq!(raw.get_field_str(54), Some("1"));
         assert_eq!(raw.get_field_str(1128), None);
+    }
+
+    #[test]
+    fn test_application_message_encodes_raw_data_as_a_counted_pair() {
+        // A RawData payload carrying SOH is routed through the encoder's
+        // LENGTH/DATA path, not put_raw, so the frame encodes and the payload
+        // survives byte-exact instead of the message being refused.
+        let payload: &[u8] = b"a\x01b=c";
+        let mut message = OutboundMessage::new(MsgType::NewOrderSingle);
+        message
+            .push_str(11, "ORDER-1")
+            .push_data(95, 96, payload.to_vec());
+
+        let frame = framed(factory().application_message(7, &message));
+        let raw = decode(&frame);
+        assert_eq!(raw.get_field_str(11), Some("ORDER-1"));
+        assert_eq!(raw.get_field(95).map(|f| f.value), Some(b"5".as_slice()));
+        assert_eq!(raw.get_field(96).map(|f| f.value), Some(payload));
     }
 
     #[test]

--- a/ironfix-engine/src/wire.rs
+++ b/ironfix-engine/src/wire.rs
@@ -14,7 +14,7 @@
 use crate::application::RejectReason;
 use crate::outbound::OutboundMessage;
 use bytes::BytesMut;
-use ironfix_core::error::DecodeError;
+use ironfix_core::error::{DecodeError, EncodeError};
 use ironfix_core::message::{OwnedMessage, RawMessage};
 use ironfix_core::types::Timestamp;
 use ironfix_core::version::FixVersion;
@@ -194,6 +194,19 @@ pub(crate) fn owned_from_frame(frame: &[u8]) -> Result<OwnedMessage, DecodeError
     Ok(decode_frame(frame)?.to_owned())
 }
 
+/// Stamps the frame and moves it into a buffer the transport owns.
+///
+/// # Errors
+/// Returns the [`EncodeError`] the encoder recorded — a field value that
+/// cannot be represented on the wire, such as a `Text` (58) carrying the SOH
+/// delimiter or an empty `TestReqID` (112) echoed back from a peer. A frame is
+/// never produced from a rejected value.
+fn into_frame(encoder: &mut Encoder) -> Result<BytesMut, EncodeError> {
+    let mut frame = BytesMut::new();
+    encoder.finish_into(&mut frame)?;
+    Ok(frame)
+}
+
 /// Builds outbound frames with the session header stamped.
 #[derive(Debug)]
 pub(crate) struct MessageFactory {
@@ -267,7 +280,12 @@ impl MessageFactory {
 
     /// Builds a Logon (35=A) with EncryptMethod=0, HeartBtInt and, for a
     /// FIXT.1.1 session, DefaultApplVerID (1137).
-    pub(crate) fn logon(&self, seq: u64, heartbeat_secs: u64, reset_seq: bool) -> BytesMut {
+    pub(crate) fn logon(
+        &self,
+        seq: u64,
+        heartbeat_secs: u64,
+        reset_seq: bool,
+    ) -> Result<BytesMut, EncodeError> {
         let mut encoder = self.header("A", seq, false, None);
         encoder.put_uint(98, 0);
         encoder.put_uint(108, heartbeat_secs);
@@ -277,53 +295,70 @@ impl MessageFactory {
         if let Some(appl_ver_id) = self.version.appl_ver_id() {
             encoder.put_str(1137, appl_ver_id);
         }
-        encoder.finish()
+        into_frame(&mut encoder)
     }
 
     /// Builds a Heartbeat (35=0), echoing TestReqID (112) when replying to
     /// a TestRequest.
-    pub(crate) fn heartbeat(&self, seq: u64, test_req_id: Option<&str>) -> BytesMut {
+    pub(crate) fn heartbeat(
+        &self,
+        seq: u64,
+        test_req_id: Option<&str>,
+    ) -> Result<BytesMut, EncodeError> {
         let mut encoder = self.header("0", seq, false, None);
         if let Some(id) = test_req_id {
             encoder.put_str(112, id);
         }
-        encoder.finish()
+        into_frame(&mut encoder)
     }
 
     /// Builds a TestRequest (35=1) with TestReqID (112).
-    pub(crate) fn test_request(&self, seq: u64, test_req_id: &str) -> BytesMut {
+    pub(crate) fn test_request(
+        &self,
+        seq: u64,
+        test_req_id: &str,
+    ) -> Result<BytesMut, EncodeError> {
         let mut encoder = self.header("1", seq, false, None);
         encoder.put_str(112, test_req_id);
-        encoder.finish()
+        into_frame(&mut encoder)
     }
 
     /// Builds a Logout (35=5) with optional Text (58).
-    pub(crate) fn logout(&self, seq: u64, text: Option<&str>) -> BytesMut {
+    pub(crate) fn logout(&self, seq: u64, text: Option<&str>) -> Result<BytesMut, EncodeError> {
         let mut encoder = self.header("5", seq, false, None);
         if let Some(text) = text {
             encoder.put_str(58, text);
         }
-        encoder.finish()
+        into_frame(&mut encoder)
     }
 
     /// Builds a ResendRequest (35=2) for `begin_seq..end_seq`
     /// (`end_seq` = 0 means "up to infinity").
-    pub(crate) fn resend_request(&self, seq: u64, begin_seq: u64, end_seq: u64) -> BytesMut {
+    pub(crate) fn resend_request(
+        &self,
+        seq: u64,
+        begin_seq: u64,
+        end_seq: u64,
+    ) -> Result<BytesMut, EncodeError> {
         let mut encoder = self.header("2", seq, false, None);
         encoder.put_uint(7, begin_seq);
         encoder.put_uint(16, end_seq);
-        encoder.finish()
+        into_frame(&mut encoder)
     }
 
     /// Builds a SequenceReset-GapFill (35=4, 123=Y) that answers a
     /// ResendRequest by jumping the counterparty's expectation to `new_seq`.
     /// Stamped with the gap's begin sequence, PossDupFlag (43=Y) and
     /// OrigSendingTime (122).
-    pub(crate) fn sequence_reset_gap_fill(&self, seq: u64, new_seq: u64) -> BytesMut {
+    pub(crate) fn sequence_reset_gap_fill(
+        &self,
+        seq: u64,
+        new_seq: u64,
+    ) -> Result<BytesMut, EncodeError> {
         let mut encoder = self.header("4", seq, true, None);
         encoder.put_bool(123, true);
         encoder.put_uint(36, new_seq);
-        encoder.finish()
+        into_frame(&mut encoder)
     }
 
     /// Builds a session-level Reject (35=3).
@@ -333,7 +368,7 @@ impl MessageFactory {
         ref_seq: u64,
         ref_msg_type: &str,
         reason: &RejectReason,
-    ) -> BytesMut {
+    ) -> Result<BytesMut, EncodeError> {
         let mut encoder = self.header("3", seq, false, None);
         encoder.put_uint(45, ref_seq);
         if let Some(ref_tag) = reason.ref_tag {
@@ -344,12 +379,16 @@ impl MessageFactory {
         if !reason.text.is_empty() {
             encoder.put_str(58, &reason.text);
         }
-        encoder.finish()
+        into_frame(&mut encoder)
     }
 
     /// Builds an application message from an [`OutboundMessage`], stamping
     /// ApplVerID (1128) for a FIXT.1.1 session.
-    pub(crate) fn application_message(&self, seq: u64, message: &OutboundMessage) -> BytesMut {
+    pub(crate) fn application_message(
+        &self,
+        seq: u64,
+        message: &OutboundMessage,
+    ) -> Result<BytesMut, EncodeError> {
         let mut encoder = self.header(
             message.msg_type().as_str(),
             seq,
@@ -359,7 +398,7 @@ impl MessageFactory {
         for (tag, value) in message.fields() {
             encoder.put_raw(*tag, value);
         }
-        encoder.finish()
+        into_frame(&mut encoder)
     }
 }
 
@@ -398,9 +437,18 @@ mod tests {
         }
     }
 
+    /// Unwraps a factory frame, failing the test with the encoder's rejection.
+    #[track_caller]
+    fn framed(frame: Result<BytesMut, EncodeError>) -> BytesMut {
+        match frame {
+            Ok(frame) => frame,
+            Err(err) => panic!("factory frame must encode: {err}"),
+        }
+    }
+
     #[test]
     fn test_logon_frame_roundtrip() {
-        let frame = factory().logon(1, 30, true);
+        let frame = framed(factory().logon(1, 30, true));
         let raw = decode(&frame);
         assert_eq!(raw.msg_type(), &MsgType::Logon);
         assert_eq!(raw.get_field_str(49), Some("CLIENT"));
@@ -415,7 +463,7 @@ mod tests {
 
     #[test]
     fn test_gap_fill_frame_carries_orig_sending_time() {
-        let frame = factory().sequence_reset_gap_fill(3, 10);
+        let frame = framed(factory().sequence_reset_gap_fill(3, 10));
         let raw = decode(&frame);
         assert_eq!(raw.msg_type(), &MsgType::SequenceReset);
         assert_eq!(raw.get_field_str(34), Some("3"));
@@ -430,7 +478,7 @@ mod tests {
 
     #[test]
     fn test_non_poss_dup_frame_omits_orig_sending_time() {
-        let frame = factory().heartbeat(4, None);
+        let frame = framed(factory().heartbeat(4, None));
         let raw = decode(&frame);
         assert_eq!(raw.get_field_str(43), None);
         assert_eq!(raw.get_field_str(122), None);
@@ -441,7 +489,7 @@ mod tests {
         let mut message = OutboundMessage::new(MsgType::NewOrderSingle);
         message.push_str(11, "ORDER-1").push_char(54, '1');
 
-        let frame = factory().application_message(7, &message);
+        let frame = framed(factory().application_message(7, &message));
         let raw = decode(&frame);
         assert_eq!(raw.msg_type(), &MsgType::NewOrderSingle);
         assert_eq!(raw.get_field_str(34), Some("7"));
@@ -479,7 +527,7 @@ mod tests {
 
             assert_eq!(resolved, Ok(version));
 
-            let frame = factory_for(version.as_str()).logon(1, 30, false);
+            let frame = framed(factory_for(version.as_str()).logon(1, 30, false));
             let raw = decode(&frame);
             assert_eq!(
                 raw.begin_string(),
@@ -539,7 +587,7 @@ mod tests {
 
     #[test]
     fn test_fix50sp2_logon_carries_fixt_begin_string_and_default_appl_ver_id() {
-        let frame = factory_for("FIX.5.0SP2").logon(1, 30, false);
+        let frame = framed(factory_for("FIX.5.0SP2").logon(1, 30, false));
         let raw = decode(&frame);
         assert_eq!(raw.begin_string(), Ok("FIXT.1.1"));
         assert_eq!(raw.get_field_str(1137), Some("9"));
@@ -550,7 +598,7 @@ mod tests {
         let mut message = OutboundMessage::new(MsgType::NewOrderSingle);
         message.push_str(11, "ORDER-1");
 
-        let frame = factory_for("FIX.5.0SP2").application_message(2, &message);
+        let frame = framed(factory_for("FIX.5.0SP2").application_message(2, &message));
         let raw = decode(&frame);
         assert_eq!(raw.begin_string(), Ok("FIXT.1.1"));
         assert_eq!(raw.get_field_str(1128), Some("9"));
@@ -564,7 +612,10 @@ mod tests {
         encoder.put_str(49, "VENUE");
         encoder.put_str(56, "CLIENT");
         encoder.put_uint(34, 1);
-        let frame = encoder.finish();
+        let frame = match encoder.finish() {
+            Ok(frame) => frame.to_vec(),
+            Err(err) => panic!("fixture frame must encode: {err}"),
+        };
 
         assert_eq!(identity.validate(&decode(&frame)), Ok(()));
     }
@@ -577,7 +628,10 @@ mod tests {
         encoder.put_str(49, "OTHER");
         encoder.put_str(56, "CLIENT");
         encoder.put_uint(34, 1);
-        let frame = encoder.finish();
+        let frame = match encoder.finish() {
+            Ok(frame) => frame.to_vec(),
+            Err(err) => panic!("fixture frame must encode: {err}"),
+        };
 
         assert_eq!(
             identity.validate(&decode(&frame)),
@@ -598,7 +652,10 @@ mod tests {
         encoder.put_str(49, "VENUE");
         encoder.put_str(56, "CLIENT");
         encoder.put_uint(34, 1);
-        let frame = encoder.finish();
+        let frame = match encoder.finish() {
+            Ok(frame) => frame.to_vec(),
+            Err(err) => panic!("fixture frame must encode: {err}"),
+        };
 
         // Our SenderSubID is the peer's TargetSubID (57).
         assert_eq!(

--- a/ironfix-engine/tests/initiator_tests.rs
+++ b/ironfix-engine/tests/initiator_tests.rs
@@ -74,7 +74,33 @@ fn venue_msg_from(
     for (tag, value) in extra {
         encoder.put_str(*tag, value);
     }
-    encoder.finish()
+    frame_of(&mut encoder)
+}
+
+/// Returns the finished frame, failing the test with the encoder's rejection.
+#[track_caller]
+fn frame_of(encoder: &mut Encoder) -> BytesMut {
+    let mut frame = BytesMut::new();
+    match encoder.finish_into(&mut frame) {
+        Ok(()) => frame,
+        Err(err) => panic!("test fixture frame must encode: {err}"),
+    }
+}
+
+/// Builds a frame around `body` with a correct BodyLength and CheckSum,
+/// bypassing the encoder's conformance checks.
+///
+/// The encoder refuses to stamp a frame whose first body field is not MsgType,
+/// which is exactly the malformed input some of these tests must put on the
+/// wire.
+fn raw_frame(body: &[u8]) -> BytesMut {
+    let mut frame = Vec::with_capacity(body.len() + 32);
+    frame.extend_from_slice(b"8=FIX.4.4\x01");
+    frame.extend_from_slice(format!("9={}\x01", body.len()).as_bytes());
+    frame.extend_from_slice(body);
+    let sum: u64 = frame.iter().map(|&b| u64::from(b)).sum();
+    frame.extend_from_slice(format!("10={:03}\x01", (sum % 256) as u8).as_bytes());
+    BytesMut::from(&frame[..])
 }
 
 /// Extracts a field from a framed message.
@@ -1521,13 +1547,11 @@ async fn test_undecodable_frame_is_dropped() {
         let mut framed = accept_logon(listener).await;
 
         // Framing is valid (8/9/10) but MsgType is absent, so the tag=value
-        // decoder rejects it.
-        let mut encoder = Encoder::new("FIX.4.4");
-        encoder.put_str(49, "VENUE");
-        encoder.put_str(56, "CLIENT");
-        encoder.put_uint(34, 2);
+        // decoder rejects it. Hand-rolled: the encoder will not produce it.
         ok(
-            framed.send(encoder.finish()).await,
+            framed
+                .send(raw_frame(b"49=VENUE\x0156=CLIENT\x0134=2\x01"))
+                .await,
             "send undecodable frame",
         );
 
@@ -1568,7 +1592,7 @@ async fn test_frame_without_msg_seq_num_is_dropped() {
         encoder.put_str(56, "CLIENT");
         encoder.put_str(52, Timestamp::now().format_millis().as_str());
         ok(
-            framed.send(encoder.finish()).await,
+            framed.send(frame_of(&mut encoder)).await,
             "send frame without MsgSeqNum",
         );
 

--- a/ironfix-engine/tests/initiator_tests.rs
+++ b/ironfix-engine/tests/initiator_tests.rs
@@ -362,6 +362,104 @@ async fn test_logon_exchange_and_logout() {
     ok(acceptor.await, "acceptor task");
 }
 
+/// A `RawData` (95/96) field carrying an embedded SOH and a non-UTF-8 byte is
+/// sent through `OutboundMessage::push_data`, arrives byte-exact, and neither
+/// tears the session down nor spends a sequence number on a legal message.
+#[tokio::test]
+async fn test_send_raw_data_field_round_trips_byte_exact() {
+    let (listener, addr) = bind_listener().await;
+    // A payload the encoder refuses as an ordinary field: it carries the SOH
+    // delimiter, `=`, and a non-UTF-8 byte, none of which survive outside a
+    // counted DATA field.
+    const PAYLOAD: &[u8] = b"sig\x01\xff=part2\x01end";
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+
+        let order = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&order), "D");
+        // First app message after the Logon (seq 1) is seq 2: encoding the
+        // RawData field spent no number and opened no gap.
+        assert_eq!(field(&order, 34).as_deref(), Some("2"));
+        assert_eq!(field(&order, 11).as_deref(), Some("ORDER-1"));
+        assert_eq!(field(&order, 95), Some(PAYLOAD.len().to_string()));
+
+        let mut decoder = Decoder::new(&order);
+        let decoded = ok(decoder.decode(), "order carrying RawData must decode");
+        // Byte-exact, including the embedded SOH and the non-UTF-8 byte.
+        assert_eq!(decoded.get_field(96).map(|f| f.value), Some(PAYLOAD));
+        // 8, 9, 35, 49, 56, 34, 52, 11, 95, 96 — no phantom field split out of
+        // the payload's SOH.
+        assert_eq!(decoded.field_count(), 10);
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    let mut order = OutboundMessage::new(MsgType::NewOrderSingle);
+    order
+        .push_str(11, "ORDER-1")
+        .push_data(95, 96, PAYLOAD.to_vec());
+    // The send path must not error and must not tear the session down.
+    ok(connection.send(order).await, "send order carrying RawData");
+
+    // The acceptor drops the socket after asserting; the session closes on that
+    // transport drop, not on an encode teardown.
+    ok(
+        timeout(Duration::from_secs(5), connection.wait_closed()).await,
+        "closed within 5s",
+    );
+    assert!(app.events().contains(&"logon".to_string()));
+
+    ok(acceptor.await, "acceptor task");
+}
+
+/// An `OutboundMessage` with no legal wire form is dropped cleanly: it spends
+/// no sequence number and does not tear the session down, so a following
+/// encodable message still flows with an unbroken sequence.
+#[tokio::test]
+async fn test_unencodable_outbound_message_is_dropped_without_teardown() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+
+        // Only the encodable message reaches the wire, and it carries seq 2:
+        // the rejected one before it neither reached the wire nor spent a
+        // number, so there is no gap for the peer to resend over.
+        let good = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&good), "D");
+        assert_eq!(field(&good, 34).as_deref(), Some("2"));
+        assert_eq!(field(&good, 11).as_deref(), Some("GOOD"));
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    // An ordinary field carrying SOH has no legal wire form; the encoder
+    // refuses it. This used to allocate a sender seq and then tear the session
+    // down on the encode failure.
+    let mut bad = OutboundMessage::new(MsgType::NewOrderSingle);
+    bad.push_str(11, "BAD").push_str(58, "text\x0149=EVIL");
+    ok(connection.send(bad).await, "queue unencodable message");
+
+    let mut good = OutboundMessage::new(MsgType::NewOrderSingle);
+    good.push_str(11, "GOOD");
+    ok(connection.send(good).await, "queue encodable message");
+
+    // The session is closed by the acceptor's transport drop after it reads the
+    // good frame, not by a teardown from the rejected message.
+    ok(
+        timeout(Duration::from_secs(5), connection.wait_closed()).await,
+        "closed within 5s",
+    );
+    assert!(app.events().contains(&"logon".to_string()));
+
+    ok(acceptor.await, "acceptor task");
+}
+
 /// Transport drop after logon fires wait_closed and on_logout.
 #[tokio::test]
 async fn test_transport_drop_fires_wait_closed() {

--- a/ironfix-example/examples/fix40_client.rs
+++ b/ironfix-example/examples/fix40_client.rs
@@ -1,6 +1,7 @@
 //! FIX 4.0 Client Example
 
 use bytes::BytesMut;
+use ironfix_core::error::EncodeError;
 use ironfix_core::{MsgType, Side};
 use ironfix_tagvalue::{Decoder, Encoder};
 use std::time::Duration;
@@ -43,7 +44,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let mut sess = Sess::new();
     let mut buf = BytesMut::with_capacity(4096);
 
-    sock.write_all(&build_logon(&cfg, sess.next())).await?;
+    sock.write_all(&build_logon(&cfg, sess.next())?).await?;
     match timeout(Duration::from_secs(10), read_msg(&mut sock, &mut buf)).await {
         Ok(Ok(m))
             if Decoder::new(&m)
@@ -67,7 +68,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         Side::Buy,
         100,
         125.0,
-    ))
+    )?)
     .await?;
     if let Ok(Ok(m)) = timeout(Duration::from_secs(5), read_msg(&mut sock, &mut buf)).await
         && let Ok(r) = Decoder::new(&m).decode()
@@ -78,11 +79,11 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let mut hb = interval(Duration::from_secs(cfg.heartbeat_interval));
     for _ in 0..2 {
         hb.tick().await;
-        sock.write_all(&build_hb(&cfg, sess.next())).await?;
+        sock.write_all(&build_hb(&cfg, sess.next())?).await?;
         info!("HB sent");
     }
 
-    sock.write_all(&build_logout(&cfg, sess.next())).await?;
+    sock.write_all(&build_logout(&cfg, sess.next())?).await?;
     info!("Done");
     Ok(())
 }
@@ -101,7 +102,7 @@ async fn read_msg(
     }
 }
 
-fn build_logon(c: &ExampleConfig, seq: u64) -> Vec<u8> {
+fn build_logon(c: &ExampleConfig, seq: u64) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "A");
     e.put_str(49, &c.sender_comp_id);
@@ -110,27 +111,27 @@ fn build_logon(c: &ExampleConfig, seq: u64) -> Vec<u8> {
     e.put_str(52, &format_timestamp());
     e.put_str(98, "0");
     e.put_str(108, &c.heartbeat_interval.to_string());
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
-fn build_hb(c: &ExampleConfig, seq: u64) -> Vec<u8> {
+fn build_hb(c: &ExampleConfig, seq: u64) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "0");
     e.put_str(49, &c.sender_comp_id);
     e.put_str(56, &c.target_comp_id);
     e.put_str(34, &seq.to_string());
     e.put_str(52, &format_timestamp());
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
-fn build_logout(c: &ExampleConfig, seq: u64) -> Vec<u8> {
+fn build_logout(c: &ExampleConfig, seq: u64) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "5");
     e.put_str(49, &c.sender_comp_id);
     e.put_str(56, &c.target_comp_id);
     e.put_str(34, &seq.to_string());
     e.put_str(52, &format_timestamp());
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
 fn build_order(
@@ -141,7 +142,7 @@ fn build_order(
     side: Side,
     qty: u64,
     px: f64,
-) -> Vec<u8> {
+) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "D");
     e.put_str(49, &c.sender_comp_id);
@@ -156,5 +157,5 @@ fn build_order(
     e.put_str(38, &qty.to_string());
     e.put_str(40, "2");
     e.put_str(44, &format!("{:.2}", px));
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }

--- a/ironfix-example/examples/fix40_server.rs
+++ b/ironfix-example/examples/fix40_server.rs
@@ -2,6 +2,7 @@
 
 use bytes::BytesMut;
 use ironfix_core::MsgType;
+use ironfix_core::error::EncodeError;
 use ironfix_tagvalue::{Decoder, Encoder};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -75,11 +76,11 @@ async fn handle(
                 let resp = match raw.msg_type() {
                     MsgType::Logon => {
                         info!("Logon");
-                        Some(build_logon(&cfg))
+                        Some(build_logon(&cfg)?)
                     }
-                    MsgType::TestRequest => Some(build_hb(&cfg, raw.get_field_str(112))),
+                    MsgType::TestRequest => Some(build_hb(&cfg, raw.get_field_str(112))?),
                     MsgType::Logout => {
-                        sock.write_all(&build_logout(&cfg)).await?;
+                        sock.write_all(&build_logout(&cfg)?).await?;
                         return Ok(());
                     }
                     MsgType::NewOrderSingle => {
@@ -90,7 +91,7 @@ async fn handle(
                             raw.get_field_str(55).unwrap_or("N/A"),
                             raw.get_field_str(54).unwrap_or("1"),
                             raw.get_field_str(38).unwrap_or("0"),
-                        ))
+                        )?)
                     }
                     _ => {
                         warn!("Unhandled: {:?}", raw.msg_type());
@@ -109,7 +110,7 @@ async fn handle(
     Ok(())
 }
 
-fn build_logon(c: &ExampleConfig) -> Vec<u8> {
+fn build_logon(c: &ExampleConfig) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "A");
     e.put_str(49, &c.sender_comp_id);
@@ -118,10 +119,10 @@ fn build_logon(c: &ExampleConfig) -> Vec<u8> {
     e.put_str(52, &format_timestamp());
     e.put_str(98, "0");
     e.put_str(108, &c.heartbeat_interval.to_string());
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
-fn build_hb(c: &ExampleConfig, id: Option<&str>) -> Vec<u8> {
+fn build_hb(c: &ExampleConfig, id: Option<&str>) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "0");
     e.put_str(49, &c.sender_comp_id);
@@ -131,20 +132,26 @@ fn build_hb(c: &ExampleConfig, id: Option<&str>) -> Vec<u8> {
     if let Some(i) = id {
         e.put_str(112, i);
     }
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
-fn build_logout(c: &ExampleConfig) -> Vec<u8> {
+fn build_logout(c: &ExampleConfig) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "5");
     e.put_str(49, &c.sender_comp_id);
     e.put_str(56, &c.target_comp_id);
     e.put_str(34, "1");
     e.put_str(52, &format_timestamp());
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
-fn build_exec(c: &ExampleConfig, clid: &str, sym: &str, side: &str, qty: &str) -> Vec<u8> {
+fn build_exec(
+    c: &ExampleConfig,
+    clid: &str,
+    sym: &str,
+    side: &str,
+    qty: &str,
+) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "8");
     e.put_str(49, &c.sender_comp_id);
@@ -162,5 +169,5 @@ fn build_exec(c: &ExampleConfig, clid: &str, sym: &str, side: &str, qty: &str) -
     e.put_str(151, qty);
     e.put_str(14, "0");
     e.put_str(6, "0");
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }

--- a/ironfix-example/examples/fix41_client.rs
+++ b/ironfix-example/examples/fix41_client.rs
@@ -1,5 +1,6 @@
 //! FIX 4.1 Client Example
 use bytes::BytesMut;
+use ironfix_core::error::EncodeError;
 use ironfix_core::{MsgType, Side};
 use ironfix_tagvalue::{Decoder, Encoder};
 use std::time::Duration;
@@ -26,7 +27,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let mut seq = 1u64;
     let mut buf = BytesMut::with_capacity(4096);
 
-    sock.write_all(&build_msg(&cfg, "A", seq, None)).await?;
+    sock.write_all(&build_msg(&cfg, "A", seq, None)?).await?;
     seq += 1;
     match timeout(Duration::from_secs(10), read_msg(&mut sock, &mut buf)).await {
         Ok(Ok(m))
@@ -43,7 +44,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    sock.write_all(&build_order(&cfg, seq, "O1", "MSFT", Side::Buy, 50, 300.0))
+    sock.write_all(&build_order(&cfg, seq, "O1", "MSFT", Side::Buy, 50, 300.0)?)
         .await?;
     seq += 1;
     if let Ok(Ok(m)) = timeout(Duration::from_secs(5), read_msg(&mut sock, &mut buf)).await
@@ -55,12 +56,12 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let mut hb = interval(Duration::from_secs(cfg.heartbeat_interval));
     for _ in 0..2 {
         hb.tick().await;
-        sock.write_all(&build_msg(&cfg, "0", seq, None)).await?;
+        sock.write_all(&build_msg(&cfg, "0", seq, None)?).await?;
         seq += 1;
         info!("HB");
     }
 
-    sock.write_all(&build_msg(&cfg, "5", seq, None)).await?;
+    sock.write_all(&build_msg(&cfg, "5", seq, None)?).await?;
     info!("Done");
     Ok(())
 }
@@ -79,7 +80,12 @@ async fn read_msg(
     }
 }
 
-fn build_msg(c: &ExampleConfig, mt: &str, seq: u64, id: Option<&str>) -> Vec<u8> {
+fn build_msg(
+    c: &ExampleConfig,
+    mt: &str,
+    seq: u64,
+    id: Option<&str>,
+) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, mt);
     e.put_str(49, &c.sender_comp_id);
@@ -93,7 +99,7 @@ fn build_msg(c: &ExampleConfig, mt: &str, seq: u64, id: Option<&str>) -> Vec<u8>
     if let Some(i) = id {
         e.put_str(112, i);
     }
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
 fn build_order(
@@ -104,7 +110,7 @@ fn build_order(
     side: Side,
     qty: u64,
     px: f64,
-) -> Vec<u8> {
+) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "D");
     e.put_str(49, &c.sender_comp_id);
@@ -119,5 +125,5 @@ fn build_order(
     e.put_str(38, &qty.to_string());
     e.put_str(40, "2");
     e.put_str(44, &format!("{:.2}", px));
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }

--- a/ironfix-example/examples/fix41_server.rs
+++ b/ironfix-example/examples/fix41_server.rs
@@ -1,6 +1,7 @@
 //! FIX 4.1 Server Example
 use bytes::BytesMut;
 use ironfix_core::MsgType;
+use ironfix_core::error::EncodeError;
 use ironfix_tagvalue::{Decoder, Encoder};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -57,14 +58,14 @@ async fn handle(
                 let resp = match raw.msg_type() {
                     MsgType::Logon => {
                         info!("Logon");
-                        Some(build_msg(&cfg, "A", None))
+                        Some(build_msg(&cfg, "A", None)?)
                     }
-                    MsgType::TestRequest => Some(build_msg(&cfg, "0", raw.get_field_str(112))),
+                    MsgType::TestRequest => Some(build_msg(&cfg, "0", raw.get_field_str(112))?),
                     MsgType::Logout => {
-                        sock.write_all(&build_msg(&cfg, "5", None)).await?;
+                        sock.write_all(&build_msg(&cfg, "5", None)?).await?;
                         return Ok(());
                     }
-                    MsgType::NewOrderSingle => Some(build_exec(&cfg, &raw)),
+                    MsgType::NewOrderSingle => Some(build_exec(&cfg, &raw)?),
                     _ => {
                         warn!("Unhandled: {:?}", raw.msg_type());
                         None
@@ -80,7 +81,7 @@ async fn handle(
     Ok(())
 }
 
-fn build_msg(c: &ExampleConfig, mt: &str, id: Option<&str>) -> Vec<u8> {
+fn build_msg(c: &ExampleConfig, mt: &str, id: Option<&str>) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, mt);
     e.put_str(49, &c.sender_comp_id);
@@ -94,10 +95,13 @@ fn build_msg(c: &ExampleConfig, mt: &str, id: Option<&str>) -> Vec<u8> {
     if let Some(i) = id {
         e.put_str(112, i);
     }
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
-fn build_exec(c: &ExampleConfig, raw: &ironfix_tagvalue::RawMessage<'_>) -> Vec<u8> {
+fn build_exec(
+    c: &ExampleConfig,
+    raw: &ironfix_tagvalue::RawMessage<'_>,
+) -> Result<Vec<u8>, EncodeError> {
     let clid = raw.get_field_str(11).unwrap_or("0");
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "8");
@@ -116,5 +120,5 @@ fn build_exec(c: &ExampleConfig, raw: &ironfix_tagvalue::RawMessage<'_>) -> Vec<
     e.put_str(151, raw.get_field_str(38).unwrap_or("0"));
     e.put_str(14, "0");
     e.put_str(6, "0");
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }

--- a/ironfix-example/examples/fix42_client.rs
+++ b/ironfix-example/examples/fix42_client.rs
@@ -1,5 +1,6 @@
 //! FIX 4.2 Client Example
 use bytes::BytesMut;
+use ironfix_core::error::EncodeError;
 use ironfix_core::{MsgType, Side};
 use ironfix_tagvalue::{Decoder, Encoder};
 use std::time::Duration;
@@ -26,7 +27,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let mut seq = 1u64;
     let mut buf = BytesMut::with_capacity(4096);
 
-    sock.write_all(&build_msg(&cfg, "A", seq, None)).await?;
+    sock.write_all(&build_msg(&cfg, "A", seq, None)?).await?;
     seq += 1;
     match timeout(Duration::from_secs(10), read_msg(&mut sock, &mut buf)).await {
         Ok(Ok(m))
@@ -43,8 +44,16 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    sock.write_all(&build_order(&cfg, seq, "O1", "GOOG", Side::Sell, 25, 140.0))
-        .await?;
+    sock.write_all(&build_order(
+        &cfg,
+        seq,
+        "O1",
+        "GOOG",
+        Side::Sell,
+        25,
+        140.0,
+    )?)
+    .await?;
     seq += 1;
     if let Ok(Ok(m)) = timeout(Duration::from_secs(5), read_msg(&mut sock, &mut buf)).await
         && let Ok(r) = Decoder::new(&m).decode()
@@ -55,12 +64,12 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let mut hb = interval(Duration::from_secs(cfg.heartbeat_interval));
     for _ in 0..2 {
         hb.tick().await;
-        sock.write_all(&build_msg(&cfg, "0", seq, None)).await?;
+        sock.write_all(&build_msg(&cfg, "0", seq, None)?).await?;
         seq += 1;
         info!("HB");
     }
 
-    sock.write_all(&build_msg(&cfg, "5", seq, None)).await?;
+    sock.write_all(&build_msg(&cfg, "5", seq, None)?).await?;
     info!("Done");
     Ok(())
 }
@@ -79,7 +88,12 @@ async fn read_msg(
     }
 }
 
-fn build_msg(c: &ExampleConfig, mt: &str, seq: u64, id: Option<&str>) -> Vec<u8> {
+fn build_msg(
+    c: &ExampleConfig,
+    mt: &str,
+    seq: u64,
+    id: Option<&str>,
+) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, mt);
     e.put_str(49, &c.sender_comp_id);
@@ -93,7 +107,7 @@ fn build_msg(c: &ExampleConfig, mt: &str, seq: u64, id: Option<&str>) -> Vec<u8>
     if let Some(i) = id {
         e.put_str(112, i);
     }
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
 fn build_order(
@@ -104,7 +118,7 @@ fn build_order(
     side: Side,
     qty: u64,
     px: f64,
-) -> Vec<u8> {
+) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "D");
     e.put_str(49, &c.sender_comp_id);
@@ -119,5 +133,5 @@ fn build_order(
     e.put_str(38, &qty.to_string());
     e.put_str(40, "2");
     e.put_str(44, &format!("{:.2}", px));
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }

--- a/ironfix-example/examples/fix42_server.rs
+++ b/ironfix-example/examples/fix42_server.rs
@@ -1,6 +1,7 @@
 //! FIX 4.2 Server Example
 use bytes::BytesMut;
 use ironfix_core::MsgType;
+use ironfix_core::error::EncodeError;
 use ironfix_tagvalue::{Decoder, Encoder};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -57,14 +58,14 @@ async fn handle(
                 let resp = match raw.msg_type() {
                     MsgType::Logon => {
                         info!("Logon");
-                        Some(build_msg(&cfg, "A", None))
+                        Some(build_msg(&cfg, "A", None)?)
                     }
-                    MsgType::TestRequest => Some(build_msg(&cfg, "0", raw.get_field_str(112))),
+                    MsgType::TestRequest => Some(build_msg(&cfg, "0", raw.get_field_str(112))?),
                     MsgType::Logout => {
-                        sock.write_all(&build_msg(&cfg, "5", None)).await?;
+                        sock.write_all(&build_msg(&cfg, "5", None)?).await?;
                         return Ok(());
                     }
-                    MsgType::NewOrderSingle => Some(build_exec(&cfg, &raw)),
+                    MsgType::NewOrderSingle => Some(build_exec(&cfg, &raw)?),
                     _ => {
                         warn!("Unhandled: {:?}", raw.msg_type());
                         None
@@ -80,7 +81,7 @@ async fn handle(
     Ok(())
 }
 
-fn build_msg(c: &ExampleConfig, mt: &str, id: Option<&str>) -> Vec<u8> {
+fn build_msg(c: &ExampleConfig, mt: &str, id: Option<&str>) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, mt);
     e.put_str(49, &c.sender_comp_id);
@@ -94,10 +95,13 @@ fn build_msg(c: &ExampleConfig, mt: &str, id: Option<&str>) -> Vec<u8> {
     if let Some(i) = id {
         e.put_str(112, i);
     }
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
-fn build_exec(c: &ExampleConfig, raw: &ironfix_tagvalue::RawMessage<'_>) -> Vec<u8> {
+fn build_exec(
+    c: &ExampleConfig,
+    raw: &ironfix_tagvalue::RawMessage<'_>,
+) -> Result<Vec<u8>, EncodeError> {
     let clid = raw.get_field_str(11).unwrap_or("0");
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "8");
@@ -116,5 +120,5 @@ fn build_exec(c: &ExampleConfig, raw: &ironfix_tagvalue::RawMessage<'_>) -> Vec<
     e.put_str(151, raw.get_field_str(38).unwrap_or("0"));
     e.put_str(14, "0");
     e.put_str(6, "0");
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }

--- a/ironfix-example/examples/fix43_client.rs
+++ b/ironfix-example/examples/fix43_client.rs
@@ -1,5 +1,6 @@
 //! FIX 4.3 Client Example
 use bytes::BytesMut;
+use ironfix_core::error::EncodeError;
 use ironfix_core::{MsgType, Side};
 use ironfix_tagvalue::{Decoder, Encoder};
 use std::time::Duration;
@@ -26,7 +27,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let mut seq = 1u64;
     let mut buf = BytesMut::with_capacity(4096);
 
-    sock.write_all(&build_msg(&cfg, "A", seq, None)).await?;
+    sock.write_all(&build_msg(&cfg, "A", seq, None)?).await?;
     seq += 1;
     match timeout(Duration::from_secs(10), read_msg(&mut sock, &mut buf)).await {
         Ok(Ok(m))
@@ -43,7 +44,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    sock.write_all(&build_order(&cfg, seq, "O1", "AMZN", Side::Buy, 10, 180.0))
+    sock.write_all(&build_order(&cfg, seq, "O1", "AMZN", Side::Buy, 10, 180.0)?)
         .await?;
     seq += 1;
     if let Ok(Ok(m)) = timeout(Duration::from_secs(5), read_msg(&mut sock, &mut buf)).await
@@ -55,12 +56,12 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let mut hb = interval(Duration::from_secs(cfg.heartbeat_interval));
     for _ in 0..2 {
         hb.tick().await;
-        sock.write_all(&build_msg(&cfg, "0", seq, None)).await?;
+        sock.write_all(&build_msg(&cfg, "0", seq, None)?).await?;
         seq += 1;
         info!("HB");
     }
 
-    sock.write_all(&build_msg(&cfg, "5", seq, None)).await?;
+    sock.write_all(&build_msg(&cfg, "5", seq, None)?).await?;
     info!("Done");
     Ok(())
 }
@@ -79,7 +80,12 @@ async fn read_msg(
     }
 }
 
-fn build_msg(c: &ExampleConfig, mt: &str, seq: u64, id: Option<&str>) -> Vec<u8> {
+fn build_msg(
+    c: &ExampleConfig,
+    mt: &str,
+    seq: u64,
+    id: Option<&str>,
+) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, mt);
     e.put_str(49, &c.sender_comp_id);
@@ -93,7 +99,7 @@ fn build_msg(c: &ExampleConfig, mt: &str, seq: u64, id: Option<&str>) -> Vec<u8>
     if let Some(i) = id {
         e.put_str(112, i);
     }
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
 fn build_order(
@@ -104,7 +110,7 @@ fn build_order(
     side: Side,
     qty: u64,
     px: f64,
-) -> Vec<u8> {
+) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "D");
     e.put_str(49, &c.sender_comp_id);
@@ -119,5 +125,5 @@ fn build_order(
     e.put_str(38, &qty.to_string());
     e.put_str(40, "2");
     e.put_str(44, &format!("{:.2}", px));
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }

--- a/ironfix-example/examples/fix43_server.rs
+++ b/ironfix-example/examples/fix43_server.rs
@@ -1,6 +1,7 @@
 //! FIX 4.3 Server Example
 use bytes::BytesMut;
 use ironfix_core::MsgType;
+use ironfix_core::error::EncodeError;
 use ironfix_tagvalue::{Decoder, Encoder};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -57,14 +58,14 @@ async fn handle(
                 let resp = match raw.msg_type() {
                     MsgType::Logon => {
                         info!("Logon");
-                        Some(build_msg(&cfg, "A", None))
+                        Some(build_msg(&cfg, "A", None)?)
                     }
-                    MsgType::TestRequest => Some(build_msg(&cfg, "0", raw.get_field_str(112))),
+                    MsgType::TestRequest => Some(build_msg(&cfg, "0", raw.get_field_str(112))?),
                     MsgType::Logout => {
-                        sock.write_all(&build_msg(&cfg, "5", None)).await?;
+                        sock.write_all(&build_msg(&cfg, "5", None)?).await?;
                         return Ok(());
                     }
-                    MsgType::NewOrderSingle => Some(build_exec(&cfg, &raw)),
+                    MsgType::NewOrderSingle => Some(build_exec(&cfg, &raw)?),
                     _ => {
                         warn!("Unhandled: {:?}", raw.msg_type());
                         None
@@ -80,7 +81,7 @@ async fn handle(
     Ok(())
 }
 
-fn build_msg(c: &ExampleConfig, mt: &str, id: Option<&str>) -> Vec<u8> {
+fn build_msg(c: &ExampleConfig, mt: &str, id: Option<&str>) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, mt);
     e.put_str(49, &c.sender_comp_id);
@@ -94,10 +95,13 @@ fn build_msg(c: &ExampleConfig, mt: &str, id: Option<&str>) -> Vec<u8> {
     if let Some(i) = id {
         e.put_str(112, i);
     }
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
-fn build_exec(c: &ExampleConfig, raw: &ironfix_tagvalue::RawMessage<'_>) -> Vec<u8> {
+fn build_exec(
+    c: &ExampleConfig,
+    raw: &ironfix_tagvalue::RawMessage<'_>,
+) -> Result<Vec<u8>, EncodeError> {
     let clid = raw.get_field_str(11).unwrap_or("0");
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "8");
@@ -115,5 +119,5 @@ fn build_exec(c: &ExampleConfig, raw: &ironfix_tagvalue::RawMessage<'_>) -> Vec<
     e.put_str(151, raw.get_field_str(38).unwrap_or("0"));
     e.put_str(14, "0");
     e.put_str(6, "0");
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }

--- a/ironfix-example/examples/fix44_client.rs
+++ b/ironfix-example/examples/fix44_client.rs
@@ -7,6 +7,7 @@ use tokio::net::TcpStream;
 use tokio::time::{interval, timeout};
 use tracing::{error, info};
 
+use ironfix_core::error::EncodeError;
 use ironfix_core::{MsgType, Side};
 use ironfix_tagvalue::{Decoder, Encoder};
 
@@ -40,7 +41,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let mut buf = BytesMut::with_capacity(4096);
 
     // Logon
-    sock.write_all(&build_logon(&cfg, sess.next())).await?;
+    sock.write_all(&build_logon(&cfg, sess.next())?).await?;
     match timeout(Duration::from_secs(10), read_msg(&mut sock, &mut buf)).await {
         Ok(Ok(m))
             if Decoder::new(&m)
@@ -65,7 +66,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         Side::Buy,
         100,
         150.50,
-    ))
+    )?)
     .await?;
     if let Ok(Ok(m)) = timeout(Duration::from_secs(5), read_msg(&mut sock, &mut buf)).await
         && let Ok(r) = Decoder::new(&m).decode()
@@ -77,12 +78,12 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let mut hb = interval(Duration::from_secs(cfg.heartbeat_interval));
     for _ in 0..2 {
         hb.tick().await;
-        sock.write_all(&build_hb(&cfg, sess.next())).await?;
+        sock.write_all(&build_hb(&cfg, sess.next())?).await?;
         info!("Sent HB");
     }
 
     // Logout
-    sock.write_all(&build_logout(&cfg, sess.next())).await?;
+    sock.write_all(&build_logout(&cfg, sess.next())?).await?;
     info!("Done");
     Ok(())
 }
@@ -101,7 +102,7 @@ async fn read_msg(
     }
 }
 
-fn build_logon(c: &ExampleConfig, seq: u64) -> Vec<u8> {
+fn build_logon(c: &ExampleConfig, seq: u64) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "A");
     e.put_str(49, &c.sender_comp_id);
@@ -110,27 +111,27 @@ fn build_logon(c: &ExampleConfig, seq: u64) -> Vec<u8> {
     e.put_str(52, &format_timestamp());
     e.put_str(98, "0");
     e.put_str(108, &c.heartbeat_interval.to_string());
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
-fn build_hb(c: &ExampleConfig, seq: u64) -> Vec<u8> {
+fn build_hb(c: &ExampleConfig, seq: u64) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "0");
     e.put_str(49, &c.sender_comp_id);
     e.put_str(56, &c.target_comp_id);
     e.put_str(34, &seq.to_string());
     e.put_str(52, &format_timestamp());
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
-fn build_logout(c: &ExampleConfig, seq: u64) -> Vec<u8> {
+fn build_logout(c: &ExampleConfig, seq: u64) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "5");
     e.put_str(49, &c.sender_comp_id);
     e.put_str(56, &c.target_comp_id);
     e.put_str(34, &seq.to_string());
     e.put_str(52, &format_timestamp());
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
 fn build_order(
@@ -141,7 +142,7 @@ fn build_order(
     side: Side,
     qty: u64,
     px: f64,
-) -> Vec<u8> {
+) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "D");
     e.put_str(49, &c.sender_comp_id);
@@ -156,5 +157,5 @@ fn build_order(
     e.put_str(38, &qty.to_string());
     e.put_str(40, "2");
     e.put_str(44, &format!("{:.2}", px));
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }

--- a/ironfix-example/examples/fix44_server.rs
+++ b/ironfix-example/examples/fix44_server.rs
@@ -10,6 +10,7 @@ use tokio::sync::Mutex;
 use tracing::{error, info, warn};
 
 use ironfix_core::MsgType;
+use ironfix_core::error::EncodeError;
 use ironfix_tagvalue::{Decoder, Encoder};
 
 mod common;
@@ -87,14 +88,14 @@ async fn handle(
                             s.logged_in = true;
                         }
                         info!("Client logged in");
-                        Some(build_logon(&cfg, seq))
+                        Some(build_logon(&cfg, seq)?)
                     }
                     MsgType::TestRequest => {
                         let id = raw.get_field_str(112);
-                        Some(build_heartbeat(&cfg, seq, id))
+                        Some(build_heartbeat(&cfg, seq, id)?)
                     }
                     MsgType::Logout => {
-                        sock.write_all(&build_logout(&cfg, seq)).await?;
+                        sock.write_all(&build_logout(&cfg, seq)?).await?;
                         return Ok(());
                     }
                     MsgType::NewOrderSingle => {
@@ -102,7 +103,7 @@ async fn handle(
                         let sym = raw.get_field_str(55).unwrap_or("N/A");
                         let side = raw.get_field_str(54).unwrap_or("1");
                         let qty = raw.get_field_str(38).unwrap_or("0");
-                        Some(build_exec(&cfg, seq, clid, sym, side, qty))
+                        Some(build_exec(&cfg, seq, clid, sym, side, qty)?)
                     }
                     _ => {
                         warn!("Unhandled: {:?}", raw.msg_type());
@@ -123,7 +124,7 @@ async fn handle(
     Ok(())
 }
 
-fn build_logon(c: &ExampleConfig, seq: u64) -> Vec<u8> {
+fn build_logon(c: &ExampleConfig, seq: u64) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "A");
     e.put_str(49, &c.sender_comp_id);
@@ -132,10 +133,14 @@ fn build_logon(c: &ExampleConfig, seq: u64) -> Vec<u8> {
     e.put_str(52, &format_timestamp());
     e.put_str(98, "0");
     e.put_str(108, &c.heartbeat_interval.to_string());
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
-fn build_heartbeat(c: &ExampleConfig, seq: u64, test_req_id: Option<&str>) -> Vec<u8> {
+fn build_heartbeat(
+    c: &ExampleConfig,
+    seq: u64,
+    test_req_id: Option<&str>,
+) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "0");
     e.put_str(49, &c.sender_comp_id);
@@ -145,17 +150,17 @@ fn build_heartbeat(c: &ExampleConfig, seq: u64, test_req_id: Option<&str>) -> Ve
     if let Some(id) = test_req_id {
         e.put_str(112, id);
     }
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
-fn build_logout(c: &ExampleConfig, seq: u64) -> Vec<u8> {
+fn build_logout(c: &ExampleConfig, seq: u64) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "5");
     e.put_str(49, &c.sender_comp_id);
     e.put_str(56, &c.target_comp_id);
     e.put_str(34, &seq.to_string());
     e.put_str(52, &format_timestamp());
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
 fn build_exec(
@@ -165,7 +170,7 @@ fn build_exec(
     sym: &str,
     side: &str,
     qty: &str,
-) -> Vec<u8> {
+) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "8");
     e.put_str(49, &c.sender_comp_id);
@@ -182,5 +187,5 @@ fn build_exec(
     e.put_str(151, qty);
     e.put_str(14, "0");
     e.put_str(6, "0");
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }

--- a/ironfix-example/examples/fix44_server_channel.rs
+++ b/ironfix-example/examples/fix44_server_channel.rs
@@ -16,6 +16,7 @@ use tokio::sync::{Mutex, mpsc};
 use tracing::{error, info, warn};
 
 use ironfix_core::MsgType;
+use ironfix_core::error::EncodeError;
 use ironfix_tagvalue::{Decoder, Encoder};
 
 mod common;
@@ -188,6 +189,20 @@ async fn handle_connection(
 }
 
 /// Message processor - handles business logic
+/// Unwraps an encoded frame, dropping the response if the encoder refused it.
+///
+/// A rejected value has no legal wire form, so there is nothing to send; the
+/// processor logs it and carries on rather than taking the session down.
+fn encoded(session_id: &str, frame: Result<Vec<u8>, EncodeError>) -> Option<Vec<u8>> {
+    match frame {
+        Ok(frame) => Some(frame),
+        Err(err) => {
+            error!("cannot encode response for session {session_id}: {err}");
+            None
+        }
+    }
+}
+
 async fn message_processor(mut rx: mpsc::Receiver<IncomingMessage>, cfg: ExampleConfig) {
     info!("Message processor started");
 
@@ -204,29 +219,33 @@ async fn message_processor(mut rx: mpsc::Receiver<IncomingMessage>, cfg: Example
         let response = match msg.msg_type {
             MsgType::Logon => {
                 info!("Session {} logged in", msg.session_id);
-                Some(OutgoingMessage {
+                encoded(&msg.session_id, build_logon(&cfg)).map(|data| OutgoingMessage {
                     session_id: msg.session_id.clone(),
-                    data: build_logon(&cfg),
+                    data,
                     close_after: false,
                 })
             }
             MsgType::TestRequest => {
                 let test_req_id = msg.fields.get(&112).map(|s| s.as_str());
-                Some(OutgoingMessage {
-                    session_id: msg.session_id.clone(),
-                    data: build_heartbeat(&cfg, test_req_id),
-                    close_after: false,
+                encoded(&msg.session_id, build_heartbeat(&cfg, test_req_id)).map(|data| {
+                    OutgoingMessage {
+                        session_id: msg.session_id.clone(),
+                        data,
+                        close_after: false,
+                    }
                 })
             }
             MsgType::Heartbeat => {
                 // Just acknowledge, no response needed
                 None
             }
-            MsgType::Logout => Some(OutgoingMessage {
-                session_id: msg.session_id.clone(),
-                data: build_logout(&cfg),
-                close_after: true,
-            }),
+            MsgType::Logout => {
+                encoded(&msg.session_id, build_logout(&cfg)).map(|data| OutgoingMessage {
+                    session_id: msg.session_id.clone(),
+                    data,
+                    close_after: true,
+                })
+            }
             MsgType::NewOrderSingle => {
                 order_counter += 1;
                 let clid = msg.fields.get(&11).map(|s| s.as_str()).unwrap_or("0");
@@ -239,9 +258,13 @@ async fn message_processor(mut rx: mpsc::Receiver<IncomingMessage>, cfg: Example
                     clid, sym, side, qty, order_counter
                 );
 
-                Some(OutgoingMessage {
+                encoded(
+                    &msg.session_id,
+                    build_exec(&cfg, clid, sym, side, qty, order_counter),
+                )
+                .map(|data| OutgoingMessage {
                     session_id: msg.session_id.clone(),
-                    data: build_exec(&cfg, clid, sym, side, qty, order_counter),
+                    data,
                     close_after: false,
                 })
             }
@@ -262,7 +285,7 @@ async fn message_processor(mut rx: mpsc::Receiver<IncomingMessage>, cfg: Example
     info!("Message processor stopped");
 }
 
-fn build_logon(c: &ExampleConfig) -> Vec<u8> {
+fn build_logon(c: &ExampleConfig) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "A");
     e.put_str(49, &c.sender_comp_id);
@@ -271,10 +294,10 @@ fn build_logon(c: &ExampleConfig) -> Vec<u8> {
     e.put_str(52, &format_timestamp());
     e.put_str(98, "0");
     e.put_str(108, &c.heartbeat_interval.to_string());
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
-fn build_heartbeat(c: &ExampleConfig, test_req_id: Option<&str>) -> Vec<u8> {
+fn build_heartbeat(c: &ExampleConfig, test_req_id: Option<&str>) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "0");
     e.put_str(49, &c.sender_comp_id);
@@ -284,17 +307,17 @@ fn build_heartbeat(c: &ExampleConfig, test_req_id: Option<&str>) -> Vec<u8> {
     if let Some(id) = test_req_id {
         e.put_str(112, id);
     }
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
-fn build_logout(c: &ExampleConfig) -> Vec<u8> {
+fn build_logout(c: &ExampleConfig) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "5");
     e.put_str(49, &c.sender_comp_id);
     e.put_str(56, &c.target_comp_id);
     e.put_str(34, "1");
     e.put_str(52, &format_timestamp());
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
 fn build_exec(
@@ -304,7 +327,7 @@ fn build_exec(
     side: &str,
     qty: &str,
     order_id: u64,
-) -> Vec<u8> {
+) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "8");
     e.put_str(49, &c.sender_comp_id);
@@ -321,5 +344,5 @@ fn build_exec(
     e.put_str(151, qty); // LeavesQty
     e.put_str(14, "0"); // CumQty
     e.put_str(6, "0"); // AvgPx
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }

--- a/ironfix-example/examples/fix50_client.rs
+++ b/ironfix-example/examples/fix50_client.rs
@@ -1,5 +1,6 @@
 //! FIX 5.0 Client Example (FIXT.1.1 Transport)
 use bytes::BytesMut;
+use ironfix_core::error::EncodeError;
 use ironfix_core::{MsgType, Side};
 use ironfix_tagvalue::{Decoder, Encoder};
 use std::time::Duration;
@@ -31,7 +32,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let mut seq = 1u64;
     let mut buf = BytesMut::with_capacity(4096);
 
-    sock.write_all(&build_logon(&cfg, seq)).await?;
+    sock.write_all(&build_logon(&cfg, seq)?).await?;
     seq += 1;
     match timeout(Duration::from_secs(10), read_msg(&mut sock, &mut buf)).await {
         Ok(Ok(m))
@@ -48,7 +49,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    sock.write_all(&build_order(&cfg, seq, "O1", "TSLA", Side::Buy, 50, 250.0))
+    sock.write_all(&build_order(&cfg, seq, "O1", "TSLA", Side::Buy, 50, 250.0)?)
         .await?;
     seq += 1;
     if let Ok(Ok(m)) = timeout(Duration::from_secs(5), read_msg(&mut sock, &mut buf)).await
@@ -60,12 +61,12 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let mut hb = interval(Duration::from_secs(cfg.heartbeat_interval));
     for _ in 0..2 {
         hb.tick().await;
-        sock.write_all(&build_hb(&cfg, seq)).await?;
+        sock.write_all(&build_hb(&cfg, seq)?).await?;
         seq += 1;
         info!("HB");
     }
 
-    sock.write_all(&build_logout(&cfg, seq)).await?;
+    sock.write_all(&build_logout(&cfg, seq)?).await?;
     info!("Done");
     Ok(())
 }
@@ -84,7 +85,7 @@ async fn read_msg(
     }
 }
 
-fn build_logon(c: &ExampleConfig, seq: u64) -> Vec<u8> {
+fn build_logon(c: &ExampleConfig, seq: u64) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "A");
     e.put_str(49, &c.sender_comp_id);
@@ -94,27 +95,27 @@ fn build_logon(c: &ExampleConfig, seq: u64) -> Vec<u8> {
     e.put_str(98, "0");
     e.put_str(108, &c.heartbeat_interval.to_string());
     e.put_str(1137, APPL_VER_ID);
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
-fn build_hb(c: &ExampleConfig, seq: u64) -> Vec<u8> {
+fn build_hb(c: &ExampleConfig, seq: u64) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "0");
     e.put_str(49, &c.sender_comp_id);
     e.put_str(56, &c.target_comp_id);
     e.put_str(34, &seq.to_string());
     e.put_str(52, &format_timestamp());
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
-fn build_logout(c: &ExampleConfig, seq: u64) -> Vec<u8> {
+fn build_logout(c: &ExampleConfig, seq: u64) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "5");
     e.put_str(49, &c.sender_comp_id);
     e.put_str(56, &c.target_comp_id);
     e.put_str(34, &seq.to_string());
     e.put_str(52, &format_timestamp());
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
 fn build_order(
@@ -125,7 +126,7 @@ fn build_order(
     side: Side,
     qty: u64,
     px: f64,
-) -> Vec<u8> {
+) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "D");
     e.put_str(49, &c.sender_comp_id);
@@ -141,5 +142,5 @@ fn build_order(
     e.put_str(38, &qty.to_string());
     e.put_str(40, "2");
     e.put_str(44, &format!("{:.2}", px));
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }

--- a/ironfix-example/examples/fix50_server.rs
+++ b/ironfix-example/examples/fix50_server.rs
@@ -1,6 +1,7 @@
 //! FIX 5.0 Server Example (FIXT.1.1 Transport)
 use bytes::BytesMut;
 use ironfix_core::MsgType;
+use ironfix_core::error::EncodeError;
 use ironfix_tagvalue::{Decoder, Encoder};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -62,14 +63,14 @@ async fn handle(
                 let resp = match raw.msg_type() {
                     MsgType::Logon => {
                         info!("Logon");
-                        Some(build_logon(&cfg))
+                        Some(build_logon(&cfg)?)
                     }
-                    MsgType::TestRequest => Some(build_hb(&cfg, raw.get_field_str(112))),
+                    MsgType::TestRequest => Some(build_hb(&cfg, raw.get_field_str(112))?),
                     MsgType::Logout => {
-                        sock.write_all(&build_logout(&cfg)).await?;
+                        sock.write_all(&build_logout(&cfg)?).await?;
                         return Ok(());
                     }
-                    MsgType::NewOrderSingle => Some(build_exec(&cfg, &raw)),
+                    MsgType::NewOrderSingle => Some(build_exec(&cfg, &raw)?),
                     _ => {
                         warn!("Unhandled: {:?}", raw.msg_type());
                         None
@@ -85,7 +86,7 @@ async fn handle(
     Ok(())
 }
 
-fn build_logon(c: &ExampleConfig) -> Vec<u8> {
+fn build_logon(c: &ExampleConfig) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "A");
     e.put_str(49, &c.sender_comp_id);
@@ -95,10 +96,10 @@ fn build_logon(c: &ExampleConfig) -> Vec<u8> {
     e.put_str(98, "0");
     e.put_str(108, &c.heartbeat_interval.to_string());
     e.put_str(1137, APPL_VER_ID);
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
-fn build_hb(c: &ExampleConfig, id: Option<&str>) -> Vec<u8> {
+fn build_hb(c: &ExampleConfig, id: Option<&str>) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "0");
     e.put_str(49, &c.sender_comp_id);
@@ -108,20 +109,23 @@ fn build_hb(c: &ExampleConfig, id: Option<&str>) -> Vec<u8> {
     if let Some(i) = id {
         e.put_str(112, i);
     }
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
-fn build_logout(c: &ExampleConfig) -> Vec<u8> {
+fn build_logout(c: &ExampleConfig) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "5");
     e.put_str(49, &c.sender_comp_id);
     e.put_str(56, &c.target_comp_id);
     e.put_str(34, "1");
     e.put_str(52, &format_timestamp());
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
-fn build_exec(c: &ExampleConfig, raw: &ironfix_tagvalue::RawMessage<'_>) -> Vec<u8> {
+fn build_exec(
+    c: &ExampleConfig,
+    raw: &ironfix_tagvalue::RawMessage<'_>,
+) -> Result<Vec<u8>, EncodeError> {
     let clid = raw.get_field_str(11).unwrap_or("0");
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "8");
@@ -140,5 +144,5 @@ fn build_exec(c: &ExampleConfig, raw: &ironfix_tagvalue::RawMessage<'_>) -> Vec<
     e.put_str(151, raw.get_field_str(38).unwrap_or("0"));
     e.put_str(14, "0");
     e.put_str(6, "0");
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }

--- a/ironfix-example/examples/fix50sp1_client.rs
+++ b/ironfix-example/examples/fix50sp1_client.rs
@@ -1,5 +1,6 @@
 //! FIX 5.0 SP1 Client Example (FIXT.1.1 Transport)
 use bytes::BytesMut;
+use ironfix_core::error::EncodeError;
 use ironfix_core::{MsgType, Side};
 use ironfix_tagvalue::{Decoder, Encoder};
 use std::time::Duration;
@@ -31,7 +32,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let mut seq = 1u64;
     let mut buf = BytesMut::with_capacity(4096);
 
-    sock.write_all(&build_logon(&cfg, seq)).await?;
+    sock.write_all(&build_logon(&cfg, seq)?).await?;
     seq += 1;
     match timeout(Duration::from_secs(10), read_msg(&mut sock, &mut buf)).await {
         Ok(Ok(m))
@@ -48,7 +49,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    sock.write_all(&build_order(&cfg, seq, "O1", "NVDA", Side::Buy, 30, 450.0))
+    sock.write_all(&build_order(&cfg, seq, "O1", "NVDA", Side::Buy, 30, 450.0)?)
         .await?;
     seq += 1;
     if let Ok(Ok(m)) = timeout(Duration::from_secs(5), read_msg(&mut sock, &mut buf)).await
@@ -60,12 +61,12 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let mut hb = interval(Duration::from_secs(cfg.heartbeat_interval));
     for _ in 0..2 {
         hb.tick().await;
-        sock.write_all(&build_hb(&cfg, seq)).await?;
+        sock.write_all(&build_hb(&cfg, seq)?).await?;
         seq += 1;
         info!("HB");
     }
 
-    sock.write_all(&build_logout(&cfg, seq)).await?;
+    sock.write_all(&build_logout(&cfg, seq)?).await?;
     info!("Done");
     Ok(())
 }
@@ -84,7 +85,7 @@ async fn read_msg(
     }
 }
 
-fn build_logon(c: &ExampleConfig, seq: u64) -> Vec<u8> {
+fn build_logon(c: &ExampleConfig, seq: u64) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "A");
     e.put_str(49, &c.sender_comp_id);
@@ -94,27 +95,27 @@ fn build_logon(c: &ExampleConfig, seq: u64) -> Vec<u8> {
     e.put_str(98, "0");
     e.put_str(108, &c.heartbeat_interval.to_string());
     e.put_str(1137, APPL_VER_ID);
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
-fn build_hb(c: &ExampleConfig, seq: u64) -> Vec<u8> {
+fn build_hb(c: &ExampleConfig, seq: u64) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "0");
     e.put_str(49, &c.sender_comp_id);
     e.put_str(56, &c.target_comp_id);
     e.put_str(34, &seq.to_string());
     e.put_str(52, &format_timestamp());
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
-fn build_logout(c: &ExampleConfig, seq: u64) -> Vec<u8> {
+fn build_logout(c: &ExampleConfig, seq: u64) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "5");
     e.put_str(49, &c.sender_comp_id);
     e.put_str(56, &c.target_comp_id);
     e.put_str(34, &seq.to_string());
     e.put_str(52, &format_timestamp());
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
 fn build_order(
@@ -125,7 +126,7 @@ fn build_order(
     side: Side,
     qty: u64,
     px: f64,
-) -> Vec<u8> {
+) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "D");
     e.put_str(49, &c.sender_comp_id);
@@ -141,5 +142,5 @@ fn build_order(
     e.put_str(38, &qty.to_string());
     e.put_str(40, "2");
     e.put_str(44, &format!("{:.2}", px));
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }

--- a/ironfix-example/examples/fix50sp1_server.rs
+++ b/ironfix-example/examples/fix50sp1_server.rs
@@ -1,6 +1,7 @@
 //! FIX 5.0 SP1 Server Example (FIXT.1.1 Transport)
 use bytes::BytesMut;
 use ironfix_core::MsgType;
+use ironfix_core::error::EncodeError;
 use ironfix_tagvalue::{Decoder, Encoder};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -62,14 +63,14 @@ async fn handle(
                 let resp = match raw.msg_type() {
                     MsgType::Logon => {
                         info!("Logon");
-                        Some(build_logon(&cfg))
+                        Some(build_logon(&cfg)?)
                     }
-                    MsgType::TestRequest => Some(build_hb(&cfg, raw.get_field_str(112))),
+                    MsgType::TestRequest => Some(build_hb(&cfg, raw.get_field_str(112))?),
                     MsgType::Logout => {
-                        sock.write_all(&build_logout(&cfg)).await?;
+                        sock.write_all(&build_logout(&cfg)?).await?;
                         return Ok(());
                     }
-                    MsgType::NewOrderSingle => Some(build_exec(&cfg, &raw)),
+                    MsgType::NewOrderSingle => Some(build_exec(&cfg, &raw)?),
                     _ => {
                         warn!("Unhandled: {:?}", raw.msg_type());
                         None
@@ -85,7 +86,7 @@ async fn handle(
     Ok(())
 }
 
-fn build_logon(c: &ExampleConfig) -> Vec<u8> {
+fn build_logon(c: &ExampleConfig) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "A");
     e.put_str(49, &c.sender_comp_id);
@@ -95,10 +96,10 @@ fn build_logon(c: &ExampleConfig) -> Vec<u8> {
     e.put_str(98, "0");
     e.put_str(108, &c.heartbeat_interval.to_string());
     e.put_str(1137, APPL_VER_ID);
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
-fn build_hb(c: &ExampleConfig, id: Option<&str>) -> Vec<u8> {
+fn build_hb(c: &ExampleConfig, id: Option<&str>) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "0");
     e.put_str(49, &c.sender_comp_id);
@@ -108,20 +109,23 @@ fn build_hb(c: &ExampleConfig, id: Option<&str>) -> Vec<u8> {
     if let Some(i) = id {
         e.put_str(112, i);
     }
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
-fn build_logout(c: &ExampleConfig) -> Vec<u8> {
+fn build_logout(c: &ExampleConfig) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "5");
     e.put_str(49, &c.sender_comp_id);
     e.put_str(56, &c.target_comp_id);
     e.put_str(34, "1");
     e.put_str(52, &format_timestamp());
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
-fn build_exec(c: &ExampleConfig, raw: &ironfix_tagvalue::RawMessage<'_>) -> Vec<u8> {
+fn build_exec(
+    c: &ExampleConfig,
+    raw: &ironfix_tagvalue::RawMessage<'_>,
+) -> Result<Vec<u8>, EncodeError> {
     let clid = raw.get_field_str(11).unwrap_or("0");
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "8");
@@ -140,5 +144,5 @@ fn build_exec(c: &ExampleConfig, raw: &ironfix_tagvalue::RawMessage<'_>) -> Vec<
     e.put_str(151, raw.get_field_str(38).unwrap_or("0"));
     e.put_str(14, "0");
     e.put_str(6, "0");
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }

--- a/ironfix-example/examples/fix50sp2_client.rs
+++ b/ironfix-example/examples/fix50sp2_client.rs
@@ -1,5 +1,6 @@
 //! FIX 5.0 SP2 Client Example (FIXT.1.1 Transport)
 use bytes::BytesMut;
+use ironfix_core::error::EncodeError;
 use ironfix_core::{MsgType, Side};
 use ironfix_tagvalue::{Decoder, Encoder};
 use std::time::Duration;
@@ -31,7 +32,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let mut seq = 1u64;
     let mut buf = BytesMut::with_capacity(4096);
 
-    sock.write_all(&build_logon(&cfg, seq)).await?;
+    sock.write_all(&build_logon(&cfg, seq)?).await?;
     seq += 1;
     match timeout(Duration::from_secs(10), read_msg(&mut sock, &mut buf)).await {
         Ok(Ok(m))
@@ -48,8 +49,16 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    sock.write_all(&build_order(&cfg, seq, "O1", "META", Side::Sell, 20, 500.0))
-        .await?;
+    sock.write_all(&build_order(
+        &cfg,
+        seq,
+        "O1",
+        "META",
+        Side::Sell,
+        20,
+        500.0,
+    )?)
+    .await?;
     seq += 1;
     if let Ok(Ok(m)) = timeout(Duration::from_secs(5), read_msg(&mut sock, &mut buf)).await
         && let Ok(r) = Decoder::new(&m).decode()
@@ -60,12 +69,12 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let mut hb = interval(Duration::from_secs(cfg.heartbeat_interval));
     for _ in 0..2 {
         hb.tick().await;
-        sock.write_all(&build_hb(&cfg, seq)).await?;
+        sock.write_all(&build_hb(&cfg, seq)?).await?;
         seq += 1;
         info!("HB");
     }
 
-    sock.write_all(&build_logout(&cfg, seq)).await?;
+    sock.write_all(&build_logout(&cfg, seq)?).await?;
     info!("Done");
     Ok(())
 }
@@ -84,7 +93,7 @@ async fn read_msg(
     }
 }
 
-fn build_logon(c: &ExampleConfig, seq: u64) -> Vec<u8> {
+fn build_logon(c: &ExampleConfig, seq: u64) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "A");
     e.put_str(49, &c.sender_comp_id);
@@ -94,27 +103,27 @@ fn build_logon(c: &ExampleConfig, seq: u64) -> Vec<u8> {
     e.put_str(98, "0");
     e.put_str(108, &c.heartbeat_interval.to_string());
     e.put_str(1137, APPL_VER_ID);
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
-fn build_hb(c: &ExampleConfig, seq: u64) -> Vec<u8> {
+fn build_hb(c: &ExampleConfig, seq: u64) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "0");
     e.put_str(49, &c.sender_comp_id);
     e.put_str(56, &c.target_comp_id);
     e.put_str(34, &seq.to_string());
     e.put_str(52, &format_timestamp());
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
-fn build_logout(c: &ExampleConfig, seq: u64) -> Vec<u8> {
+fn build_logout(c: &ExampleConfig, seq: u64) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "5");
     e.put_str(49, &c.sender_comp_id);
     e.put_str(56, &c.target_comp_id);
     e.put_str(34, &seq.to_string());
     e.put_str(52, &format_timestamp());
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
 fn build_order(
@@ -125,7 +134,7 @@ fn build_order(
     side: Side,
     qty: u64,
     px: f64,
-) -> Vec<u8> {
+) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "D");
     e.put_str(49, &c.sender_comp_id);
@@ -141,5 +150,5 @@ fn build_order(
     e.put_str(38, &qty.to_string());
     e.put_str(40, "2");
     e.put_str(44, &format!("{:.2}", px));
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }

--- a/ironfix-example/examples/fix50sp2_server.rs
+++ b/ironfix-example/examples/fix50sp2_server.rs
@@ -1,6 +1,7 @@
 //! FIX 5.0 SP2 Server Example (FIXT.1.1 Transport)
 use bytes::BytesMut;
 use ironfix_core::MsgType;
+use ironfix_core::error::EncodeError;
 use ironfix_tagvalue::{Decoder, Encoder};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -62,14 +63,14 @@ async fn handle(
                 let resp = match raw.msg_type() {
                     MsgType::Logon => {
                         info!("Logon");
-                        Some(build_logon(&cfg))
+                        Some(build_logon(&cfg)?)
                     }
-                    MsgType::TestRequest => Some(build_hb(&cfg, raw.get_field_str(112))),
+                    MsgType::TestRequest => Some(build_hb(&cfg, raw.get_field_str(112))?),
                     MsgType::Logout => {
-                        sock.write_all(&build_logout(&cfg)).await?;
+                        sock.write_all(&build_logout(&cfg)?).await?;
                         return Ok(());
                     }
-                    MsgType::NewOrderSingle => Some(build_exec(&cfg, &raw)),
+                    MsgType::NewOrderSingle => Some(build_exec(&cfg, &raw)?),
                     _ => {
                         warn!("Unhandled: {:?}", raw.msg_type());
                         None
@@ -85,7 +86,7 @@ async fn handle(
     Ok(())
 }
 
-fn build_logon(c: &ExampleConfig) -> Vec<u8> {
+fn build_logon(c: &ExampleConfig) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "A");
     e.put_str(49, &c.sender_comp_id);
@@ -95,10 +96,10 @@ fn build_logon(c: &ExampleConfig) -> Vec<u8> {
     e.put_str(98, "0");
     e.put_str(108, &c.heartbeat_interval.to_string());
     e.put_str(1137, APPL_VER_ID);
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
-fn build_hb(c: &ExampleConfig, id: Option<&str>) -> Vec<u8> {
+fn build_hb(c: &ExampleConfig, id: Option<&str>) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "0");
     e.put_str(49, &c.sender_comp_id);
@@ -108,20 +109,23 @@ fn build_hb(c: &ExampleConfig, id: Option<&str>) -> Vec<u8> {
     if let Some(i) = id {
         e.put_str(112, i);
     }
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
-fn build_logout(c: &ExampleConfig) -> Vec<u8> {
+fn build_logout(c: &ExampleConfig) -> Result<Vec<u8>, EncodeError> {
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "5");
     e.put_str(49, &c.sender_comp_id);
     e.put_str(56, &c.target_comp_id);
     e.put_str(34, "1");
     e.put_str(52, &format_timestamp());
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }
 
-fn build_exec(c: &ExampleConfig, raw: &ironfix_tagvalue::RawMessage<'_>) -> Vec<u8> {
+fn build_exec(
+    c: &ExampleConfig,
+    raw: &ironfix_tagvalue::RawMessage<'_>,
+) -> Result<Vec<u8>, EncodeError> {
     let clid = raw.get_field_str(11).unwrap_or("0");
     let mut e = Encoder::new(FIX_VERSION);
     e.put_str(35, "8");
@@ -140,5 +144,5 @@ fn build_exec(c: &ExampleConfig, raw: &ironfix_tagvalue::RawMessage<'_>) -> Vec<
     e.put_str(151, raw.get_field_str(38).unwrap_or("0"));
     e.put_str(14, "0");
     e.put_str(6, "0");
-    e.finish().to_vec()
+    Ok(e.finish()?.to_vec())
 }

--- a/ironfix-tagvalue/src/checksum.rs
+++ b/ironfix-tagvalue/src/checksum.rs
@@ -74,13 +74,14 @@ pub fn format_checksum(checksum: u8) -> [u8; 3] {
 #[inline]
 #[must_use]
 pub fn parse_checksum(bytes: &[u8]) -> Option<u8> {
-    if bytes.len() != 3 {
-        return None;
-    }
+    // Destructured rather than indexed: the length check and the reads are then
+    // one operation the compiler verifies, instead of two that a later edit
+    // could separate.
+    let [b0, b1, b2] = <[u8; 3]>::try_from(bytes).ok()?;
 
-    let d0 = bytes[0].checked_sub(b'0')?;
-    let d1 = bytes[1].checked_sub(b'0')?;
-    let d2 = bytes[2].checked_sub(b'0')?;
+    let d0 = b0.checked_sub(b'0')?;
+    let d1 = b1.checked_sub(b'0')?;
+    let d2 = b2.checked_sub(b'0')?;
 
     if d0 > 9 || d1 > 9 || d2 > 9 {
         return None;

--- a/ironfix-tagvalue/src/decoder.rs
+++ b/ironfix-tagvalue/src/decoder.rs
@@ -23,11 +23,12 @@ use memchr::memchr;
 use smallvec::SmallVec;
 use std::ops::Range;
 
-/// SOH (Start of Header) delimiter used in FIX messages.
-pub const SOH: u8 = 0x01;
-
-/// Equals sign delimiter between tag and value.
-pub const EQUALS: u8 = b'=';
+/// SOH (Start of Header) delimiter, and the `=` tag/value separator.
+///
+/// Both are defined once at the crate root and re-exported here, so
+/// `ironfix_tagvalue::decoder::SOH` keeps resolving to the same item as
+/// `ironfix_tagvalue::SOH`.
+pub use crate::{EQUALS, SOH};
 
 /// Maximum number of digits accepted in a tag number.
 const MAX_TAG_DIGITS: usize = 10;
@@ -64,7 +65,7 @@ const MAX_TAG_DIAGNOSTIC_LEN: usize = 16;
 /// drift.
 #[inline]
 #[must_use]
-const fn paired_data_tag(length_tag: u32) -> Option<u32> {
+pub(crate) const fn paired_data_tag(length_tag: u32) -> Option<u32> {
     match length_tag {
         90 => Some(91),   // SecureDataLen / SecureData
         93 => Some(89),   // SignatureLength / Signature
@@ -84,6 +85,25 @@ const fn paired_data_tag(length_tag: u32) -> Option<u32> {
         621 => Some(622), // EncodedLegSecurityDescLen / EncodedLegSecurityDesc
         _ => None,
     }
+}
+
+/// Returns true if `tag` is a spec-defined `DATA` field.
+///
+/// The right-hand column of [`paired_data_tag`]: a value under one of these
+/// tags may legally contain SOH and `=`, so it is only decodable when the
+/// paired `LENGTH` field precedes it and declares its byte count. The encoder
+/// uses this to refuse a `DATA` field written through the ordinary field path,
+/// which would emit a frame no decoder can frame back.
+///
+/// Written as a `match` for the same reason as [`paired_data_tag`], and
+/// cross-checked against `LENGTH_DATA_PAIRS` in the tests.
+#[inline]
+#[must_use]
+pub(crate) const fn is_data_tag(tag: u32) -> bool {
+    matches!(
+        tag,
+        89 | 91 | 96 | 213 | 349 | 351 | 353 | 355 | 357 | 359 | 361 | 363 | 365 | 446 | 619 | 622
+    )
 }
 
 /// A `DATA` field announced by the `LENGTH` field just consumed.
@@ -168,10 +188,12 @@ impl<'a> Decoder<'a> {
         if body_length_field.tag != 9 {
             return Err(DecodeError::MissingBodyLength);
         }
-        let body_length: usize = body_length_field
-            .as_str()?
-            .parse()
-            .map_err(|_| DecodeError::InvalidBodyLength)?;
+        // FIX types tag 9 as a `Length`: ASCII digits only. `str::parse` would
+        // accept `9=+8`, and would additionally cost a UTF-8 validation pass
+        // per frame, so the same strict digit fold used for every other length
+        // in this file is used here.
+        let body_length =
+            parse_length(body_length_field.value).ok_or(DecodeError::InvalidBodyLength)?;
 
         // Record body start position. BodyLength (tag 9) is fully
         // attacker-controlled, so the end of the body is computed with checked
@@ -530,7 +552,11 @@ fn parse_tag(bytes: &[u8]) -> Option<u32> {
     Some(result)
 }
 
-/// Parses a `LENGTH` field value (a byte count) from ASCII bytes.
+/// Parses a FIX `Length` field value (a byte count) from ASCII bytes.
+///
+/// Used for `BodyLength` (tag 9) and for every `LENGTH` field that frames a
+/// paired `DATA` field. FIX defines these as unsigned integers, so a leading
+/// sign, a space, or any other non-digit byte is rejected rather than coerced.
 ///
 /// # Returns
 /// The declared count, or `None` if the value is empty, non-numeric, too long,
@@ -1094,6 +1120,166 @@ mod tests {
             result.err(),
             Some(DecodeError::UnterminatedField { tag: 58 })
         );
+    }
+
+    #[test]
+    fn test_decode_body_length_with_leading_sign_is_rejected() {
+        // FIX types tag 9 as a digits-only Length. `str::parse` accepted "+8",
+        // so a frame whose declared length carried a sign framed cleanly.
+        for text in ["+8", "-8", " 8", "8 ", "0x8", ""] {
+            let msg = frame_with_body_length(text, "9");
+            assert_eq!(
+                Decoder::new(&msg).decode().err(),
+                Some(DecodeError::InvalidBodyLength),
+                "9={text:?} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn test_decode_body_length_non_utf8_is_invalid_body_length() {
+        let mut msg = Vec::new();
+        msg.extend_from_slice(b"8=FIX.4.4\x01");
+        msg.extend_from_slice(b"9=\xff\xfe\x01");
+        msg.extend_from_slice(b"35=0\x0110=000\x01");
+        assert_eq!(
+            Decoder::new(&msg).decode().err(),
+            Some(DecodeError::InvalidBodyLength)
+        );
+    }
+
+    #[test]
+    fn test_decode_body_length_with_too_many_digits_is_rejected() {
+        let msg = frame_with_body_length("00000000008", "9");
+        assert_eq!(
+            Decoder::new(&msg).decode().err(),
+            Some(DecodeError::InvalidBodyLength)
+        );
+    }
+
+    #[test]
+    fn test_decode_first_tag_not_8_is_invalid_begin_string() {
+        let msg = b"9=5\x018=FIX.4.4\x0135=0\x0110=000\x01";
+        assert_eq!(
+            Decoder::new(msg).decode().err(),
+            Some(DecodeError::InvalidBeginString)
+        );
+    }
+
+    #[test]
+    fn test_decode_second_tag_not_9_is_missing_body_length() {
+        let msg = b"8=FIX.4.4\x0135=0\x0110=000\x01";
+        assert_eq!(
+            Decoder::new(msg).decode().err(),
+            Some(DecodeError::MissingBodyLength)
+        );
+    }
+
+    #[test]
+    fn test_decode_body_length_only_is_missing_msg_type() {
+        // Nothing after the header at all: the body is empty and there is no
+        // third field to read a MsgType from.
+        let msg = b"8=FIX.4.4\x019=0\x01";
+        assert_eq!(
+            Decoder::new(msg).decode().err(),
+            Some(DecodeError::MissingMsgType)
+        );
+    }
+
+    #[test]
+    fn test_decode_third_tag_not_35_is_missing_msg_type() {
+        let body = b"49=A\x0135=0\x01";
+        let msg = build_frame(body);
+        assert_eq!(
+            Decoder::new(&msg).decode().err(),
+            Some(DecodeError::MissingMsgType)
+        );
+    }
+
+    #[test]
+    fn test_decode_wrong_checksum_is_checksum_mismatch() {
+        let body: &[u8] = b"35=0\x0149=A\x0156=B\x01";
+        let mut msg = Vec::new();
+        msg.extend_from_slice(b"8=FIX.4.4\x01");
+        msg.extend_from_slice(format!("9={}\x01", body.len()).as_bytes());
+        msg.extend_from_slice(body);
+        let sum: u64 = msg.iter().map(|&b| u64::from(b)).sum();
+        let declared = ((sum % 256) as u8) ^ 0x01;
+        msg.extend_from_slice(format!("10={declared:03}\x01").as_bytes());
+
+        assert_eq!(
+            Decoder::new(&msg).decode().err(),
+            Some(DecodeError::ChecksumMismatch {
+                calculated: (sum % 256) as u8,
+                declared,
+            })
+        );
+    }
+
+    #[test]
+    fn test_decode_out_of_range_checksum_is_typed_error() {
+        let body: &[u8] = b"35=0\x0149=A\x01";
+        let mut msg = Vec::new();
+        msg.extend_from_slice(b"8=FIX.4.4\x01");
+        msg.extend_from_slice(format!("9={}\x01", body.len()).as_bytes());
+        msg.extend_from_slice(body);
+        // 999 does not fit in a u8 and must not wrap to 231.
+        msg.extend_from_slice(b"10=999\x01");
+
+        assert!(matches!(
+            Decoder::new(&msg).decode(),
+            Err(DecodeError::InvalidFieldValue { tag: 10, .. })
+        ));
+    }
+
+    #[test]
+    fn test_decode_wrong_checksum_is_accepted_without_validation() {
+        // The production path (`with_checksum_validation(false)`, used by the
+        // engine after the codec has already verified the frame) ignores the
+        // checksum *value* — but the BodyLength cross-check still binds.
+        let body: &[u8] = b"35=0\x0149=A\x0156=B\x01";
+        let mut msg = Vec::new();
+        msg.extend_from_slice(b"8=FIX.4.4\x01");
+        msg.extend_from_slice(format!("9={}\x01", body.len()).as_bytes());
+        msg.extend_from_slice(body);
+        msg.extend_from_slice(b"10=000\x01");
+
+        let Ok(decoded) = Decoder::new(&msg).with_checksum_validation(false).decode() else {
+            panic!("a wrong checksum must not stop the validation-off path");
+        };
+        assert_eq!(*decoded.msg_type(), MsgType::Heartbeat);
+        assert_eq!(decoded.body(), Ok(body));
+
+        // Same frame, BodyLength one byte short.
+        let mut short = Vec::new();
+        short.extend_from_slice(b"8=FIX.4.4\x01");
+        short.extend_from_slice(format!("9={}\x01", body.len() - 1).as_bytes());
+        short.extend_from_slice(body);
+        short.extend_from_slice(b"10=000\x01");
+        assert_eq!(
+            Decoder::new(&short)
+                .with_checksum_validation(false)
+                .decode()
+                .err(),
+            Some(DecodeError::InvalidBodyLength)
+        );
+    }
+
+    #[test]
+    fn test_is_data_tag_matches_the_spec_table() {
+        for (length_tag, data_tag) in LENGTH_DATA_PAIRS {
+            assert!(is_data_tag(data_tag), "tag {data_tag} is a DATA field");
+            assert!(
+                !is_data_tag(length_tag),
+                "tag {length_tag} is a LENGTH field, not a DATA field"
+            );
+        }
+        let data_tags: Vec<u32> = LENGTH_DATA_PAIRS.iter().map(|(_, data)| *data).collect();
+        for tag in 1..=700u32 {
+            if !data_tags.contains(&tag) {
+                assert!(!is_data_tag(tag), "tag {tag} must not be a DATA field");
+            }
+        }
     }
 
     #[test]

--- a/ironfix-tagvalue/src/encoder.rs
+++ b/ironfix-tagvalue/src/encoder.rs
@@ -6,54 +6,185 @@
 
 //! FIX message encoder.
 //!
-//! This module provides an encoder for building FIX messages in the
-//! standard tag=value format.
+//! [`Encoder`] builds a complete tag=value frame —
+//! `8=<BeginString><SOH>9=<BodyLength><SOH>` … `10=<CheckSum><SOH>` — in one
+//! buffer.
+//!
+//! # The frame is assembled once
+//!
+//! `BodyLength` (tag 9) is not known until the body is complete, which is why
+//! a header cannot simply be written first. Instead the buffer opens with
+//! a fixed, worst-case-sized run of unused bytes and the body is written after
+//! them; [`Encoder::finish`] formats the header into the **tail** of that
+//! reserved prefix, so the header ends exactly where the body begins and the
+//! frame is contiguous. Nothing is copied and no intermediate buffer exists.
+//! [`Encoder::clear`] rewinds to that same starting state with the buffer's
+//! capacity retained, so a long-lived encoder encodes without allocating.
+//!
+//! # A rejected value never reaches the wire
+//!
+//! An application string carrying a SOH byte would terminate its own field
+//! early and let the rest of the value inject tag/value pairs into the frame —
+//! with a `BodyLength` and `CheckSum` correct for the corrupted bytes, so the
+//! counterparty accepts it. The encoder therefore refuses such a value, along
+//! with an empty one, tag `0`, and the framing tags it stamps itself.
+//!
+//! The `put_*` methods stay infallible and **record** the first rejection;
+//! [`Encoder::finish`] returns it and yields no bytes. That is deliberate: a
+//! fallible `put_*` whose `Result` a caller drops would silently omit the
+//! field and produce a well-formed frame that is missing data, which is the
+//! harder failure to notice. Callers that want the rejection at the point of
+//! the write can use [`Encoder::try_put_raw`] / [`Encoder::try_put_data`], or
+//! read [`Encoder::error`].
+//!
+//! # `DATA` fields
+//!
+//! A FIX `DATA` field (`RawData`/96, `Signature`/89, the `Encoded*` family)
+//! legally contains SOH and `=`; it is decodable only because its paired
+//! `LENGTH` field declares its byte count. [`Encoder::put_data`] emits the
+//! pair together and derives the count from the value, so the two cannot
+//! disagree. Writing either half through [`Encoder::put_raw`] is refused.
 
 use crate::checksum::{calculate_checksum, format_checksum};
+use crate::decoder::{is_data_tag, paired_data_tag};
+pub use crate::{EQUALS, SOH};
 use bytes::{BufMut, BytesMut};
+use ironfix_core::error::{EncodeError, MsgTypeError};
+use ironfix_core::message::MsgType;
+use memchr::memchr;
 
-/// SOH (Start of Header) delimiter used in FIX messages.
-pub const SOH: u8 = 0x01;
+/// Maximum length of a `BeginString` (tag 8) value in bytes.
+///
+/// Every `BeginString` the FIX family defines is at most ten bytes
+/// (`FIX.5.0SP2`), and the longest that actually reaches the wire is
+/// `FIXT.1.1`. Like [`ironfix_core::types::COMP_ID_MAX_LEN`] this bound is an
+/// IronFix engineering choice, not a specification limit: it is what lets the
+/// value live inline in the encoder and what bounds the reserved header
+/// prefix. A longer value is [`EncodeError::FieldTooLong`], never a truncation.
+pub const BEGIN_STRING_MAX_LEN: usize = 16;
+
+/// Maximum number of digits a `BodyLength` (tag 9) value can need.
+///
+/// `usize::MAX` is 20 decimal digits on a 64-bit target, so no body length is
+/// longer than this and the reserved header prefix can never be too small.
+const MAX_BODY_LENGTH_DIGITS: usize = 20;
+
+/// Bytes reserved at the front of the buffer for `8=…<SOH>9=…<SOH>`.
+///
+/// The worst case exactly: `8=` + a [`BEGIN_STRING_MAX_LEN`]-byte BeginString
+/// + SOH + `9=` + [`MAX_BODY_LENGTH_DIGITS`] digits + SOH.
+const HEADER_RESERVE: usize = 2 + BEGIN_STRING_MAX_LEN + 1 + 2 + MAX_BODY_LENGTH_DIGITS + 1;
+
+/// Length of the `10=NNN<SOH>` trailer in bytes.
+const TRAILER_LEN: usize = 7;
+
+/// Default body capacity of a new encoder, in bytes.
+const DEFAULT_BODY_CAPACITY: usize = 256;
 
 /// FIX message encoder.
 ///
-/// The encoder builds FIX messages by appending fields in tag=value format.
-/// It handles BeginString, BodyLength, and Checksum fields automatically.
+/// The encoder appends body fields in tag=value form and stamps
+/// `BeginString` (8), `BodyLength` (9) and `CheckSum` (10) itself.
+///
+/// # Example
+///
+/// ```
+/// use ironfix_tagvalue::Encoder;
+///
+/// let mut encoder = Encoder::new("FIX.4.4");
+/// encoder.put_str(35, "0");
+/// encoder.put_str(49, "SENDER");
+/// let frame = encoder.finish()?;
+/// assert!(frame.starts_with(b"8=FIX.4.4\x01"));
+/// # Ok::<(), ironfix_core::error::EncodeError>(())
+/// ```
 #[derive(Debug)]
 pub struct Encoder {
-    /// Buffer for the message body (between BodyLength and Checksum).
-    body: BytesMut,
-    /// The BeginString value (e.g., "FIX.4.4").
-    begin_string: &'static str,
+    /// Frame buffer: `HEADER_RESERVE` bytes of header space, then the body,
+    /// then the trailer once [`Encoder::finish`] has stamped it.
+    buf: BytesMut,
+    /// Validated `BeginString` bytes, held inline.
+    begin_string: [u8; BEGIN_STRING_MAX_LEN],
+    /// Number of leading bytes of `begin_string` in use.
+    begin_string_len: usize,
+    /// Bytes of body written so far — the value stamped into tag 9.
+    body_len: usize,
+    /// Tag of the first body field, which FIX requires to be MsgType (35).
+    first_tag: Option<u32>,
+    /// Offset of the frame's first byte once the header has been stamped.
+    frame_start: Option<usize>,
+    /// Rejection recorded when the `BeginString` was set.
+    ///
+    /// Survives [`Encoder::clear`]: an encoder built with an unusable
+    /// BeginString cannot frame any message, not just the current one.
+    begin_string_error: Option<EncodeError>,
+    /// First rejected write of the current message, cleared by
+    /// [`Encoder::clear`].
+    error: Option<EncodeError>,
 }
 
 impl Encoder {
-    /// Creates a new encoder with the specified BeginString.
+    /// Creates a new encoder with the specified `BeginString`.
+    ///
+    /// A `BeginString` that is empty, longer than [`BEGIN_STRING_MAX_LEN`], or
+    /// carries a byte that cannot appear in tag 8 is recorded and reported by
+    /// [`Encoder::finish`]; no such frame is ever produced.
     ///
     /// # Arguments
     /// * `begin_string` - The FIX version string (e.g., "FIX.4.4")
     #[must_use]
-    pub fn new(begin_string: &'static str) -> Self {
-        Self {
-            body: BytesMut::with_capacity(256),
-            begin_string,
-        }
+    pub fn new(begin_string: &str) -> Self {
+        Self::with_capacity(begin_string, DEFAULT_BODY_CAPACITY)
     }
 
-    /// Creates a new encoder with pre-allocated capacity.
+    /// Creates a new encoder with a pre-allocated body capacity.
+    ///
+    /// The buffer is sized for `capacity` bytes of body plus the reserved
+    /// header prefix and the trailer, so a message whose body fits in
+    /// `capacity` is encoded without the buffer growing.
     ///
     /// # Arguments
     /// * `begin_string` - The FIX version string
-    /// * `capacity` - Initial buffer capacity in bytes
+    /// * `capacity` - Expected body size in bytes
     #[must_use]
-    pub fn with_capacity(begin_string: &'static str, capacity: usize) -> Self {
-        Self {
-            body: BytesMut::with_capacity(capacity),
-            begin_string,
+    pub fn with_capacity(begin_string: &str, capacity: usize) -> Self {
+        let total = match HEADER_RESERVE
+            .checked_add(capacity)
+            .and_then(|n| n.checked_add(TRAILER_LEN))
+        {
+            Some(total) => total,
+            // A capacity this close to `usize::MAX` cannot be allocated
+            // anyway; fall back to the frame overhead alone rather than
+            // wrapping into a small one.
+            None => HEADER_RESERVE + TRAILER_LEN,
+        };
+
+        let mut buf = BytesMut::with_capacity(total);
+        buf.resize(HEADER_RESERVE, 0);
+
+        let mut encoder = Self {
+            buf,
+            begin_string: [0; BEGIN_STRING_MAX_LEN],
+            begin_string_len: 0,
+            body_len: 0,
+            first_tag: None,
+            frame_start: None,
+            begin_string_error: None,
+            error: None,
+        };
+
+        match copy_begin_string(begin_string, &mut encoder.begin_string) {
+            Ok(len) => encoder.begin_string_len = len,
+            Err(err) => encoder.begin_string_error = Some(err),
         }
+
+        encoder
     }
 
     /// Appends a field with a string value.
+    ///
+    /// A rejected value is recorded and surfaced by [`Encoder::finish`]; see
+    /// [`Encoder::try_put_raw`] for the exact preconditions.
     ///
     /// # Arguments
     /// * `tag` - The field tag number
@@ -111,71 +242,312 @@ impl Encoder {
 
     /// Appends a field with raw bytes.
     ///
+    /// A rejected value is recorded and surfaced by [`Encoder::finish`]; see
+    /// [`Encoder::try_put_raw`] for the exact preconditions.
+    ///
     /// # Arguments
     /// * `tag` - The field tag number
     /// * `value` - The field value bytes
     #[inline]
     pub fn put_raw(&mut self, tag: u32, value: &[u8]) {
+        if let Err(err) = self.try_put_raw(tag, value) {
+            self.record(err);
+        }
+    }
+
+    /// Appends a field with raw bytes, reporting a rejection immediately.
+    ///
+    /// Nothing is written when this returns `Err`, and the rejection is **not**
+    /// recorded: the caller has it.
+    ///
+    /// # Arguments
+    /// * `tag` - The field tag number
+    /// * `value` - The field value bytes
+    ///
+    /// # Errors
+    /// [`EncodeError::InvalidFieldValue`] if:
+    /// * `tag` is `0`, which is not a legal FIX tag;
+    /// * `tag` is `8`, `9` or `10` — the framing fields [`Encoder::finish`]
+    ///   stamps itself, so a second copy would break the frame;
+    /// * `tag` is a `LENGTH` or `DATA` field of a spec-defined pair, which must
+    ///   be written together through [`Encoder::put_data`];
+    /// * `value` is empty, which FIX rejects as "tag specified without a
+    ///   value";
+    /// * `value` contains SOH, which would terminate the field early and let
+    ///   the remainder inject fields into the frame;
+    /// * `tag` is 35 and `value` is not a code
+    ///   [`ironfix_core::message::MsgType`] can represent;
+    /// * the frame is already finished — call [`Encoder::clear`] first.
+    ///
+    /// [`EncodeError::FieldTooLong`] if `tag` is 35 and `value` exceeds
+    /// [`ironfix_core::message::MSG_TYPE_MAX_LEN`].
+    ///
+    /// A `=` byte inside a value is **accepted**: a decoder splits a field at
+    /// its first `=`, so `58=a=b` reads back as the value `a=b`, and Text
+    /// fields legitimately carry it.
+    pub fn try_put_raw(&mut self, tag: u32, value: &[u8]) -> Result<(), EncodeError> {
+        self.check_open(tag)?;
+        check_body_tag(tag)?;
+        if value.is_empty() {
+            return Err(empty_value(tag));
+        }
+        if let Some(position) = memchr(SOH, value) {
+            return Err(soh_in_value(tag, position));
+        }
+        if tag == 35 {
+            check_msg_type(value)?;
+        }
+        self.write_field(tag, value);
+        Ok(())
+    }
+
+    /// Appends a `LENGTH`/`DATA` field pair.
+    ///
+    /// Emits `length_tag=<value.len()><SOH>data_tag=<value><SOH>`. The count is
+    /// derived from `value`, so the declared length and the payload cannot
+    /// disagree, and `value` may contain SOH and `=` — that is what the pair
+    /// exists for.
+    ///
+    /// A rejected pair is recorded and surfaced by [`Encoder::finish`]; see
+    /// [`Encoder::try_put_data`] for the exact preconditions.
+    ///
+    /// # Arguments
+    /// * `length_tag` - The `LENGTH` field tag (e.g., 95 `RawDataLength`)
+    /// * `data_tag` - The paired `DATA` field tag (e.g., 96 `RawData`)
+    /// * `value` - The raw payload, which may be empty
+    #[inline]
+    pub fn put_data(&mut self, length_tag: u32, data_tag: u32, value: &[u8]) {
+        if let Err(err) = self.try_put_data(length_tag, data_tag, value) {
+            self.record(err);
+        }
+    }
+
+    /// Appends a `LENGTH`/`DATA` field pair, reporting a rejection immediately.
+    ///
+    /// Nothing is written when this returns `Err`.
+    ///
+    /// # Arguments
+    /// * `length_tag` - The `LENGTH` field tag (e.g., 95 `RawDataLength`)
+    /// * `data_tag` - The paired `DATA` field tag (e.g., 96 `RawData`)
+    /// * `value` - The raw payload, which may be empty
+    ///
+    /// # Errors
+    /// [`EncodeError::InvalidFieldValue`] if either tag is `0`, if `data_tag`
+    /// is not the `DATA` field the FIX specification pairs with `length_tag`,
+    /// or if the frame is already finished. An unpaired combination is refused
+    /// because a decoder frames a `DATA` value by the count in *its own* paired
+    /// `LENGTH` field: under any other tag the payload's SOH bytes are read as
+    /// field terminators.
+    pub fn try_put_data(
+        &mut self,
+        length_tag: u32,
+        data_tag: u32,
+        value: &[u8],
+    ) -> Result<(), EncodeError> {
+        self.check_open(data_tag)?;
+        check_tag(length_tag)?;
+        check_tag(data_tag)?;
+        if paired_data_tag(length_tag) != Some(data_tag) {
+            return Err(unpaired_data_tag(length_tag, data_tag));
+        }
+
+        let mut len_buf = itoa::Buffer::new();
+        let len_str = len_buf.format(value.len());
+        self.write_field(length_tag, len_str.as_bytes());
+        self.write_field(data_tag, value);
+        Ok(())
+    }
+
+    /// Stamps the frame and returns it.
+    ///
+    /// Writes `8=<BeginString><SOH>9=<BodyLength><SOH>` into the reserved
+    /// prefix so that it ends exactly where the body starts, then appends
+    /// `10=<CheckSum><SOH>`. The returned slice borrows the encoder's own
+    /// buffer: no intermediate buffer is allocated and the body is not moved.
+    ///
+    /// Calling it again returns the same frame; call [`Encoder::clear`] to
+    /// start the next message.
+    ///
+    /// # Errors
+    /// * The first rejection recorded by any `put_*` call, or by
+    ///   [`Encoder::new`] for an unusable `BeginString`.
+    /// * [`EncodeError::MissingRequiredField`] for tag 35 if no field was
+    ///   written, or if the first body field is not `MsgType` — FIX fixes it as
+    ///   the third field of every message, and a frame without it there is one
+    ///   no decoder can route.
+    pub fn finish(&mut self) -> Result<&[u8], EncodeError> {
+        if let Some(err) = self.first_error() {
+            return Err(err.clone());
+        }
+        if self.frame_start.is_none() {
+            self.stamp()?;
+        }
+        let start = self.frame_start.ok_or_else(|| header_overflow(0))?;
+        self.buf.get(start..).ok_or_else(|| header_overflow(start))
+    }
+
+    /// Stamps the frame and appends it to `dst`.
+    ///
+    /// For callers that need the frame in a buffer they own — a transport
+    /// write queue, for instance. The encoder's own buffer is left holding the
+    /// finished frame, so [`Encoder::clear`] still retains its capacity.
+    ///
+    /// # Arguments
+    /// * `dst` - Buffer the frame is appended to
+    ///
+    /// # Errors
+    /// The same rejections as [`Encoder::finish`]; `dst` is left untouched.
+    pub fn finish_into(&mut self, dst: &mut BytesMut) -> Result<(), EncodeError> {
+        let frame = self.finish()?;
+        dst.reserve(frame.len());
+        dst.put_slice(frame);
+        Ok(())
+    }
+
+    /// Returns the current body length in bytes — the value stamped into
+    /// `BodyLength` (tag 9).
+    #[inline]
+    #[must_use]
+    pub const fn body_len(&self) -> usize {
+        self.body_len
+    }
+
+    /// Returns the first rejection recorded so far, if any.
+    ///
+    /// Lets a caller using the infallible `put_*` methods check before
+    /// [`Encoder::finish`].
+    #[inline]
+    pub fn error(&self) -> Option<&EncodeError> {
+        self.first_error()
+    }
+
+    /// Clears the encoder for the next message, retaining its capacity.
+    ///
+    /// A rejection recorded for the `BeginString` is **not** cleared: it makes
+    /// every message this encoder could build unframeable, not just the one
+    /// being discarded.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.buf.clear();
+        self.buf.resize(HEADER_RESERVE, 0);
+        self.body_len = 0;
+        self.first_tag = None;
+        self.frame_start = None;
+        self.error = None;
+    }
+
+    /// Returns the construction rejection if there is one, else the first
+    /// rejected write.
+    #[inline]
+    fn first_error(&self) -> Option<&EncodeError> {
+        self.begin_string_error.as_ref().or(self.error.as_ref())
+    }
+
+    /// Records the first rejected write; later ones are dropped, since the
+    /// frame is already unproducible and the first is the one that explains
+    /// why.
+    #[cold]
+    #[inline(never)]
+    fn record(&mut self, err: EncodeError) {
+        if self.error.is_none() {
+            self.error = Some(err);
+        }
+    }
+
+    /// Rejects a write into a frame that has already been stamped.
+    #[inline]
+    fn check_open(&self, tag: u32) -> Result<(), EncodeError> {
+        if self.frame_start.is_some() {
+            return Err(already_finished(tag));
+        }
+        Ok(())
+    }
+
+    /// Appends `tag=value<SOH>` to the body. The caller has validated both.
+    #[inline]
+    fn write_field(&mut self, tag: u32, value: &[u8]) {
         let mut tag_buf = itoa::Buffer::new();
         let tag_str = tag_buf.format(tag);
 
-        self.body.put_slice(tag_str.as_bytes());
-        self.body.put_u8(b'=');
-        self.body.put_slice(value);
-        self.body.put_u8(SOH);
+        // The running body length is what gets stamped into tag 9, so it is
+        // folded with checked arithmetic rather than recovered from the
+        // buffer's length by subtraction. `+ 2` is `=` and SOH.
+        let Some(body_len) = tag_str
+            .len()
+            .checked_add(value.len())
+            .and_then(|n| n.checked_add(2))
+            .and_then(|n| self.body_len.checked_add(n))
+        else {
+            self.record(body_overflow(value.len()));
+            return;
+        };
+
+        self.buf.put_slice(tag_str.as_bytes());
+        self.buf.put_u8(EQUALS);
+        self.buf.put_slice(value);
+        self.buf.put_u8(SOH);
+
+        if self.first_tag.is_none() {
+            self.first_tag = Some(tag);
+        }
+        self.body_len = body_len;
     }
 
-    /// Finalizes the message and returns the complete encoded bytes.
-    ///
-    /// This method:
-    /// 1. Prepends BeginString (tag 8) and BodyLength (tag 9)
-    /// 2. Appends Checksum (tag 10)
-    ///
-    /// # Returns
-    /// The complete FIX message as bytes.
-    #[must_use]
-    pub fn finish(self) -> BytesMut {
-        let body_len = self.body.len();
+    /// Writes the header into the reserved prefix and appends the trailer.
+    fn stamp(&mut self) -> Result<(), EncodeError> {
+        if self.first_tag != Some(35) {
+            return Err(EncodeError::MissingRequiredField { tag: 35 });
+        }
 
-        // Build header: 8=BeginString|9=BodyLength|
-        let mut header = BytesMut::with_capacity(32);
-        header.put_slice(b"8=");
-        header.put_slice(self.begin_string.as_bytes());
-        header.put_u8(SOH);
-        header.put_slice(b"9=");
+        let begin_string = self
+            .begin_string
+            .get(..self.begin_string_len)
+            .ok_or_else(|| header_overflow(self.begin_string_len))?;
 
         let mut len_buf = itoa::Buffer::new();
-        let len_str = len_buf.format(body_len);
-        header.put_slice(len_str.as_bytes());
-        header.put_u8(SOH);
+        let body_len_str = len_buf.format(self.body_len);
 
-        // Combine header and body
-        let mut message = BytesMut::with_capacity(header.len() + body_len + 8);
-        message.put_slice(&header);
-        message.put_slice(&self.body);
+        // `8=` + BeginString + SOH + `9=` + digits + SOH.
+        let header_len = [2, begin_string.len(), 1, 2, body_len_str.len(), 1]
+            .into_iter()
+            .try_fold(0usize, usize::checked_add)
+            .ok_or_else(|| header_overflow(usize::MAX))?;
+        // Right-align the header so its last byte is the SOH immediately
+        // before the body: that is what makes the frame contiguous without
+        // moving the body.
+        let frame_start = HEADER_RESERVE
+            .checked_sub(header_len)
+            .ok_or_else(|| header_overflow(header_len))?;
 
-        // Calculate and append checksum
-        let checksum = calculate_checksum(&message);
-        let checksum_bytes = format_checksum(checksum);
+        {
+            let slot = self
+                .buf
+                .get_mut(frame_start..HEADER_RESERVE)
+                .ok_or_else(|| header_overflow(header_len))?;
+            let mut written = 0usize;
+            let overflow = || header_overflow(header_len);
+            push_bytes(slot, &mut written, b"8=").ok_or_else(overflow)?;
+            push_bytes(slot, &mut written, begin_string).ok_or_else(overflow)?;
+            push_bytes(slot, &mut written, &[SOH]).ok_or_else(overflow)?;
+            push_bytes(slot, &mut written, b"9=").ok_or_else(overflow)?;
+            push_bytes(slot, &mut written, body_len_str.as_bytes()).ok_or_else(overflow)?;
+            push_bytes(slot, &mut written, &[SOH]).ok_or_else(overflow)?;
+        }
 
-        message.put_slice(b"10=");
-        message.put_slice(&checksum_bytes);
-        message.put_u8(SOH);
+        let checksum = {
+            let span = self
+                .buf
+                .get(frame_start..)
+                .ok_or_else(|| header_overflow(header_len))?;
+            calculate_checksum(span)
+        };
+        let digits = format_checksum(checksum);
+        self.buf.put_slice(b"10=");
+        self.buf.put_slice(&digits);
+        self.buf.put_u8(SOH);
 
-        message
-    }
-
-    /// Returns the current body length.
-    #[inline]
-    #[must_use]
-    pub fn body_len(&self) -> usize {
-        self.body.len()
-    }
-
-    /// Clears the encoder for reuse.
-    #[inline]
-    pub fn clear(&mut self) {
-        self.body.clear();
+        self.frame_start = Some(frame_start);
+        Ok(())
     }
 }
 
@@ -185,71 +557,843 @@ impl Default for Encoder {
     }
 }
 
+/// Copies a validated `BeginString` into inline storage, returning its length.
+///
+/// Tag 8 opens every frame, so a value carrying SOH would make the very first
+/// field of the message ambiguous. The charset matches
+/// [`ironfix_core::message::MsgType`]: printable ASCII, no `=`.
+///
+/// # Errors
+/// [`EncodeError::InvalidFieldValue`] for an empty value or an illegal byte,
+/// [`EncodeError::FieldTooLong`] past [`BEGIN_STRING_MAX_LEN`].
+fn copy_begin_string(
+    value: &str,
+    slot: &mut [u8; BEGIN_STRING_MAX_LEN],
+) -> Result<usize, EncodeError> {
+    if value.is_empty() {
+        return Err(empty_value(8));
+    }
+    if value.len() > BEGIN_STRING_MAX_LEN {
+        return Err(EncodeError::FieldTooLong {
+            tag: 8,
+            length: value.len(),
+            max_length: BEGIN_STRING_MAX_LEN,
+        });
+    }
+    for (position, &byte) in value.as_bytes().iter().enumerate() {
+        if !byte.is_ascii_graphic() || byte == EQUALS {
+            return Err(illegal_begin_string_byte(byte, position));
+        }
+    }
+    slot.get_mut(..value.len())
+        .ok_or_else(|| header_overflow(value.len()))?
+        .copy_from_slice(value.as_bytes());
+    Ok(value.len())
+}
+
+/// Rejects a `MsgType` (tag 35) value the decoder would refuse.
+///
+/// The decoder builds an [`MsgType`] out of tag 35 and rejects the whole frame
+/// if the value is empty, over-long, or carries a byte that cannot appear
+/// there, so emitting one would mean emitting a frame this crate's own decoder
+/// will not read back. The check delegates to [`MsgType::new`] rather than
+/// restating its rule, so the two cannot drift.
+///
+/// # Errors
+/// [`EncodeError::FieldTooLong`] past
+/// [`ironfix_core::message::MSG_TYPE_MAX_LEN`], otherwise
+/// [`EncodeError::InvalidFieldValue`].
+fn check_msg_type(value: &[u8]) -> Result<(), EncodeError> {
+    // A legal MsgType is printable ASCII, so anything that fails UTF-8 here
+    // would fail the byte check anyway.
+    let Ok(code) = std::str::from_utf8(value) else {
+        return Err(invalid_msg_type("msg type is not valid UTF-8".to_string()));
+    };
+    match MsgType::new(code) {
+        Ok(_) => Ok(()),
+        Err(MsgTypeError::TooLong { len, max_len }) => Err(EncodeError::FieldTooLong {
+            tag: 35,
+            length: len,
+            max_length: max_len,
+        }),
+        Err(err) => Err(invalid_msg_type(err.to_string())),
+    }
+}
+
+/// Builds the rejection for an unrepresentable `MsgType` value.
+#[cold]
+#[inline(never)]
+fn invalid_msg_type(reason: String) -> EncodeError {
+    EncodeError::InvalidFieldValue { tag: 35, reason }
+}
+
+/// Appends `src` to `dst` at `*len`, advancing it.
+///
+/// Returns `None` rather than writing out of bounds, which the caller turns
+/// into a typed error.
+#[inline]
+fn push_bytes(dst: &mut [u8], len: &mut usize, src: &[u8]) -> Option<()> {
+    let end = len.checked_add(src.len())?;
+    dst.get_mut(*len..end)?.copy_from_slice(src);
+    *len = end;
+    Some(())
+}
+
+/// Rejects a tag that is not a legal FIX field tag.
+#[inline]
+fn check_tag(tag: u32) -> Result<(), EncodeError> {
+    if tag == 0 {
+        return Err(zero_tag());
+    }
+    Ok(())
+}
+
+/// Rejects a tag that may not be written as an ordinary body field.
+#[inline]
+fn check_body_tag(tag: u32) -> Result<(), EncodeError> {
+    check_tag(tag)?;
+    // 8 BeginString, 9 BodyLength, 10 CheckSum.
+    if matches!(tag, 8..=10) {
+        return Err(framing_tag(tag));
+    }
+    if paired_data_tag(tag).is_some() || is_data_tag(tag) {
+        return Err(data_tag_needs_pair(tag));
+    }
+    Ok(())
+}
+
+/// Builds the rejection for tag `0`.
+///
+/// The error constructors below are out of line because each formats a
+/// `String`: that allocation belongs on the rejection path, not in the
+/// instruction-cache footprint of the field-writing loop.
+#[cold]
+#[inline(never)]
+fn zero_tag() -> EncodeError {
+    EncodeError::InvalidFieldValue {
+        tag: 0,
+        reason: "0 is not a legal FIX field tag: tags are positive integers starting at 1"
+            .to_string(),
+    }
+}
+
+/// Builds the rejection for a framing tag written as a body field.
+#[cold]
+#[inline(never)]
+fn framing_tag(tag: u32) -> EncodeError {
+    EncodeError::InvalidFieldValue {
+        tag,
+        reason: format!(
+            "tag {tag} is stamped by the encoder itself; writing it into the body \
+             would give the frame two of it"
+        ),
+    }
+}
+
+/// Builds the rejection for half of a `LENGTH`/`DATA` pair written alone.
+#[cold]
+#[inline(never)]
+fn data_tag_needs_pair(tag: u32) -> EncodeError {
+    EncodeError::InvalidFieldValue {
+        tag,
+        reason: format!(
+            "tag {tag} belongs to a LENGTH/DATA field pair and must be written with put_data, \
+             which derives the declared count from the payload"
+        ),
+    }
+}
+
+/// Builds the rejection for a `DATA` tag that is not paired with the
+/// `LENGTH` tag it was offered with.
+#[cold]
+#[inline(never)]
+fn unpaired_data_tag(length_tag: u32, data_tag: u32) -> EncodeError {
+    EncodeError::InvalidFieldValue {
+        tag: data_tag,
+        reason: format!(
+            "tag {data_tag} is not the DATA field the FIX specification pairs with LENGTH \
+             field {length_tag}; a decoder frames a DATA value by the count in its own \
+             paired LENGTH field"
+        ),
+    }
+}
+
+/// Builds the rejection for an empty field value.
+#[cold]
+#[inline(never)]
+fn empty_value(tag: u32) -> EncodeError {
+    EncodeError::InvalidFieldValue {
+        tag,
+        reason: "value is empty; a FIX field carries at least one byte".to_string(),
+    }
+}
+
+/// Builds the rejection for a value carrying the SOH delimiter.
+#[cold]
+#[inline(never)]
+fn soh_in_value(tag: u32, position: usize) -> EncodeError {
+    EncodeError::InvalidFieldValue {
+        tag,
+        reason: format!(
+            "value contains the SOH delimiter at offset {position}, which would terminate \
+             the field early and inject the remainder as further fields"
+        ),
+    }
+}
+
+/// Builds the rejection for an illegal `BeginString` byte.
+#[cold]
+#[inline(never)]
+fn illegal_begin_string_byte(byte: u8, position: usize) -> EncodeError {
+    EncodeError::InvalidFieldValue {
+        tag: 8,
+        reason: format!(
+            "begin string contains illegal byte {byte:#04x} at offset {position}: \
+             only printable ASCII (0x21..=0x7e) except '=' is allowed"
+        ),
+    }
+}
+
+/// Builds the rejection for a write into an already-stamped frame.
+#[cold]
+#[inline(never)]
+fn already_finished(tag: u32) -> EncodeError {
+    EncodeError::InvalidFieldValue {
+        tag,
+        reason: "the frame is already finished; call clear() before encoding the next message"
+            .to_string(),
+    }
+}
+
+/// Builds the rejection for a body that cannot grow further.
+///
+/// The body length is a `usize` counting bytes already in memory, so this is
+/// unreachable on any real machine; it exists so the fold that proves it has
+/// somewhere to fail instead of wrapping.
+#[cold]
+#[inline(never)]
+fn body_overflow(needed: usize) -> EncodeError {
+    EncodeError::BufferOverflow {
+        needed,
+        available: 0,
+    }
+}
+
+/// Builds the rejection for a header that does not fit the reserved prefix.
+///
+/// [`HEADER_RESERVE`] is sized for the worst case, so this is unreachable; it
+/// exists so the arithmetic and slicing that prove it have somewhere to fail
+/// instead of panicking.
+#[cold]
+#[inline(never)]
+fn header_overflow(needed: usize) -> EncodeError {
+    EncodeError::BufferOverflow {
+        needed,
+        available: HEADER_RESERVE,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_encoder_basic() {
+    use crate::Decoder;
+    use ironfix_core::error::DecodeError;
+    use ironfix_core::message::MsgType;
+
+    /// Returns the finished frame, failing the test with the rejection.
+    #[track_caller]
+    fn frame_of(encoder: &mut Encoder) -> Vec<u8> {
+        match encoder.finish() {
+            Ok(frame) => frame.to_vec(),
+            Err(err) => panic!("frame must encode: {err}"),
+        }
+    }
+
+    /// Builds a minimal valid frame carrying the extra fields in `fields`.
+    fn encode(fields: &[(u32, &[u8])]) -> Vec<u8> {
         let mut encoder = Encoder::new("FIX.4.4");
         encoder.put_str(35, "0");
+        for (tag, value) in fields {
+            encoder.put_raw(*tag, value);
+        }
+        frame_of(&mut encoder)
+    }
 
-        let message = encoder.finish();
-        let msg_str = String::from_utf8_lossy(&message);
+    /// Asserts that `encoder` refuses to produce a frame, with
+    /// `InvalidFieldValue` for `tag`.
+    #[track_caller]
+    fn assert_rejected(encoder: &mut Encoder, tag: u32) {
+        match encoder.finish() {
+            Err(EncodeError::InvalidFieldValue { tag: actual, .. }) => assert_eq!(actual, tag),
+            Ok(frame) => panic!(
+                "the frame must be refused, got {:?}",
+                String::from_utf8_lossy(frame)
+            ),
+            Err(other) => panic!("expected InvalidFieldValue for tag {tag}, got {other}"),
+        }
+    }
 
-        assert!(msg_str.starts_with("8=FIX.4.4\x01"));
-        assert!(msg_str.contains("35=0\x01"));
-        assert!(msg_str.contains("10="));
+    /// Reads the value of `tag` out of a finished frame.
+    #[track_caller]
+    fn field_of(frame: &[u8], tag: u32) -> Option<String> {
+        match Decoder::new(frame).decode() {
+            Ok(decoded) => decoded
+                .get_field(tag)
+                .map(|field| String::from_utf8_lossy(field.value).into_owned()),
+            Err(err) => panic!("frame must decode: {err}"),
+        }
     }
 
     #[test]
-    fn test_encoder_multiple_fields() {
+    fn test_encoder_basic_frame_is_well_formed() {
+        let frame = encode(&[]);
+        let text = String::from_utf8_lossy(&frame).into_owned();
+
+        assert!(text.starts_with("8=FIX.4.4\x019="));
+        assert!(text.contains("35=0\x01"));
+        assert!(text.ends_with('\x01'));
+        assert_eq!(field_of(&frame, 35).as_deref(), Some("0"));
+    }
+
+    #[test]
+    fn test_encoder_multiple_fields_round_trip() {
         let mut encoder = Encoder::new("FIX.4.4");
         encoder.put_str(35, "D");
         encoder.put_str(49, "SENDER");
         encoder.put_str(56, "TARGET");
         encoder.put_uint(34, 1);
-
-        let message = encoder.finish();
-        let msg_str = String::from_utf8_lossy(&message);
-
-        assert!(msg_str.contains("35=D\x01"));
-        assert!(msg_str.contains("49=SENDER\x01"));
-        assert!(msg_str.contains("56=TARGET\x01"));
-        assert!(msg_str.contains("34=1\x01"));
-    }
-
-    #[test]
-    fn test_encoder_bool() {
-        let mut encoder = Encoder::new("FIX.4.4");
-        encoder.put_bool(141, true);
-        encoder.put_bool(142, false);
-
-        let message = encoder.finish();
-        let msg_str = String::from_utf8_lossy(&message);
-
-        assert!(msg_str.contains("141=Y\x01"));
-        assert!(msg_str.contains("142=N\x01"));
-    }
-
-    #[test]
-    fn test_encoder_char() {
-        let mut encoder = Encoder::new("FIX.4.4");
+        encoder.put_int(44, -7);
+        encoder.put_bool(43, true);
         encoder.put_char(54, '1');
+        let frame = frame_of(&mut encoder);
 
-        let message = encoder.finish();
-        let msg_str = String::from_utf8_lossy(&message);
-
-        assert!(msg_str.contains("54=1\x01"));
+        let Ok(decoded) = Decoder::new(&frame).decode() else {
+            panic!("frame must decode");
+        };
+        assert_eq!(*decoded.msg_type(), MsgType::NewOrderSingle);
+        assert_eq!(decoded.get_field_str(49), Some("SENDER"));
+        assert_eq!(decoded.get_field_str(56), Some("TARGET"));
+        assert_eq!(decoded.get_field_str(34), Some("1"));
+        assert_eq!(decoded.get_field_str(44), Some("-7"));
+        assert_eq!(decoded.get_field_str(43), Some("Y"));
+        assert_eq!(decoded.get_field_str(54), Some("1"));
+        // 8, 9, 35, 49, 56, 34, 44, 43, 54, 10 — the CheckSum field is not
+        // collected into the field list.
+        assert_eq!(decoded.field_count(), 9);
     }
 
     #[test]
-    fn test_encoder_clear() {
+    fn test_encoder_stamps_the_exact_body_length_and_checksum() {
         let mut encoder = Encoder::new("FIX.4.4");
-        encoder.put_str(35, "0");
-        assert!(encoder.body_len() > 0);
+        encoder.put_str(35, "D");
+        encoder.put_str(49, "SENDER");
+        encoder.put_uint(34, 42);
+        let body_len = encoder.body_len();
+        let frame = frame_of(&mut encoder);
+
+        // The body is exactly what the encoder counted.
+        let body = b"35=D\x0149=SENDER\x0134=42\x01";
+        assert_eq!(body_len, body.len());
+
+        let expected_header = format!("8=FIX.4.4\x019={}\x01", body.len());
+        let mut expected = expected_header.into_bytes();
+        expected.extend_from_slice(body);
+        let checksum: u64 = expected.iter().map(|&b| u64::from(b)).sum();
+        let expected_checksum = (checksum % 256) as u8;
+        expected.extend_from_slice(format!("10={expected_checksum:03}\x01").as_bytes());
+
+        assert_eq!(frame, expected);
+
+        // And the stamped values are what the decoder recomputes.
+        let Ok(decoded) = Decoder::new(&frame).decode() else {
+            panic!("frame must decode with checksum validation on");
+        };
+        assert_eq!(decoded.body(), Ok(&body[..]));
+        assert_eq!(
+            decoded.get_field_str(9),
+            Some(body.len().to_string().as_str())
+        );
+    }
+
+    #[test]
+    fn test_encoder_body_length_digit_growth_keeps_the_frame_contiguous() {
+        // The header is right-aligned in the reserved prefix, so its length
+        // changes with the digit count of BodyLength. Each of these must still
+        // decode with the checksum computed over the frame actually emitted.
+        for filler in [1usize, 8, 97, 1000] {
+            let payload = vec![b'x'; filler];
+            let mut encoder = Encoder::new("FIX.4.4");
+            encoder.put_str(35, "D");
+            encoder.put_raw(58, &payload);
+            let frame = frame_of(&mut encoder);
+
+            assert!(frame.starts_with(b"8=FIX.4.4\x019="));
+            let Ok(decoded) = Decoder::new(&frame).decode() else {
+                panic!("frame with a {filler}-byte value must decode");
+            };
+            assert_eq!(decoded.get_field(58).map(|f| f.value.len()), Some(filler));
+        }
+    }
+
+    #[test]
+    fn test_encoder_reuse_after_clear_produces_an_independent_frame() {
+        let mut encoder = Encoder::new("FIX.4.4");
+        encoder.put_str(35, "A");
+        encoder.put_str(49, "FIRST");
+        let first = frame_of(&mut encoder);
 
         encoder.clear();
         assert_eq!(encoder.body_len(), 0);
+        encoder.put_str(35, "0");
+        encoder.put_str(49, "SECOND");
+        let second = frame_of(&mut encoder);
+
+        assert_eq!(field_of(&first, 49).as_deref(), Some("FIRST"));
+        assert_eq!(field_of(&second, 49).as_deref(), Some("SECOND"));
+        // No residue of the first message, in particular no second trailer.
+        assert_eq!(second.iter().filter(|&&b| b == SOH).count(), 5);
+    }
+
+    #[test]
+    fn test_encoder_finish_is_idempotent() {
+        let mut encoder = Encoder::new("FIX.4.4");
+        encoder.put_str(35, "0");
+        let first = frame_of(&mut encoder);
+        let second = frame_of(&mut encoder);
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn test_encoder_finish_into_appends_the_same_frame() {
+        let mut encoder = Encoder::new("FIX.4.4");
+        encoder.put_str(35, "0");
+        encoder.put_str(49, "SENDER");
+
+        let mut dst = BytesMut::from(&b"PRE"[..]);
+        match encoder.finish_into(&mut dst) {
+            Ok(()) => {}
+            Err(err) => panic!("frame must encode: {err}"),
+        }
+        let frame = frame_of(&mut encoder);
+
+        assert_eq!(dst.len(), 3 + frame.len());
+        assert_eq!(dst.get(3..), Some(&frame[..]));
+    }
+
+    #[test]
+    fn test_encoder_value_with_embedded_soh_is_rejected() {
+        let mut encoder = Encoder::new("FIX.4.4");
+        encoder.put_str(35, "D");
+        // The injection this rejection exists for: without it the frame carries
+        // a phantom 49=EVIL with a BodyLength and CheckSum correct for it.
+        encoder.put_str(58, "text\x0149=EVIL");
+        assert_rejected(&mut encoder, 58);
+    }
+
+    #[test]
+    fn test_encoder_try_put_raw_reports_soh_immediately_and_writes_nothing() {
+        let mut encoder = Encoder::new("FIX.4.4");
+        encoder.put_str(35, "D");
+        let before = encoder.body_len();
+
+        let result = encoder.try_put_raw(58, b"a\x01b");
+        assert!(matches!(
+            result,
+            Err(EncodeError::InvalidFieldValue { tag: 58, .. })
+        ));
+        assert_eq!(encoder.body_len(), before);
+        // A rejection the caller took delivery of is not also recorded.
+        assert!(encoder.error().is_none());
+        assert!(encoder.finish().is_ok());
+    }
+
+    #[test]
+    fn test_encoder_value_with_equals_is_accepted_and_round_trips() {
+        // '=' inside a value is legal FIX: a decoder splits at the first '='.
+        let frame = encode(&[(58, b"key=value")]);
+        assert_eq!(field_of(&frame, 58).as_deref(), Some("key=value"));
+    }
+
+    #[test]
+    fn test_encoder_empty_value_is_rejected() {
+        let mut encoder = Encoder::new("FIX.4.4");
+        encoder.put_str(35, "D");
+        encoder.put_str(58, "");
+        assert_rejected(&mut encoder, 58);
+    }
+
+    #[test]
+    fn test_encoder_zero_tag_is_rejected() {
+        let mut encoder = Encoder::new("FIX.4.4");
+        encoder.put_str(35, "D");
+        encoder.put_str(0, "x");
+        assert_rejected(&mut encoder, 0);
+    }
+
+    #[test]
+    fn test_encoder_framing_tags_are_rejected() {
+        // Writing 8, 9 or 10 into the body gives the frame two of them; a
+        // mid-body 10= in particular is read as the trailer by the decoder.
+        for tag in [8u32, 9, 10] {
+            let mut encoder = Encoder::new("FIX.4.4");
+            encoder.put_str(35, "D");
+            encoder.put_str(tag, "1");
+            assert_rejected(&mut encoder, tag);
+        }
+    }
+
+    #[test]
+    fn test_encoder_length_or_data_tag_written_alone_is_rejected() {
+        // The frame this prevents: `95=3<SOH>96=abcdefg<SOH>` declares a count
+        // that disagrees with the payload, which the decoder rejects.
+        for tag in [95u32, 96, 93, 89, 354, 355] {
+            let mut encoder = Encoder::new("FIX.4.4");
+            encoder.put_str(35, "D");
+            encoder.put_str(tag, "3");
+            assert_rejected(&mut encoder, tag);
+        }
+    }
+
+    #[test]
+    fn test_encoder_missing_msg_type_is_rejected() {
+        let mut encoder = Encoder::new("FIX.4.4");
+        assert_eq!(
+            encoder.finish().err(),
+            Some(EncodeError::MissingRequiredField { tag: 35 })
+        );
+
+        // Present but not first: the decoder reads the third field of the frame
+        // as MsgType, so this would frame 49 as the message type.
+        let mut encoder = Encoder::new("FIX.4.4");
+        encoder.put_str(49, "SENDER");
+        encoder.put_str(35, "D");
+        assert_eq!(
+            encoder.finish().err(),
+            Some(EncodeError::MissingRequiredField { tag: 35 })
+        );
+    }
+
+    #[test]
+    fn test_encoder_unrepresentable_msg_type_is_rejected() {
+        // Each of these frames decodes as far as tag 35 and is then refused by
+        // the decoder, so the encoder must not produce it in the first place.
+        for code in ["A B", "A=B", "\u{7f}"] {
+            let mut encoder = Encoder::new("FIX.4.4");
+            encoder.put_str(35, code);
+            assert_rejected(&mut encoder, 35);
+        }
+
+        let mut encoder = Encoder::new("FIX.4.4");
+        encoder.put_str(35, "U99999999");
+        assert_eq!(
+            encoder.finish().err(),
+            Some(EncodeError::FieldTooLong {
+                tag: 35,
+                length: 9,
+                max_length: 8,
+            })
+        );
+    }
+
+    #[test]
+    fn test_encoder_representable_custom_msg_type_is_accepted() {
+        let mut encoder = Encoder::new("FIX.4.4");
+        encoder.put_str(35, "U9999999");
+        let frame = frame_of(&mut encoder);
+        let Ok(decoded) = Decoder::new(&frame).decode() else {
+            panic!("a representable custom MsgType must decode");
+        };
+        assert_eq!(decoded.msg_type().as_str(), "U9999999");
+    }
+
+    #[test]
+    fn test_encoder_write_after_finish_is_rejected() {
+        let mut encoder = Encoder::new("FIX.4.4");
+        encoder.put_str(35, "0");
+        let frame = frame_of(&mut encoder);
+
+        assert!(matches!(
+            encoder.try_put_raw(58, b"late"),
+            Err(EncodeError::InvalidFieldValue { tag: 58, .. })
+        ));
+        // The stamped frame is unchanged.
+        assert_eq!(frame_of(&mut encoder), frame);
+    }
+
+    #[test]
+    fn test_encoder_illegal_begin_string_is_rejected() {
+        for begin_string in ["", "FIX\x014.4", "FIX=4.4", "FIX 4.4"] {
+            let mut encoder = Encoder::new(begin_string);
+            encoder.put_str(35, "0");
+            match encoder.finish() {
+                Err(EncodeError::InvalidFieldValue { tag: 8, .. }) => {}
+                other => panic!("{begin_string:?} must be refused, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_encoder_over_long_begin_string_is_rejected() {
+        let begin_string = "F".repeat(BEGIN_STRING_MAX_LEN + 1);
+        let mut encoder = Encoder::new(&begin_string);
+        encoder.put_str(35, "0");
+        assert_eq!(
+            encoder.finish().err(),
+            Some(EncodeError::FieldTooLong {
+                tag: 8,
+                length: BEGIN_STRING_MAX_LEN + 1,
+                max_length: BEGIN_STRING_MAX_LEN,
+            })
+        );
+    }
+
+    #[test]
+    fn test_encoder_begin_string_rejection_survives_clear() {
+        let mut encoder = Encoder::new("FIX\x014.4");
+        encoder.put_str(35, "0");
+        assert!(encoder.finish().is_err());
+        encoder.clear();
+        encoder.put_str(35, "0");
+        assert!(
+            encoder.finish().is_err(),
+            "an unusable BeginString makes every message unframeable"
+        );
+    }
+
+    #[test]
+    fn test_encoder_begin_string_at_the_bound_is_accepted() {
+        let begin_string = "F".repeat(BEGIN_STRING_MAX_LEN);
+        let mut encoder = Encoder::new(&begin_string);
+        encoder.put_str(35, "0");
+        let frame = frame_of(&mut encoder);
+        let Ok(decoded) = Decoder::new(&frame).decode() else {
+            panic!("frame must decode");
+        };
+        assert_eq!(decoded.begin_string(), Ok(begin_string.as_str()));
+    }
+
+    #[test]
+    fn test_encoder_first_rejection_is_the_one_reported() {
+        let mut encoder = Encoder::new("FIX.4.4");
+        encoder.put_str(35, "D");
+        encoder.put_str(58, "a\x01b");
+        encoder.put_str(11, "");
+        assert_rejected(&mut encoder, 58);
+    }
+
+    #[test]
+    fn test_encoder_put_data_round_trips_a_payload_carrying_soh_and_equals() {
+        let payload: &[u8] = b"a\x01b=c\x01d";
+        let mut encoder = Encoder::new("FIX.4.4");
+        encoder.put_str(35, "A");
+        encoder.put_data(95, 96, payload);
+        encoder.put_str(58, "after");
+        let frame = frame_of(&mut encoder);
+
+        let Ok(decoded) = Decoder::new(&frame).decode() else {
+            panic!("frame with RawData must decode");
+        };
+        assert_eq!(decoded.get_field(95).map(|f| f.value), Some(&b"7"[..]));
+        assert_eq!(decoded.get_field(96).map(|f| f.value), Some(payload));
+        assert_eq!(decoded.get_field_str(58), Some("after"));
+        // 8, 9, 35, 95, 96, 58 — no phantom field from inside the payload.
+        assert_eq!(decoded.field_count(), 6);
+    }
+
+    #[test]
+    fn test_encoder_put_data_empty_payload_round_trips() {
+        let mut encoder = Encoder::new("FIX.4.4");
+        encoder.put_str(35, "A");
+        encoder.put_data(95, 96, b"");
+        encoder.put_str(58, "after");
+        let frame = frame_of(&mut encoder);
+
+        let Ok(decoded) = Decoder::new(&frame).decode() else {
+            panic!("frame with an empty RawData must decode");
+        };
+        assert_eq!(decoded.get_field(95).map(|f| f.value), Some(&b"0"[..]));
+        assert_eq!(decoded.get_field(96).map(|f| f.value), Some(&b""[..]));
+        assert_eq!(decoded.get_field_str(58), Some("after"));
+    }
+
+    #[test]
+    fn test_encoder_put_data_round_trips_every_spec_pair() {
+        // Each pair the decoder frames by count must also be emittable.
+        let pairs = [
+            (90u32, 91u32),
+            (93, 89),
+            (95, 96),
+            (212, 213),
+            (348, 349),
+            (350, 351),
+            (352, 353),
+            (354, 355),
+            (356, 357),
+            (358, 359),
+            (360, 361),
+            (362, 363),
+            (364, 365),
+            (445, 446),
+            (618, 619),
+            (621, 622),
+        ];
+        let payload: &[u8] = b"\x01=\x01";
+        for (length_tag, data_tag) in pairs {
+            let mut encoder = Encoder::new("FIX.4.4");
+            encoder.put_str(35, "A");
+            encoder.put_data(length_tag, data_tag, payload);
+            let frame = frame_of(&mut encoder);
+
+            let Ok(decoded) = Decoder::new(&frame).decode() else {
+                panic!("frame carrying {length_tag}/{data_tag} must decode");
+            };
+            assert_eq!(decoded.get_field(data_tag).map(|f| f.value), Some(payload));
+        }
+    }
+
+    #[test]
+    fn test_encoder_put_data_unpaired_tags_are_rejected() {
+        // 96 is paired with 95, not with 93: emitting it under 93 would leave
+        // the payload's SOH bytes to be read as field terminators.
+        let mut encoder = Encoder::new("FIX.4.4");
+        encoder.put_str(35, "A");
+        encoder.put_data(93, 96, b"x\x01y");
+        assert_rejected(&mut encoder, 96);
+
+        let mut encoder = Encoder::new("FIX.4.4");
+        encoder.put_str(35, "A");
+        encoder.put_data(58, 59, b"x");
+        assert_rejected(&mut encoder, 59);
+    }
+
+    #[test]
+    fn test_encoder_put_data_zero_tag_is_rejected() {
+        let mut encoder = Encoder::new("FIX.4.4");
+        encoder.put_str(35, "A");
+        encoder.put_data(0, 96, b"x");
+        assert_rejected(&mut encoder, 0);
+    }
+
+    #[test]
+    fn test_encoder_output_always_decodes_under_checksum_validation() {
+        // The property the whole module exists to hold: anything `finish`
+        // yields is a frame this crate's decoder accepts.
+        let mut encoder = Encoder::new("FIXT.1.1");
+        encoder.put_str(35, "A");
+        encoder.put_str(49, "CLIENT");
+        encoder.put_str(56, "VENUE");
+        encoder.put_uint(34, 1);
+        encoder.put_str(52, "20260721-12:00:00.000");
+        encoder.put_data(95, 96, b"\x01\x01\x01");
+        encoder.put_str(1137, "9");
+        let frame = frame_of(&mut encoder);
+
+        let Ok(decoded) = Decoder::new(&frame).decode() else {
+            panic!("frame must decode");
+        };
+        assert_eq!(decoded.begin_string(), Ok("FIXT.1.1"));
+        assert_eq!(*decoded.msg_type(), MsgType::Logon);
+        assert_eq!(decoded.len(), frame.len());
+    }
+
+    #[test]
+    fn test_encoder_frame_is_rejected_when_a_byte_is_flipped() {
+        // Guards the assertion above against being vacuous: the decoder really
+        // is checking the checksum the encoder stamped.
+        let mut encoder = Encoder::new("FIX.4.4");
+        encoder.put_str(35, "0");
+        encoder.put_str(49, "SENDER");
+        let mut frame = frame_of(&mut encoder);
+        let Some(position) = memchr(b'S', &frame) else {
+            panic!("the frame carries the SENDER value");
+        };
+        let Some(byte) = frame.get_mut(position) else {
+            panic!("the position came from the frame itself");
+        };
+        // Case flip: same length, so only the checksum can catch it.
+        *byte ^= 0x20;
+
+        assert!(matches!(
+            Decoder::new(&frame).decode(),
+            Err(DecodeError::ChecksumMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn test_encoder_never_emits_a_frame_its_own_decoder_rejects() {
+        // The invariant, stated as a property over hostile inputs: for every
+        // tag and value, `finish` either refuses or yields a frame `decode`
+        // accepts with checksum validation on. There is no third outcome.
+        let tags: [u32; 12] = [0, 1, 8, 9, 10, 35, 49, 58, 93, 95, 96, u32::MAX];
+        let values: [&[u8]; 12] = [
+            b"",
+            b"x",
+            b"a\x01b",
+            b"\x01",
+            b"=",
+            b"a=b",
+            b"10=999",
+            b"\x0110=000\x01",
+            b"\xff\xfe",
+            b"\x00",
+            b" ",
+            b"U99999999",
+        ];
+
+        for tag in tags {
+            for value in values {
+                // As a trailing field of an otherwise valid message...
+                let mut encoder = Encoder::new("FIX.4.4");
+                encoder.put_str(35, "D");
+                encoder.put_raw(tag, value);
+                assert_frame_or_rejection(&mut encoder, tag, value);
+
+                // ...and as the message's very first field.
+                let mut encoder = Encoder::new("FIX.4.4");
+                encoder.put_raw(tag, value);
+                assert_frame_or_rejection(&mut encoder, tag, value);
+
+                // The Length/Data path takes the same payloads.
+                let mut encoder = Encoder::new("FIX.4.4");
+                encoder.put_str(35, "D");
+                encoder.put_data(95, tag, value);
+                assert_frame_or_rejection(&mut encoder, tag, value);
+            }
+        }
+    }
+
+    /// Asserts that `encoder` either refuses, or yields a frame the decoder
+    /// accepts. Used by the property test above.
+    #[track_caller]
+    fn assert_frame_or_rejection(encoder: &mut Encoder, tag: u32, value: &[u8]) {
+        let Ok(frame) = encoder.finish() else {
+            return;
+        };
+        let frame = frame.to_vec();
+        if let Err(err) = Decoder::new(&frame).decode() {
+            panic!(
+                "tag {tag} value {value:?} produced a frame the decoder rejects \
+                 ({err}): {:?}",
+                String::from_utf8_lossy(&frame)
+            );
+        }
+    }
+
+    #[test]
+    fn test_encoder_default_uses_fix44() {
+        let mut encoder = Encoder::default();
+        encoder.put_str(35, "0");
+        let frame = frame_of(&mut encoder);
+        assert!(frame.starts_with(b"8=FIX.4.4\x01"));
+    }
+
+    #[test]
+    fn test_encoder_with_capacity_encodes_without_growing_the_buffer() {
+        let mut encoder = Encoder::with_capacity("FIX.4.4", 512);
+        encoder.put_str(35, "D");
+        encoder.put_raw(58, &vec![b'x'; 400]);
+        let frame = frame_of(&mut encoder);
+        assert!(Decoder::new(&frame).decode().is_ok());
     }
 }

--- a/ironfix-tagvalue/src/encoder.rs
+++ b/ironfix-tagvalue/src/encoder.rs
@@ -314,7 +314,7 @@ impl Encoder {
     /// # Arguments
     /// * `length_tag` - The `LENGTH` field tag (e.g., 95 `RawDataLength`)
     /// * `data_tag` - The paired `DATA` field tag (e.g., 96 `RawData`)
-    /// * `value` - The raw payload, which may be empty
+    /// * `value` - The raw payload; at least one byte
     #[inline]
     pub fn put_data(&mut self, length_tag: u32, data_tag: u32, value: &[u8]) {
         if let Err(err) = self.try_put_data(length_tag, data_tag, value) {
@@ -329,15 +329,17 @@ impl Encoder {
     /// # Arguments
     /// * `length_tag` - The `LENGTH` field tag (e.g., 95 `RawDataLength`)
     /// * `data_tag` - The paired `DATA` field tag (e.g., 96 `RawData`)
-    /// * `value` - The raw payload, which may be empty
+    /// * `value` - The raw payload; at least one byte
     ///
     /// # Errors
     /// [`EncodeError::InvalidFieldValue`] if either tag is `0`, if `data_tag`
     /// is not the `DATA` field the FIX specification pairs with `length_tag`,
-    /// or if the frame is already finished. An unpaired combination is refused
-    /// because a decoder frames a `DATA` value by the count in *its own* paired
-    /// `LENGTH` field: under any other tag the payload's SOH bytes are read as
-    /// field terminators.
+    /// if `value` is empty, or if the frame is already finished. An unpaired
+    /// combination is refused because a decoder frames a `DATA` value by the
+    /// count in *its own* paired `LENGTH` field: under any other tag the
+    /// payload's SOH bytes are read as field terminators. An empty payload is
+    /// refused for the same reason an ordinary empty value is — FIX treats a
+    /// tag specified without a value as malformed.
     pub fn try_put_data(
         &mut self,
         length_tag: u32,
@@ -349,6 +351,9 @@ impl Encoder {
         check_tag(data_tag)?;
         if paired_data_tag(length_tag) != Some(data_tag) {
             return Err(unpaired_data_tag(length_tag, data_tag));
+        }
+        if value.is_empty() {
+            return Err(empty_value(data_tag));
         }
 
         let mut len_buf = itoa::Buffer::new();
@@ -1202,19 +1207,30 @@ mod tests {
     }
 
     #[test]
-    fn test_encoder_put_data_empty_payload_round_trips() {
+    fn test_encoder_put_data_empty_payload_is_rejected() {
+        // `96=<SOH>` (empty-valued DATA) is malformed FIX and inconsistent with
+        // the encoder rejecting an empty ordinary value; the rejection names the
+        // DATA tag, as an empty ordinary value names its own tag.
         let mut encoder = Encoder::new("FIX.4.4");
         encoder.put_str(35, "A");
         encoder.put_data(95, 96, b"");
-        encoder.put_str(58, "after");
-        let frame = frame_of(&mut encoder);
+        assert_rejected(&mut encoder, 96);
+    }
 
-        let Ok(decoded) = Decoder::new(&frame).decode() else {
-            panic!("frame with an empty RawData must decode");
-        };
-        assert_eq!(decoded.get_field(95).map(|f| f.value), Some(&b"0"[..]));
-        assert_eq!(decoded.get_field(96).map(|f| f.value), Some(&b""[..]));
-        assert_eq!(decoded.get_field_str(58), Some("after"));
+    #[test]
+    fn test_encoder_try_put_data_empty_payload_reports_immediately() {
+        let mut encoder = Encoder::new("FIX.4.4");
+        encoder.put_str(35, "A");
+        let before = encoder.body_len();
+
+        let result = encoder.try_put_data(95, 96, b"");
+        assert!(matches!(
+            result,
+            Err(EncodeError::InvalidFieldValue { tag: 96, .. })
+        ));
+        // Nothing written, and the caller took delivery of the rejection.
+        assert_eq!(encoder.body_len(), before);
+        assert!(encoder.error().is_none());
     }
 
     #[test]

--- a/ironfix-tagvalue/src/lib.rs
+++ b/ironfix-tagvalue/src/lib.rs
@@ -26,15 +26,29 @@
 //!   targets.
 //! - **Checksum**: [`calculate_checksum`] plus formatting and parsing of the
 //!   tag 10 trailer.
+//! - **Single-buffer encoding**: [`Encoder`] reserves room for the header and
+//!   back-fills it, so a frame is assembled without an intermediate buffer or a
+//!   copy of the body, and [`Encoder::clear`] retains the capacity for the next
+//!   message.
 //!
-//! ## Untrusted input
+//! ## Both directions are hostile-input boundaries
 //!
-//! Every entry point here is an untrusted-input parser. Truncated messages, a
-//! bogus `BodyLength` (tag 9), a bad or malformed `CheckSum` (tag 10), a
-//! non-numeric tag, and an out-of-range declared length each map to a typed
-//! `DecodeError` — never a panic and never an attacker-controlled allocation.
-//! A genuinely incomplete buffer is reported distinctly from malformed input,
-//! so a caller framing a stream can tell "read more" from "reject this".
+//! Every entry point here is an untrusted-input parser. [`Decoder`] treats
+//! every byte as attacker-controlled: truncated messages, a `BodyLength` (tag
+//! 9) that disagrees with the bytes, a bad or malformed `CheckSum` (tag 10), a
+//! non-numeric tag, and a `DATA` field whose declared count reaches past the
+//! body each map to a typed [`ironfix_core::error::DecodeError`] — never a
+//! panic and never an attacker-controlled allocation. A genuinely incomplete
+//! buffer is reported distinctly from malformed input, so a caller framing a
+//! stream can tell "read more" from "reject this".
+//!
+//! [`Encoder`] holds the mirror invariant: **every frame it produces is one
+//! this crate's [`Decoder`] accepts**. A value carrying the SOH delimiter, an
+//! empty value, a framing tag written into the body, a `MsgType` (tag 35) that
+//! is missing, not first, or unrepresentable, and half of a `LENGTH`/`DATA`
+//! pair written alone are all refused with a typed
+//! [`ironfix_core::error::EncodeError`] rather than stamped into a frame whose
+//! `BodyLength` and `CheckSum` are correct for corrupted bytes.
 //!
 //! No performance figure is quoted here, and none should be: the criterion
 //! harness under `benches/` records no baseline, so nothing here has been
@@ -43,6 +57,16 @@
 pub mod checksum;
 pub mod decoder;
 pub mod encoder;
+
+/// SOH (Start of Header), the byte that terminates every FIX field.
+///
+/// Defined once here and re-exported from [`decoder`] and [`encoder`], which
+/// both need it: two independent definitions of one protocol byte are two
+/// semver-governed paths that can drift.
+pub const SOH: u8 = 0x01;
+
+/// The `=` byte that separates a tag from its value.
+pub const EQUALS: u8 = b'=';
 
 pub use checksum::calculate_checksum;
 pub use decoder::Decoder;


### PR DESCRIPTION
## Summary

Closes the encode-side counterpart of the injection defect already fixed on the decode side, and removes the per-message allocations from `finish`.

Closes #12.

## Stack

- **Base branch:** `stack/28-version-hoist` (PR #34)
- **Stack:** #25 → #30 → #31 → #32 → #34 → **#12 (this PR)**

## The invariant

**Every frame `Encoder::finish` yields is one this crate's `Decoder` accepts.** That is now a property test rather than a claim: 12 tags (including 0, 8, 9, 10, 35, 95, 96, `u32::MAX`) against 12 hostile values (empty, embedded SOH, bare `=`, `10=999`, `\x0110=000\x01`, invalid UTF-8, NUL, an over-long MsgType) in three positions each. For all 432 combinations `finish` must either refuse or produce a frame that decodes with checksum validation **on**. There is no third outcome.

Chasing that invariant found a hole the issue did not list: **tag 35 content was unvalidated**, so an over-long or non-printable MsgType produced a frame the decoder rejects. The encoder now runs tag 35 through core's `MsgType` rather than restating the rule somewhere the two could drift.

## What was wrong

**The encoder emitted corruptible frames.** An application value containing SOH or `=` was written raw, injecting fields into its own message — the exact mirror of the decoder-side injection closed in #23.

**But a blanket byte rejection would break legal messages.** FIX `DATA` fields (`RawData`/96, `Signature`/89, the `Encoded*` family) legally contain SOH and `=`. `put_data` writes the `LENGTH` and `DATA` halves as one operation, deriving the declared count from the payload so the two cannot disagree, and refuses a pair the decoder does not count-frame — under such a tag the payload's SOH bytes would become field terminators. Writing either half alone through `put_raw` is refused for the same reason.

**`finish` allocated and copied per message.** It built a header buffer, then a whole-frame buffer, and copied both into it. The buffer now opens with a reserved prefix sized to the worst-case header; the body is written after it; `finish` formats the header right-aligned into that prefix so its closing SOH abuts the body. The frame is contiguous, the body never moves, and a reused encoder allocates and copies nothing.

**No performance claim is made.** There is no benchmark harness on this branch (one is added by #35), so the change is described structurally — allocations and copies removed — and no number appears anywhere.

**BodyLength parsing was lenient**, accepting `+8`, ` 8`, `0x8` and an over-long value. It now uses the same strict digit fold as every other length in the crate.

## Public API changes (semver)

Breaking: `Encoder::finish(self) -> BytesMut` becomes `finish(&mut self) -> Result<&[u8], EncodeError>`. `MessageFactory`'s builders become fallible in the engine. New: `put_data` / `try_put_data`, `try_put_raw`, `finish_into`, `error()`. `EngineError` gains `Encode`.

`put_*` stays infallible by design: a fallible setter whose `Result` a caller drops would silently omit the field and produce a well-formed frame **missing data** — the harder failure to notice. The first rejection is recorded and returned by `finish`, which then yields no bytes; `try_put_*` is available where reporting at the write site is wanted.

## Behaviour changes worth a reviewer's attention

- **An application value with no legal wire form now tears the session down** rather than emitting a corrupt frame. Fail-closed was the deliberate call: the sequence number is already spent by the time encoding fails, so continuing would leave a gap. Validating `OutboundMessage` *before* allocating the sequence number would be better, and is engine-side work that belongs with #11.
- **A peer sending `112=` with no value** was previously echoed back verbatim; an empty field now has no wire form, so the Heartbeat is sent without TestReqID rather than dropping the session. The spec-strict answer is a session Reject (reason 4, "tag specified without a value"), which is **not** implemented here.

## Not done

`MessageFactory` still builds a fresh `Encoder` per message and copies the finished frame into an owned buffer — two allocations and one copy per outbound message, down from three and two, but not zero. Making it reusable needs `&mut self` or interior mutability in the reactor, which belongs with the engine work in #11.

## Tests

Workspace goes to **407 passing**, in both debug and release. The encoder goes from 5 tests to 33, the decoder from 37 to 48, each new rejection path with its own test — and the round-trip assertions are checked non-vacuous by flipping a byte and requiring `ChecksumMismatch`.

## Verification

```
cargo test --workspace            # 407 passed
cargo test --workspace --release  # 407 passed
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --all --check
cargo build --release --workspace --examples
make doc
```
