### PR TITLE
fix(session): stop the heartbeat logic from killing live sessions

### DIFF
--- a/doc/fix_operations.md
+++ b/doc/fix_operations.md
@@ -68,9 +68,15 @@ and stops at the first failure:
    runs and before sequence state moves, so a cross-wired connection can never
    establish a session.
 3. **`from_admin`.** A rejection sends a Logout and fails the handshake.
-4. **`HeartBtInt` (108).** The interval confirmed by the counterparty wins,
-   within a bound. Because the value is counterparty-controlled and drives
-   every liveness timer in the session, a confirmed interval above
+4. **`HeartBtInt` (108).** 108 is a *required* field of the Logon, so an ack
+   that omits it (session Reject, reason 1 — required tag missing) or carries a
+   non-numeric value (session Reject, reason 6 — incorrect data format for
+   value), `RefTagID` = 108 in both cases and each followed by a Logout, fails
+   the handshake with `EngineError::HeartbeatInterval` rather than silently
+   establishing the session on the locally configured interval. When present and
+   numeric the interval confirmed by the counterparty wins, within a bound.
+   Because the value is counterparty-controlled and drives every liveness timer
+   in the session, a confirmed interval above
    `ironfix_session::heartbeat::MAX_HEARTBEAT_INTERVAL_SECS` (3600 s) is
    refused with a session Reject, reason 5 (value is incorrect),
    `RefTagID` = 108, followed by a Logout; the handshake then fails with
@@ -915,13 +921,15 @@ Rationale for the two policies:
 ### Phase 1: Core Session Layer (Required)
 - [x] Logon / Logout
 - [x] Heartbeat / Test Request — the interval is negotiated (bounded, since it
-  is counterparty-controlled), `HeartBtInt = 0` disables heartbeating as FIX
-  intends, heartbeats and TestRequests fire at the interval plus a derived
-  grace, and the silent-peer timeout stops the moment any accepted inbound
-  message arrives. See "Heartbeat" and "Test Request" above for the negotiation
-  bound, the grace rule, and the definition of "a response". Note this covers
-  the **initiator** only: there is no Acceptor in `ironfix-engine`, so the
-  server-side examples do their own heartbeating.
+  is counterparty-controlled), a Logon ack that omits the required `HeartBtInt`
+  (108) or carries a non-numeric value fails the handshake rather than
+  establishing a session on the local interval, `HeartBtInt = 0` disables
+  heartbeating as FIX intends, heartbeats and TestRequests fire at the interval
+  plus a derived grace, and the silent-peer timeout stops the moment any
+  accepted inbound message arrives. See "Heartbeat" and "Test Request" above for
+  the negotiation bound, the grace rule, and the definition of "a response".
+  Note this covers the **initiator** only: there is no Acceptor in
+  `ironfix-engine`, so the server-side examples do their own heartbeating.
 - [x] Reject
 - [x] Sequence Reset
 - [ ] Resend Request — **partial**: inbound requests are validated and answered

--- a/doc/fix_operations.md
+++ b/doc/fix_operations.md
@@ -68,10 +68,18 @@ and stops at the first failure:
    runs and before sequence state moves, so a cross-wired connection can never
    establish a session.
 3. **`from_admin`.** A rejection sends a Logout and fails the handshake.
-4. **`HeartBtInt` (108).** The interval confirmed by the counterparty wins.
-   Note the counterparty therefore controls this value, and `108=0` — legal
-   FIX for "do not send heartbeats" — is not handled correctly today; see the
-   Phase 1 checklist entry for Heartbeat / Test Request.
+4. **`HeartBtInt` (108).** The interval confirmed by the counterparty wins,
+   within a bound. Because the value is counterparty-controlled and drives
+   every liveness timer in the session, a confirmed interval above
+   `ironfix_session::heartbeat::MAX_HEARTBEAT_INTERVAL_SECS` (3600 s) is
+   refused with a session Reject, reason 5 (value is incorrect),
+   `RefTagID` = 108, followed by a Logout; the handshake then fails with
+   `EngineError::HeartbeatInterval`. Adopting an unbounded value would let a
+   peer switch dead-peer detection off for as long as it liked. The one
+   exception is a confirmed value that is *exactly* the interval this side
+   requested: echoing our own configuration back is our choice, not the
+   counterparty pushing us past the ceiling. `108=0` is legal and always
+   accepted; see "Heartbeat" below for what it means.
 5. **`ResetSeqNumFlag` (141).** `141=Y` on the ack must arrive under
    `MsgSeqNum = 1` — the reset and the number carrying it have to describe the
    same stream — and a peer that sends any other number fails the handshake
@@ -151,6 +159,29 @@ Outbound `ResetSeqNumFlag` is driven by `SessionConfig::reset_on_logon`.
 2. When responding to TestRequest, include TestReqID (tag 112)
 3. Monitor for missing heartbeats from counterparty
 
+**What IronFix implements today**
+
+`ironfix-session::HeartbeatManager` owns the timing; `ironfix-engine`'s
+reactor polls it on a 100 ms tick.
+
+- **`HeartBtInt` = 0 means no heartbeating.** Zero is a legal negotiated
+  interval and disables the mechanism outright: no Heartbeat is emitted, no
+  TestRequest is sent, and the session is never timed out for silence.
+  `should_send_heartbeat`, `should_send_test_request` and `is_timed_out` all
+  return `false` for the life of such a session. It is *not* treated as a
+  zero-length interval. Note the consequence the FIX spec implies: with
+  `108=0` there is no heartbeat-driven liveness check at all, so a dead peer is
+  only noticed when TCP notices.
+- **Heartbeat due.** One interval with nothing sent. Any outbound message
+  resets the timer, so a busy session emits no Heartbeats.
+- **TestRequest due.** One interval plus a transmission grace with nothing
+  received, and no TestRequest already outstanding.
+- **Transmission grace.** Derived from the interval, not configured:
+  `HeartBtInt / 5` (the 20% the QuickFIX family uses), floored at 250 ms. The
+  floor exists because the proportional allowance collapses into scheduling
+  noise for sub-second intervals. It is readable as
+  `HeartbeatManager::test_request_grace()`.
+
 ---
 
 ### Test Request (MsgType = 1)
@@ -173,6 +204,41 @@ Outbound `ResetSeqNumFlag` is driven by `SessionConfig::reset_on_logon`.
 1. Send TestRequest if no message received within HeartBtInt + tolerance
 2. Expect Heartbeat response with matching TestReqID
 3. If no response, consider session disconnected
+
+**What IronFix implements today — what counts as "a response"**
+
+Item 3 above is the only guidance the FIX session spec gives, and it does not
+define what a response is. IronFix defines it explicitly, because the choice is
+the difference between disconnecting a dead peer and disconnecting a live one:
+
+> **Any inbound message the session accepts stops the timeout countdown.** A
+> Heartbeat echoing the outstanding `TestReqID` (112) is the positive
+> confirmation; anything else — an ExecutionReport, a Heartbeat without tag
+> 112, a Heartbeat with the wrong ID — clears the pending TestRequest as
+> *superseded by traffic*.
+
+"Accepted" means the frame decoded, carried a `MsgSeqNum` (34), and passed the
+CompID identity check; foreign traffic never touches the heartbeat clock. A
+sequence gap does *not* disqualify a message here: a gapped frame is still
+proof the peer is transmitting.
+
+Rationale. A peer that is sending us messages is alive, whatever it did with
+our `TestReqID`, and the FIX liveness question is about the connection, not
+about protocol pedantry. Real venues answer a TestRequest with a Heartbeat that
+omits tag 112, or let that Heartbeat be reordered behind a burst of application
+traffic; keying the timeout on the echo alone tears down demonstrably healthy
+sessions. This is also what the QuickFIX family does — it resets its
+test-request counter on any successfully verified inbound message.
+
+Consequence, stated plainly: a peer that streams traffic but never answers a
+TestRequest is never disconnected by this engine. That is deliberate. The
+timeout exists to detect a peer that has stopped talking, and such a peer is
+still talking. The engine distinguishes the two cases in its logs
+(`ironfix_session::TestRequestOutcome`), so a counterparty that never echoes
+`TestReqID` is observable without being disconnected.
+
+The countdown itself is: `is_timed_out()` is true only when a TestRequest was
+sent and **nothing at all** arrived in the interval that followed.
 
 ---
 
@@ -848,15 +914,14 @@ Rationale for the two policies:
 
 ### Phase 1: Core Session Layer (Required)
 - [x] Logon / Logout
-- [ ] Heartbeat / Test Request — **partial**: the interval is negotiated and
-  heartbeats, TestRequests and the silent-peer timeout all work at the
-  configured interval, but two cases in `ironfix-session::HeartbeatManager` are
-  wrong. `HeartBtInt = 0` (legal FIX, meaning "do not send heartbeats") is
-  taken literally as a zero-length interval, so the session floods the peer and
-  then times itself out; and a pending TestRequest is cleared only by a
-  Heartbeat echoing the matching `TestReqID`, so a peer that answers without
-  tag 112 — or whose Heartbeat is reordered behind application traffic — is
-  disconnected despite being demonstrably alive.
+- [x] Heartbeat / Test Request — the interval is negotiated (bounded, since it
+  is counterparty-controlled), `HeartBtInt = 0` disables heartbeating as FIX
+  intends, heartbeats and TestRequests fire at the interval plus a derived
+  grace, and the silent-peer timeout stops the moment any accepted inbound
+  message arrives. See "Heartbeat" and "Test Request" above for the negotiation
+  bound, the grace rule, and the definition of "a response". Note this covers
+  the **initiator** only: there is no Acceptor in `ironfix-engine`, so the
+  server-side examples do their own heartbeating.
 - [x] Reject
 - [x] Sequence Reset
 - [ ] Resend Request — **partial**: inbound requests are validated and answered

--- a/ironfix-engine/src/error.rs
+++ b/ironfix-engine/src/error.rs
@@ -51,6 +51,19 @@ pub enum EngineError {
         reason: String,
     },
 
+    /// The counterparty confirmed a `HeartBtInt` (108) this engine refuses to
+    /// adopt.
+    ///
+    /// The value drives every liveness timer in the session and is
+    /// counterparty-controlled, so it is bounded by
+    /// [`ironfix_session::heartbeat::MAX_HEARTBEAT_INTERVAL_SECS`]. `108=0` is
+    /// legal and never raises this — it means "do not heartbeat".
+    #[error("unsupported heartbeat interval: {detail}")]
+    HeartbeatInterval {
+        /// Why the confirmed `HeartBtInt` was refused.
+        detail: String,
+    },
+
     /// An unexpected message type arrived while awaiting the Logon
     /// acknowledgement.
     #[error("unexpected message during logon: 35={msg_type}")]

--- a/ironfix-engine/src/error.rs
+++ b/ironfix-engine/src/error.rs
@@ -51,13 +51,15 @@ pub enum EngineError {
         reason: String,
     },
 
-    /// The counterparty confirmed a `HeartBtInt` (108) this engine refuses to
-    /// adopt.
+    /// The `HeartBtInt` (108) on the Logon acknowledgement could not be adopted
+    /// as the session's heartbeat interval.
     ///
-    /// The value drives every liveness timer in the session and is
-    /// counterparty-controlled, so it is bounded by
-    /// [`ironfix_session::heartbeat::MAX_HEARTBEAT_INTERVAL_SECS`]. `108=0` is
-    /// legal and never raises this — it means "do not heartbeat".
+    /// Raised when the ack omits the required field, carries a non-numeric
+    /// value, or confirms an interval above
+    /// [`ironfix_session::heartbeat::MAX_HEARTBEAT_INTERVAL_SECS`] — the value
+    /// drives every liveness timer in the session and is counterparty
+    /// controlled, so an unbounded one is refused. `108=0` is legal and never
+    /// raises this — it means "do not heartbeat".
     #[error("unsupported heartbeat interval: {detail}")]
     HeartbeatInterval {
         /// Why the confirmed `HeartBtInt` was refused.

--- a/ironfix-engine/src/initiator.rs
+++ b/ironfix-engine/src/initiator.rs
@@ -25,6 +25,22 @@
 //! heartbeat clock deliberately — traffic from the wrong counterparty must not
 //! keep the session alive, reach the [`Application`], or move sequence state.
 //!
+//! # Heartbeats
+//!
+//! The `HeartBtInt` (108) confirmed on the Logon ack wins, but it is
+//! counterparty-controlled and drives every liveness timer, so it is bounded
+//! by [`ironfix_session::heartbeat::negotiate_interval`]: a confirmed interval
+//! above [`ironfix_session::heartbeat::MAX_HEARTBEAT_INTERVAL_SECS`] that is
+//! not simply an echo of what this side requested fails the handshake with a
+//! Reject (reason 5, `RefTagID` 108) and a Logout. `108=0` is legal and means
+//! "do not heartbeat": the reactor then emits no Heartbeat, sends no
+//! TestRequest, and never times the session out.
+//!
+//! Once a TestRequest is outstanding, **any** inbound frame the session
+//! accepts stops the timeout countdown; a Heartbeat echoing the `TestReqID` is
+//! the positive confirmation. See the `ironfix_session::heartbeat` module
+//! documentation for why the rule is that broad.
+//!
 //! Sequence recovery follows `doc/fix_operations.md`: a `SequenceReset` with
 //! `GapFillFlag` (123) = Y is an ordinary sequenced message and is validated
 //! against its own `MsgSeqNum`, while Reset mode alone may ignore it; an
@@ -76,10 +92,11 @@ use futures_util::{SinkExt, StreamExt};
 use ironfix_core::error::EncodeError;
 use ironfix_core::message::{MsgType, RawMessage};
 use ironfix_core::version::FixVersion;
-use ironfix_session::heartbeat::generate_test_req_id;
+use ironfix_session::heartbeat::{generate_test_req_id, negotiate_interval};
 use ironfix_session::sequence::{SequenceExhausted, SequenceResult};
 use ironfix_session::{
     Active, Disconnected, HeartbeatManager, LogoutPending, SequenceManager, Session, SessionConfig,
+    TestRequestOutcome,
 };
 use ironfix_transport::FixCodec;
 use std::sync::{Arc, Mutex};
@@ -396,19 +413,50 @@ impl<A: Application + 'static> Initiator<A> {
                 });
             }
 
-            // Honor the heartbeat interval confirmed by the counterparty.
+            // Honor the heartbeat interval confirmed by the counterparty, but
+            // only within the bound `negotiate_interval` enforces: 108 is
+            // counterparty-controlled and drives every liveness timer in the
+            // session. Resolved before the lock is taken, because refusing it
+            // has to send a Reject and a Logout.
+            let mut negotiated = None;
+            if let Some(secs) = raw.get_field_str(108).and_then(|s| s.parse::<u64>().ok()) {
+                match negotiate_interval(self.config.heartbeat_interval, secs) {
+                    Ok(interval) => negotiated = Some(interval),
+                    Err(err) => {
+                        let detail = err.to_string();
+                        let reason = RejectReason::new(5, detail.clone()).with_ref_tag(108);
+                        if let Ok(out_seq) = runtime.sequences.try_allocate_sender_seq()
+                            && let Ok(reject) = factory.session_reject(
+                                out_seq.value(),
+                                ack_seq,
+                                MsgType::Logon.as_str(),
+                                &reason,
+                            )
+                        {
+                            let _ = framed.send(reject).await;
+                        }
+                        if let Ok(out_seq) = runtime.sequences.try_allocate_sender_seq()
+                            && let Ok(logout) = factory.logout(out_seq.value(), Some(&detail))
+                        {
+                            let _ = framed.send(logout).await;
+                        }
+                        let _ = session.on_logon_reject();
+                        return Err(EngineError::HeartbeatInterval { detail });
+                    }
+                }
+            }
             {
                 let mut heartbeat = lock_heartbeat(&runtime);
                 heartbeat.on_message_received(false, None);
-                if let Some(secs) = raw.get_field_str(108).and_then(|s| s.parse::<u64>().ok())
-                    && Duration::from_secs(secs) != heartbeat.interval()
+                if let Some(interval) = negotiated
+                    && interval != heartbeat.interval()
                 {
                     tracing::info!(
                         session = %session_id,
-                        heartbeat_secs = secs,
+                        heartbeat_secs = interval.as_secs(),
                         "using heartbeat interval confirmed by counterparty"
                     );
-                    *heartbeat = HeartbeatManager::new(Duration::from_secs(secs));
+                    *heartbeat = HeartbeatManager::new(interval);
                 }
             }
 
@@ -1184,10 +1232,23 @@ impl<A: Application> Reactor<A> {
         // The frame is well-formed, sequenced, and from the configured
         // counterparty: it proves the peer is alive. A sequence gap is a
         // recoverable condition, not evidence of a dead peer, so gapped
-        // frames still count here.
+        // frames still count here — and so does any frame arriving while a
+        // TestRequest is outstanding, which is what stops the countdown.
         let test_req_id = raw.get_field_str(112);
-        lock_heartbeat(&self.runtime)
+        let outcome = lock_heartbeat(&self.runtime)
             .on_message_received(msg_type == MsgType::Heartbeat, test_req_id);
+        match outcome {
+            TestRequestOutcome::Confirmed => tracing::debug!(
+                session = %self.session_id,
+                "TestRequest answered by Heartbeat with matching TestReqID"
+            ),
+            TestRequestOutcome::SupersededByTraffic => tracing::debug!(
+                session = %self.session_id,
+                msg_type = %msg_type,
+                "pending TestRequest cleared by inbound traffic"
+            ),
+            TestRequestOutcome::NonePending => {}
+        }
 
         if msg_type == MsgType::SequenceReset {
             return self.on_sequence_reset(framed, phase, &raw, seq).await;

--- a/ironfix-engine/src/initiator.rs
+++ b/ironfix-engine/src/initiator.rs
@@ -89,7 +89,7 @@ use crate::error::EngineError;
 use crate::wire::{self, MessageFactory, PeerIdentity, UnsupportedVersion};
 use bytes::BytesMut;
 use futures_util::{SinkExt, StreamExt};
-use ironfix_core::error::EncodeError;
+use ironfix_core::error::{DecodeError, EncodeError};
 use ironfix_core::message::{MsgType, RawMessage};
 use ironfix_core::version::FixVersion;
 use ironfix_session::heartbeat::{generate_test_req_id, negotiate_interval};
@@ -418,45 +418,82 @@ impl<A: Application + 'static> Initiator<A> {
             // counterparty-controlled and drives every liveness timer in the
             // session. Resolved before the lock is taken, because refusing it
             // has to send a Reject and a Logout.
-            let mut negotiated = None;
-            if let Some(secs) = raw.get_field_str(108).and_then(|s| s.parse::<u64>().ok()) {
-                match negotiate_interval(self.config.heartbeat_interval, secs) {
-                    Ok(interval) => negotiated = Some(interval),
-                    Err(err) => {
-                        let detail = err.to_string();
-                        let reason = RejectReason::new(5, detail.clone()).with_ref_tag(108);
-                        if let Ok(out_seq) = runtime.sequences.try_allocate_sender_seq()
-                            && let Ok(reject) = factory.session_reject(
-                                out_seq.value(),
-                                ack_seq,
-                                MsgType::Logon.as_str(),
-                                &reason,
-                            )
-                        {
-                            let _ = framed.send(reject).await;
-                        }
-                        if let Ok(out_seq) = runtime.sequences.try_allocate_sender_seq()
-                            && let Ok(logout) = factory.logout(out_seq.value(), Some(&detail))
-                        {
-                            let _ = framed.send(logout).await;
-                        }
-                        let _ = session.on_logon_reject();
-                        return Err(EngineError::HeartbeatInterval { detail });
+            //
+            // HeartBtInt (108) is a *required* field of the Logon
+            // (`doc/fix_operations.md`, "Logon"). An ack that omits it or
+            // carries a non-numeric value gives the two sides nothing to agree
+            // liveness timing on, so the handshake fails rather than silently
+            // establishing the session on the locally configured interval.
+            let secs: u64 = match raw.get_field_as::<u64>(108) {
+                Ok(secs) => secs,
+                Err(err) => {
+                    // SessionRejectReason 1 (Required tag missing) for an
+                    // absent 108, 6 (Incorrect data format for value) for a
+                    // present-but-unparseable one.
+                    let (code, detail) = if matches!(err, DecodeError::MissingRequiredField { .. })
+                    {
+                        (
+                            1,
+                            "Logon acknowledgement omitted the required HeartBtInt (108)"
+                                .to_string(),
+                        )
+                    } else {
+                        (6, err.to_string())
+                    };
+                    let reason = RejectReason::new(code, detail.clone()).with_ref_tag(108);
+                    if let Ok(out_seq) = runtime.sequences.try_allocate_sender_seq()
+                        && let Ok(reject) = factory.session_reject(
+                            out_seq.value(),
+                            ack_seq,
+                            MsgType::Logon.as_str(),
+                            &reason,
+                        )
+                    {
+                        let _ = framed.send(reject).await;
                     }
+                    if let Ok(out_seq) = runtime.sequences.try_allocate_sender_seq()
+                        && let Ok(logout) = factory.logout(out_seq.value(), Some(&detail))
+                    {
+                        let _ = framed.send(logout).await;
+                    }
+                    let _ = session.on_logon_reject();
+                    return Err(EngineError::HeartbeatInterval { detail });
                 }
-            }
+            };
+            let negotiated = match negotiate_interval(self.config.heartbeat_interval, secs) {
+                Ok(interval) => interval,
+                Err(err) => {
+                    let detail = err.to_string();
+                    let reason = RejectReason::new(5, detail.clone()).with_ref_tag(108);
+                    if let Ok(out_seq) = runtime.sequences.try_allocate_sender_seq()
+                        && let Ok(reject) = factory.session_reject(
+                            out_seq.value(),
+                            ack_seq,
+                            MsgType::Logon.as_str(),
+                            &reason,
+                        )
+                    {
+                        let _ = framed.send(reject).await;
+                    }
+                    if let Ok(out_seq) = runtime.sequences.try_allocate_sender_seq()
+                        && let Ok(logout) = factory.logout(out_seq.value(), Some(&detail))
+                    {
+                        let _ = framed.send(logout).await;
+                    }
+                    let _ = session.on_logon_reject();
+                    return Err(EngineError::HeartbeatInterval { detail });
+                }
+            };
             {
                 let mut heartbeat = lock_heartbeat(&runtime);
                 heartbeat.on_message_received(false, None);
-                if let Some(interval) = negotiated
-                    && interval != heartbeat.interval()
-                {
+                if negotiated != heartbeat.interval() {
                     tracing::info!(
                         session = %session_id,
-                        heartbeat_secs = interval.as_secs(),
+                        heartbeat_secs = negotiated.as_secs(),
                         "using heartbeat interval confirmed by counterparty"
                     );
-                    *heartbeat = HeartbeatManager::new(interval);
+                    *heartbeat = HeartbeatManager::new(negotiated);
                 }
             }
 

--- a/ironfix-engine/tests/initiator_tests.rs
+++ b/ironfix-engine/tests/initiator_tests.rs
@@ -757,6 +757,179 @@ async fn test_heartbeat_timeout_closes_session() {
     );
 }
 
+/// A counterparty that answers a TestRequest with application traffic instead
+/// of a Heartbeat keeps the session alive: any accepted inbound frame stops
+/// the timeout countdown.
+///
+/// This is the regression that was reproduced against a live session — six
+/// in-sequence ExecutionReports were delivered to the application and the
+/// session was then torn down as timed out.
+#[tokio::test]
+async fn test_test_request_answered_with_app_traffic_keeps_session_alive() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_framed(listener).await;
+        let _logon = next_frame(&mut framed).await;
+        ok(
+            framed
+                .send(venue_msg("A", 1, &[(98, "0"), (108, "1")]))
+                .await,
+            "send logon ack",
+        );
+
+        // Stay silent until the client probes us.
+        loop {
+            let frame = next_frame(&mut framed).await;
+            if msg_type_of(&frame) == "1" {
+                break;
+            }
+        }
+
+        // Answer with application traffic only: valid, in sequence, and never
+        // a Heartbeat echoing the TestReqID. Eight reports at 200ms span
+        // 1.6s, comfortably past the 1s interval the old timeout used.
+        for seq in 2..10u64 {
+            ok(
+                framed
+                    .send(venue_msg(
+                        "8",
+                        seq,
+                        &[
+                            (37, "ORDER-1"),
+                            (17, "EXEC-1"),
+                            (150, "0"),
+                            (39, "0"),
+                            (55, "AAPL"),
+                        ],
+                    ))
+                    .await,
+                "send execution report",
+            );
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+    });
+
+    let (app, mut app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(1)), Arc::clone(&app));
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(20), acceptor).await,
+            "acceptor done within 20s",
+        ),
+        "acceptor task",
+    );
+
+    for _ in 0..8 {
+        let received = ok(
+            timeout(Duration::from_secs(5), app_rx.recv()).await,
+            "execution report must reach the application",
+        );
+        assert_eq!(some(received, "app channel must stay open"), "8");
+    }
+
+    assert!(
+        !connection.is_timed_out(),
+        "inbound traffic after the TestRequest must clear the pending probe"
+    );
+    assert!(
+        !connection.is_closed(),
+        "a demonstrably live session must not be torn down"
+    );
+}
+
+/// HeartBtInt = 0 on the Logon ack disables heartbeating: no Heartbeat, no
+/// TestRequest, and no self-inflicted timeout.
+#[tokio::test]
+async fn test_zero_heartbeat_interval_disables_heartbeating() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_framed(listener).await;
+        let _logon = next_frame(&mut framed).await;
+        ok(
+            framed
+                .send(venue_msg("A", 1, &[(98, "0"), (108, "0")]))
+                .await,
+            "send logon ack with HeartBtInt=0",
+        );
+
+        // The client requested a 1s interval, so without the fix this window
+        // carries two Heartbeats at least — in practice one per 100ms tick.
+        match timeout(Duration::from_secs(2), framed.next()).await {
+            Err(_) => {}
+            Ok(Some(Ok(frame))) => panic!(
+                "HeartBtInt=0 must silence the session, got 35={}",
+                msg_type_of(&frame)
+            ),
+            Ok(Some(Err(err))) => panic!("codec error while expecting silence: {err:?}"),
+            Ok(None) => panic!("session closed itself with HeartBtInt=0"),
+        }
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(1)), Arc::clone(&app));
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(10), acceptor).await,
+            "acceptor done within 10s",
+        ),
+        "acceptor task",
+    );
+
+    assert!(!connection.is_timed_out());
+    assert!(!connection.is_closed());
+}
+
+/// A counterparty HeartBtInt above the supported ceiling is refused with a
+/// Reject (reason 5, RefTagID 108) and a Logout, and fails the handshake
+/// rather than disabling dead-peer detection.
+#[tokio::test]
+async fn test_out_of_range_heartbeat_interval_fails_handshake() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_framed(listener).await;
+        let _logon = next_frame(&mut framed).await;
+        ok(
+            framed
+                .send(venue_msg("A", 1, &[(98, "0"), (108, "99999")]))
+                .await,
+            "send logon ack with an out-of-range HeartBtInt",
+        );
+
+        let reject = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&reject), "3");
+        assert_eq!(field(&reject, 373).as_deref(), Some("5"));
+        assert_eq!(field(&reject, 371).as_deref(), Some("108"));
+
+        let logout = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&logout), "5");
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+
+    match initiator.connect(addr).await {
+        Err(EngineError::HeartbeatInterval { detail }) => {
+            assert!(detail.contains("99999"), "got {detail}");
+        }
+        other => panic!("expected HeartbeatInterval, got {other:?}"),
+    }
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+}
+
 /// A sequence gap triggers a ResendRequest and the gapped app message is not
 /// delivered to the application.
 #[tokio::test]

--- a/ironfix-engine/tests/initiator_tests.rs
+++ b/ironfix-engine/tests/initiator_tests.rs
@@ -940,6 +940,59 @@ async fn test_out_of_range_heartbeat_interval_fails_handshake() {
     );
 }
 
+/// A HeartBtInt (108) of `u64::MAX` parses as a valid u64, so it is not caught
+/// as malformed; `Duration::from_secs(u64::MAX)` plus the transmission grace
+/// would overflow and — under `panic = "abort"` — kill the process on the first
+/// heartbeat tick. The handshake bound refuses it before any `HeartbeatManager`
+/// is built, so a single crafted Logon field fails the handshake with a Reject
+/// (reason 5, RefTagID 108) and a Logout rather than aborting.
+#[tokio::test]
+async fn test_max_u64_heartbeat_interval_fails_handshake_without_abort() {
+    let (listener, addr) = bind_listener().await;
+    let absurd = u64::MAX.to_string();
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_framed(listener).await;
+        let _logon = next_frame(&mut framed).await;
+        ok(
+            framed
+                .send(venue_msg(
+                    "A",
+                    1,
+                    &[(98, "0"), (108, "18446744073709551615")],
+                ))
+                .await,
+            "send logon ack with a u64::MAX HeartBtInt",
+        );
+
+        let reject = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&reject), "3");
+        assert_eq!(field(&reject, 373).as_deref(), Some("5"));
+        assert_eq!(field(&reject, 371).as_deref(), Some("108"));
+
+        let logout = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&logout), "5");
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+
+    match initiator.connect(addr).await {
+        Err(EngineError::HeartbeatInterval { detail }) => {
+            assert!(detail.contains(&absurd), "got {detail}");
+        }
+        other => panic!("expected HeartbeatInterval, got {other:?}"),
+    }
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+}
+
 /// HeartBtInt (108) is a required field of the Logon. An ack that omits it is
 /// refused with a Reject (reason 1, RefTagID 108) and a Logout, and fails the
 /// handshake rather than silently establishing a session on the locally

--- a/ironfix-engine/tests/initiator_tests.rs
+++ b/ironfix-engine/tests/initiator_tests.rs
@@ -767,6 +767,10 @@ async fn test_heartbeat_timeout_closes_session() {
 #[tokio::test]
 async fn test_test_request_answered_with_app_traffic_keeps_session_alive() {
     let (listener, addr) = bind_listener().await;
+    // Keeps the acceptor's socket open until the client-side assertions have
+    // run, so `!is_closed()` below cannot race the acceptor dropping its
+    // framed socket at end of task.
+    let (done_tx, done_rx) = tokio::sync::oneshot::channel::<()>();
 
     let acceptor = tokio::spawn(async move {
         let mut framed = accept_framed(listener).await;
@@ -808,19 +812,15 @@ async fn test_test_request_answered_with_app_traffic_keeps_session_alive() {
             );
             tokio::time::sleep(Duration::from_millis(200)).await;
         }
+
+        // Hold the socket open until the test has finished asserting on the
+        // live session, then let the task end (dropping `framed`).
+        let _ = done_rx.await;
     });
 
     let (app, mut app_rx) = RecordingApp::new();
     let initiator = Initiator::new(client_config(Duration::from_secs(1)), Arc::clone(&app));
     let connection = ok(initiator.connect(addr).await, "connect");
-
-    ok(
-        ok(
-            timeout(Duration::from_secs(20), acceptor).await,
-            "acceptor done within 20s",
-        ),
-        "acceptor task",
-    );
 
     for _ in 0..8 {
         let received = ok(
@@ -837,6 +837,16 @@ async fn test_test_request_answered_with_app_traffic_keeps_session_alive() {
     assert!(
         !connection.is_closed(),
         "a demonstrably live session must not be torn down"
+    );
+
+    // Release the acceptor now that the live-session assertions have passed.
+    let _ = done_tx.send(());
+    ok(
+        ok(
+            timeout(Duration::from_secs(20), acceptor).await,
+            "acceptor done within 20s",
+        ),
+        "acceptor task",
     );
 }
 
@@ -917,6 +927,95 @@ async fn test_out_of_range_heartbeat_interval_fails_handshake() {
     match initiator.connect(addr).await {
         Err(EngineError::HeartbeatInterval { detail }) => {
             assert!(detail.contains("99999"), "got {detail}");
+        }
+        other => panic!("expected HeartbeatInterval, got {other:?}"),
+    }
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+}
+
+/// HeartBtInt (108) is a required field of the Logon. An ack that omits it is
+/// refused with a Reject (reason 1, RefTagID 108) and a Logout, and fails the
+/// handshake rather than silently establishing a session on the locally
+/// configured interval.
+#[tokio::test]
+async fn test_missing_heartbeat_interval_fails_handshake() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_framed(listener).await;
+        let _logon = next_frame(&mut framed).await;
+        ok(
+            framed.send(venue_msg("A", 1, &[(98, "0")])).await,
+            "send logon ack without HeartBtInt",
+        );
+
+        let reject = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&reject), "3");
+        assert_eq!(field(&reject, 373).as_deref(), Some("1"));
+        assert_eq!(field(&reject, 371).as_deref(), Some("108"));
+
+        let logout = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&logout), "5");
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+
+    match initiator.connect(addr).await {
+        Err(EngineError::HeartbeatInterval { detail }) => {
+            assert!(detail.contains("108"), "got {detail}");
+        }
+        other => panic!("expected HeartbeatInterval, got {other:?}"),
+    }
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+}
+
+/// A non-numeric HeartBtInt (108) on the Logon ack is refused with a Reject
+/// (reason 6, RefTagID 108) and a Logout, and fails the handshake rather than
+/// silently establishing a session on the locally configured interval.
+#[tokio::test]
+async fn test_non_numeric_heartbeat_interval_fails_handshake() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_framed(listener).await;
+        let _logon = next_frame(&mut framed).await;
+        ok(
+            framed
+                .send(venue_msg("A", 1, &[(98, "0"), (108, "abc")]))
+                .await,
+            "send logon ack with a non-numeric HeartBtInt",
+        );
+
+        let reject = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&reject), "3");
+        assert_eq!(field(&reject, 373).as_deref(), Some("6"));
+        assert_eq!(field(&reject, 371).as_deref(), Some("108"));
+
+        let logout = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&logout), "5");
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+
+    match initiator.connect(addr).await {
+        Err(EngineError::HeartbeatInterval { detail }) => {
+            assert!(detail.contains("108"), "got {detail}");
         }
         other => panic!("expected HeartbeatInterval, got {other:?}"),
     }

--- a/ironfix-example/src/lib.rs
+++ b/ironfix-example/src/lib.rs
@@ -176,8 +176,8 @@ pub mod prelude {
 
     // Session
     pub use ironfix_session::{
-        Active, Connecting, Disconnected, HeartbeatManager, LogonSent, LogoutPending, Resending,
-        SequenceManager, SessionConfig, SessionState,
+        Active, Connecting, Disconnected, HeartbeatIntervalError, HeartbeatManager, LogonSent,
+        LogoutPending, Resending, SequenceManager, SessionConfig, SessionState, TestRequestOutcome,
     };
 
     // Store

--- a/ironfix-session/src/heartbeat.rs
+++ b/ironfix-session/src/heartbeat.rs
@@ -460,16 +460,22 @@ mod tests {
         let mgr = HeartbeatManager::new(Duration::from_secs(1));
         assert_eq!(mgr.test_request_grace(), Duration::from_millis(250));
 
-        sleep(Duration::from_millis(700));
+        // The "not due" side is asserted at ~0ms elapsed rather than after a
+        // sleep: `sleep` only ever overshoots, so a scheduler stall could push a
+        // mid-interval sleep past the 1250ms boundary and fail a negative
+        // assertion even when the logic is correct. At construction no inbound
+        // silence has elapsed, so it cannot be due for any realistic stall.
         assert!(
             !mgr.should_send_test_request(),
-            "neither interval nor grace has elapsed"
+            "not due before interval plus grace elapses"
         );
 
-        sleep(Duration::from_millis(700));
+        // The "due" side is robust: sleeping past the boundary can only ever
+        // wait longer than requested, so once well past 1250ms it is due.
+        sleep(Duration::from_millis(1400));
         assert!(
             mgr.should_send_test_request(),
-            "interval plus grace has elapsed"
+            "due once interval plus grace has elapsed"
         );
     }
 

--- a/ironfix-session/src/heartbeat.rs
+++ b/ironfix-session/src/heartbeat.rs
@@ -489,6 +489,27 @@ mod tests {
         assert!(!mgr.should_send_test_request());
     }
 
+    #[test]
+    fn test_predicates_near_duration_max_do_not_panic() {
+        // Backstop for the remote-DoS root cause: a manager built with a huge
+        // interval (e.g. from a counterparty HeartBtInt of u64::MAX that slipped
+        // past the handshake bound) must not overflow the `interval + grace`
+        // arithmetic. Under `panic = "abort"` an overflow here is a process
+        // kill, so every timing predicate has to return, not panic. An
+        // unreachable interval means "effectively never": nothing is ever due
+        // and the session never times out.
+        let mut mgr = HeartbeatManager::new(Duration::MAX);
+        assert!(!mgr.should_send_heartbeat());
+        assert!(!mgr.should_send_test_request());
+        assert!(!mgr.is_timed_out());
+
+        // Reach the `is_timed_out` comparison against the near-MAX interval by
+        // leaving a TestRequest outstanding; it must compare, not overflow.
+        mgr.on_test_request_sent("TEST-NEAR-MAX".to_string());
+        assert!(!mgr.is_timed_out());
+        assert!(!mgr.should_send_test_request());
+    }
+
     // --- Timeout branches ----------------------------------------------------
 
     #[test]

--- a/ironfix-session/src/heartbeat.rs
+++ b/ironfix-session/src/heartbeat.rs
@@ -10,14 +10,139 @@
 //! - Sending heartbeats at configured intervals
 //! - Sending TestRequest when no messages received
 //! - Detecting heartbeat timeouts
+//!
+//! # `HeartBtInt` (108) = 0
+//!
+//! Zero is a legal `HeartBtInt` and means *do not heartbeat*: neither side
+//! emits Heartbeats, neither side probes with a TestRequest, and there is
+//! therefore no heartbeat-driven liveness check at all. A
+//! [`HeartbeatManager`] built with [`Duration::ZERO`] reports `false` from
+//! [`HeartbeatManager::should_send_heartbeat`],
+//! [`HeartbeatManager::should_send_test_request`] and
+//! [`HeartbeatManager::is_timed_out`] for the life of the session.
+//!
+//! # Liveness after a TestRequest
+//!
+//! `doc/fix_operations.md` ("Test Request") says only "if no response,
+//! consider session disconnected" and does not define what counts as a
+//! response. IronFix defines it here: **any inbound message the session
+//! accepts stops the countdown**, and a Heartbeat echoing the outstanding
+//! `TestReqID` (112) is the positive confirmation, reported as
+//! [`TestRequestOutcome::Confirmed`]. Traffic that is not that Heartbeat
+//! clears the pending request as [`TestRequestOutcome::SupersededByTraffic`].
+//! A peer that is sending us messages is alive whether or not it echoed our
+//! `TestReqID`, and several real venues answer a TestRequest with a Heartbeat
+//! that omits tag 112 or let it be reordered behind application traffic.
+//! This matches the QuickFIX family, which resets its test-request counter on
+//! any successfully verified inbound message.
 
 use std::time::{Duration, Instant};
+
+/// Largest counterparty-confirmed `HeartBtInt` (108) this engine will honour,
+/// in seconds (one hour).
+///
+/// `HeartBtInt` is counterparty-controlled, and it drives every liveness timer
+/// in the session. An unbounded value disables dead-peer detection outright,
+/// so a confirmed interval above this ceiling is refused rather than adopted.
+/// See [`negotiate_interval`].
+pub const MAX_HEARTBEAT_INTERVAL_SECS: u64 = 3600;
+
+/// Fraction of the heartbeat interval allowed as transmission grace before a
+/// TestRequest is due: the grace is `interval / TEST_REQUEST_GRACE_DIVISOR`.
+///
+/// Five gives the 20% allowance the QuickFIX family uses (`1.2 * HeartBtInt`
+/// of inbound silence before probing).
+const TEST_REQUEST_GRACE_DIVISOR: u32 = 5;
+
+/// Floor for the TestRequest grace period.
+///
+/// The proportional allowance collapses to almost nothing for sub-second
+/// intervals, where ordinary scheduling jitter is already comparable to the
+/// interval itself. 250 ms is long enough to absorb a scheduler hiccup and
+/// short enough that it never dominates a realistic `HeartBtInt`.
+const MIN_TEST_REQUEST_GRACE: Duration = Duration::from_millis(250);
+
+/// A counterparty-confirmed `HeartBtInt` (108) this engine refuses to adopt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("counterparty HeartBtInt (108) of {secs}s exceeds the maximum supported {max}s")]
+pub struct HeartbeatIntervalError {
+    /// The interval the counterparty confirmed, in seconds.
+    pub secs: u64,
+    /// The largest interval this engine honours, in seconds.
+    pub max: u64,
+}
+
+/// Effect an inbound message had on an outstanding TestRequest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TestRequestOutcome {
+    /// No TestRequest was outstanding.
+    NonePending,
+    /// A Heartbeat echoed the outstanding `TestReqID` (112): the counterparty
+    /// answered the probe exactly as asked.
+    Confirmed,
+    /// Other inbound traffic arrived while a TestRequest was outstanding. The
+    /// countdown stops — the peer is demonstrably alive — but this is not the
+    /// Heartbeat the TestRequest asked for.
+    SupersededByTraffic,
+}
+
+/// Resolves the heartbeat interval for a session from the interval this side
+/// requested and the `HeartBtInt` (108) the counterparty confirmed.
+///
+/// FIX expects the acceptor to echo the requested value; when it does not, the
+/// confirmed value wins (`doc/fix_operations.md`, "Logon"). Because that value
+/// is counterparty-controlled it is bounded: anything above
+/// [`MAX_HEARTBEAT_INTERVAL_SECS`] is refused, since adopting it would disable
+/// dead-peer detection for as long as the peer chose. A confirmed value that is
+/// exactly what this side requested is always accepted — a peer echoing our own
+/// configuration back is not the counterparty pushing us anywhere.
+///
+/// `0` is accepted at any time and means "do not heartbeat"; see the module
+/// documentation.
+///
+/// # Arguments
+/// * `requested` - The interval this side asked for in its Logon
+/// * `confirmed_secs` - The `HeartBtInt` (108) on the counterparty's Logon
+///
+/// # Errors
+/// Returns [`HeartbeatIntervalError`] when `confirmed_secs` exceeds
+/// [`MAX_HEARTBEAT_INTERVAL_SECS`] and is not the requested interval.
+pub fn negotiate_interval(
+    requested: Duration,
+    confirmed_secs: u64,
+) -> Result<Duration, HeartbeatIntervalError> {
+    let confirmed = Duration::from_secs(confirmed_secs);
+    if confirmed == requested {
+        return Ok(confirmed);
+    }
+    if confirmed_secs > MAX_HEARTBEAT_INTERVAL_SECS {
+        return Err(HeartbeatIntervalError {
+            secs: confirmed_secs,
+            max: MAX_HEARTBEAT_INTERVAL_SECS,
+        });
+    }
+    Ok(confirmed)
+}
+
+/// Transmission grace allowed on top of the interval before a TestRequest is
+/// due.
+///
+/// Proportional to the interval, floored at [`MIN_TEST_REQUEST_GRACE`]. A
+/// disabled interval has no grace because it has no TestRequest.
+fn grace_for(interval: Duration) -> Duration {
+    if interval.is_zero() {
+        return Duration::ZERO;
+    }
+    (interval / TEST_REQUEST_GRACE_DIVISOR).max(MIN_TEST_REQUEST_GRACE)
+}
 
 /// Manages heartbeat timing for a FIX session.
 #[derive(Debug)]
 pub struct HeartbeatManager {
-    /// Heartbeat interval.
+    /// Heartbeat interval. [`Duration::ZERO`] disables heartbeating entirely.
     interval: Duration,
+    /// Transmission grace added to the interval before a TestRequest is due.
+    grace: Duration,
     /// Time of last message sent.
     last_sent: Instant,
     /// Time of last message received.
@@ -31,6 +156,10 @@ pub struct HeartbeatManager {
 impl HeartbeatManager {
     /// Creates a new heartbeat manager with the specified interval.
     ///
+    /// [`Duration::ZERO`] is the legal `HeartBtInt` = 0 case and disables
+    /// heartbeats, TestRequests and the heartbeat timeout; see the module
+    /// documentation.
+    ///
     /// # Arguments
     /// * `interval` - The heartbeat interval
     #[must_use]
@@ -38,11 +167,20 @@ impl HeartbeatManager {
         let now = Instant::now();
         Self {
             interval,
+            grace: grace_for(interval),
             last_sent: now,
             last_received: now,
             test_request_pending: None,
             test_request_sent_at: None,
         }
+    }
+
+    /// Returns whether heartbeating is enabled, i.e. `HeartBtInt` is not 0.
+    ///
+    /// When this is `false` every timing predicate on this manager is `false`.
+    #[must_use]
+    pub const fn is_enabled(&self) -> bool {
+        !self.interval.is_zero()
     }
 
     /// Records that a message was sent.
@@ -53,63 +191,83 @@ impl HeartbeatManager {
 
     /// Records that a message was received.
     ///
-    /// If a TestRequest was pending and a Heartbeat with matching ID is received,
-    /// the pending request is cleared.
+    /// Any inbound message clears an outstanding TestRequest: the counterparty
+    /// is demonstrably alive, so the timeout countdown stops. The returned
+    /// [`TestRequestOutcome`] distinguishes the Heartbeat that actually echoed
+    /// the `TestReqID` from other traffic that merely superseded it. See the
+    /// module documentation for why the rule is this broad.
     ///
     /// # Arguments
     /// * `is_heartbeat` - Whether the received message is a Heartbeat
-    /// * `test_req_id` - The TestReqID from the Heartbeat, if present
-    pub fn on_message_received(&mut self, is_heartbeat: bool, test_req_id: Option<&str>) {
+    /// * `test_req_id` - The `TestReqID` (112) on the message, if present
+    pub fn on_message_received(
+        &mut self,
+        is_heartbeat: bool,
+        test_req_id: Option<&str>,
+    ) -> TestRequestOutcome {
         self.last_received = Instant::now();
 
-        if is_heartbeat
-            && let (Some(pending), Some(received)) = (&self.test_request_pending, test_req_id)
-            && pending == received
-        {
-            self.test_request_pending = None;
-            self.test_request_sent_at = None;
+        let Some(pending) = self.test_request_pending.take() else {
+            return TestRequestOutcome::NonePending;
+        };
+        self.test_request_sent_at = None;
+
+        if is_heartbeat && test_req_id == Some(pending.as_str()) {
+            TestRequestOutcome::Confirmed
+        } else {
+            TestRequestOutcome::SupersededByTraffic
         }
     }
 
     /// Checks if a heartbeat should be sent.
     ///
-    /// A heartbeat should be sent if no message has been sent within the interval.
+    /// A heartbeat should be sent if no message has been sent within the
+    /// interval. Always `false` when `HeartBtInt` is 0.
     #[must_use]
     pub fn should_send_heartbeat(&self) -> bool {
-        self.last_sent.elapsed() >= self.interval
+        self.is_enabled() && self.last_sent.elapsed() >= self.interval
     }
 
     /// Checks if a TestRequest should be sent.
     ///
-    /// A TestRequest should be sent if no message has been received within
-    /// the interval plus a grace period, and no TestRequest is already pending.
+    /// A TestRequest should be sent if no message has been received within the
+    /// interval plus [`HeartbeatManager::test_request_grace`], and no
+    /// TestRequest is already pending. Always `false` when `HeartBtInt` is 0.
     #[must_use]
     pub fn should_send_test_request(&self) -> bool {
-        if self.test_request_pending.is_some() {
+        if !self.is_enabled() || self.test_request_pending.is_some() {
             return false;
         }
-
-        let grace = Duration::from_secs(1);
-        self.last_received.elapsed() >= self.interval + grace
+        // An interval so large that adding the grace overflows can never come
+        // due; report that rather than panicking on the addition.
+        match self.interval.checked_add(self.grace) {
+            Some(due_after) => self.last_received.elapsed() >= due_after,
+            None => false,
+        }
     }
 
     /// Checks if the session has timed out.
     ///
-    /// A timeout occurs if a TestRequest was sent but no response was received
-    /// within the interval.
+    /// A timeout occurs only if a TestRequest was sent and **nothing at all**
+    /// has been received since, for one full interval — any inbound message
+    /// clears the pending request (see
+    /// [`HeartbeatManager::on_message_received`]). Always `false` when
+    /// `HeartBtInt` is 0.
     #[must_use]
     pub fn is_timed_out(&self) -> bool {
-        if let Some(sent_at) = self.test_request_sent_at {
-            sent_at.elapsed() >= self.interval
-        } else {
-            false
+        if !self.is_enabled() {
+            return false;
+        }
+        match self.test_request_sent_at {
+            Some(sent_at) => sent_at.elapsed() >= self.interval,
+            None => false,
         }
     }
 
     /// Records that a TestRequest was sent.
     ///
     /// # Arguments
-    /// * `test_req_id` - The TestReqID that was sent
+    /// * `test_req_id` - The `TestReqID` that was sent
     pub fn on_test_request_sent(&mut self, test_req_id: String) {
         self.test_request_pending = Some(test_req_id);
         self.test_request_sent_at = Some(Instant::now());
@@ -140,7 +298,20 @@ impl HeartbeatManager {
         self.interval
     }
 
+    /// Returns the transmission grace added to the interval before a
+    /// TestRequest becomes due.
+    ///
+    /// Derived from the interval, not configured: 20% of it, floored at
+    /// 250 ms. Zero when `HeartBtInt` is 0.
+    #[must_use]
+    pub const fn test_request_grace(&self) -> Duration {
+        self.grace
+    }
+
     /// Resets the manager state.
+    ///
+    /// The interval and its derived grace are session configuration and are
+    /// kept; only the timers and the pending TestRequest are cleared.
     pub fn reset(&mut self) {
         let now = Instant::now();
         self.last_sent = now;
@@ -175,6 +346,7 @@ mod tests {
         let mgr = HeartbeatManager::new(Duration::from_secs(30));
         assert_eq!(mgr.interval(), Duration::from_secs(30));
         assert!(mgr.pending_test_request().is_none());
+        assert!(mgr.is_enabled());
     }
 
     #[test]
@@ -203,7 +375,8 @@ mod tests {
         mgr.on_test_request_sent("TEST123".to_string());
         assert_eq!(mgr.pending_test_request(), Some("TEST123"));
 
-        mgr.on_message_received(true, Some("TEST123"));
+        let outcome = mgr.on_message_received(true, Some("TEST123"));
+        assert_eq!(outcome, TestRequestOutcome::Confirmed);
         assert!(mgr.pending_test_request().is_none());
     }
 
@@ -219,5 +392,260 @@ mod tests {
         // The important thing is that they have the correct format
         assert!(id1.len() > 4);
         assert!(id2.len() > 4);
+    }
+
+    // --- HeartBtInt = 0: heartbeating disabled -------------------------------
+
+    #[test]
+    fn test_zero_interval_reports_disabled() {
+        let mgr = HeartbeatManager::new(Duration::ZERO);
+        assert!(!mgr.is_enabled());
+        assert_eq!(mgr.test_request_grace(), Duration::ZERO);
+    }
+
+    #[test]
+    fn test_zero_interval_never_sends_heartbeat_or_test_request() {
+        let mgr = HeartbeatManager::new(Duration::ZERO);
+        assert!(!mgr.should_send_heartbeat());
+        assert!(!mgr.should_send_test_request());
+
+        sleep(Duration::from_millis(20));
+        assert!(!mgr.should_send_heartbeat());
+        assert!(!mgr.should_send_test_request());
+    }
+
+    #[test]
+    fn test_zero_interval_never_times_out() {
+        let mut mgr = HeartbeatManager::new(Duration::ZERO);
+        assert!(!mgr.is_timed_out());
+
+        // Even with a TestRequest artificially outstanding, a disabled
+        // interval has no timeout to expire.
+        mgr.on_test_request_sent("TEST-ZERO".to_string());
+        sleep(Duration::from_millis(20));
+        assert!(!mgr.is_timed_out());
+    }
+
+    // --- Grace period --------------------------------------------------------
+
+    #[test]
+    fn test_test_request_grace_is_one_fifth_of_a_long_interval() {
+        let mgr = HeartbeatManager::new(Duration::from_secs(30));
+        assert_eq!(mgr.test_request_grace(), Duration::from_secs(6));
+    }
+
+    #[test]
+    fn test_test_request_grace_uses_floor_for_short_intervals() {
+        let mgr = HeartbeatManager::new(Duration::from_millis(100));
+        assert_eq!(mgr.test_request_grace(), MIN_TEST_REQUEST_GRACE);
+    }
+
+    #[test]
+    fn test_should_send_test_request_waits_for_interval_plus_grace() {
+        // 2s interval -> 400ms grace, so the probe is due at 2.4s. Scaled down
+        // by using an interval whose fifth is above the floor.
+        let interval = Duration::from_millis(2000);
+        let mgr = HeartbeatManager::new(interval);
+        assert_eq!(mgr.test_request_grace(), Duration::from_millis(400));
+
+        // Before interval + grace: not due.
+        sleep(Duration::from_millis(50));
+        assert!(!mgr.should_send_test_request());
+    }
+
+    #[test]
+    fn test_should_send_test_request_boundary() {
+        // 1s interval -> grace floored at 250ms, so the probe is due at 1250ms
+        // of inbound silence.
+        let mgr = HeartbeatManager::new(Duration::from_secs(1));
+        assert_eq!(mgr.test_request_grace(), Duration::from_millis(250));
+
+        sleep(Duration::from_millis(700));
+        assert!(
+            !mgr.should_send_test_request(),
+            "neither interval nor grace has elapsed"
+        );
+
+        sleep(Duration::from_millis(700));
+        assert!(
+            mgr.should_send_test_request(),
+            "interval plus grace has elapsed"
+        );
+    }
+
+    #[test]
+    fn test_should_send_test_request_suppressed_while_pending() {
+        let mut mgr = HeartbeatManager::new(Duration::from_millis(50));
+        sleep(Duration::from_millis(320));
+        assert!(mgr.should_send_test_request());
+
+        mgr.on_test_request_sent("TEST-PENDING".to_string());
+        assert!(!mgr.should_send_test_request());
+    }
+
+    #[test]
+    fn test_should_send_test_request_unreachable_interval_is_never_due() {
+        let mgr = HeartbeatManager::new(Duration::MAX);
+        assert!(!mgr.should_send_test_request());
+    }
+
+    // --- Timeout branches ----------------------------------------------------
+
+    #[test]
+    fn test_is_timed_out_false_without_pending_test_request() {
+        let mgr = HeartbeatManager::new(Duration::from_millis(10));
+        sleep(Duration::from_millis(50));
+        assert!(!mgr.is_timed_out());
+    }
+
+    #[test]
+    fn test_is_timed_out_false_before_the_interval_elapses() {
+        let mut mgr = HeartbeatManager::new(Duration::from_millis(200));
+        mgr.on_test_request_sent("TEST-EARLY".to_string());
+        sleep(Duration::from_millis(20));
+        assert!(!mgr.is_timed_out());
+    }
+
+    #[test]
+    fn test_is_timed_out_true_after_silence_since_the_test_request() {
+        let mut mgr = HeartbeatManager::new(Duration::from_millis(50));
+        mgr.on_test_request_sent("TEST-SILENT".to_string());
+        sleep(Duration::from_millis(80));
+        assert!(mgr.is_timed_out());
+    }
+
+    // --- Clearing a pending TestRequest -------------------------------------
+
+    #[test]
+    fn test_application_traffic_clears_pending_test_request() {
+        let mut mgr = HeartbeatManager::new(Duration::from_millis(50));
+        mgr.on_test_request_sent("TEST-TRAFFIC".to_string());
+
+        // An ExecutionReport, not a Heartbeat, and carrying no TestReqID.
+        let outcome = mgr.on_message_received(false, None);
+        assert_eq!(outcome, TestRequestOutcome::SupersededByTraffic);
+        assert!(mgr.pending_test_request().is_none());
+
+        sleep(Duration::from_millis(80));
+        assert!(
+            !mgr.is_timed_out(),
+            "traffic after the TestRequest proves the peer is alive"
+        );
+    }
+
+    #[test]
+    fn test_heartbeat_without_test_req_id_clears_pending_test_request() {
+        let mut mgr = HeartbeatManager::new(Duration::from_millis(50));
+        mgr.on_test_request_sent("TEST-NO-112".to_string());
+
+        let outcome = mgr.on_message_received(true, None);
+        assert_eq!(outcome, TestRequestOutcome::SupersededByTraffic);
+        assert!(mgr.pending_test_request().is_none());
+        assert!(!mgr.is_timed_out());
+    }
+
+    #[test]
+    fn test_heartbeat_with_wrong_test_req_id_clears_pending_test_request() {
+        let mut mgr = HeartbeatManager::new(Duration::from_millis(50));
+        mgr.on_test_request_sent("TEST-WANTED".to_string());
+
+        let outcome = mgr.on_message_received(true, Some("TEST-OTHER"));
+        assert_eq!(outcome, TestRequestOutcome::SupersededByTraffic);
+        assert!(mgr.pending_test_request().is_none());
+        assert!(!mgr.is_timed_out());
+    }
+
+    #[test]
+    fn test_non_heartbeat_with_matching_id_is_not_confirmation() {
+        let mut mgr = HeartbeatManager::new(Duration::from_millis(50));
+        mgr.on_test_request_sent("TEST-ECHO".to_string());
+
+        // A TestRequest of the counterparty's own carrying the same ID is not
+        // the Heartbeat we asked for, though it still proves liveness.
+        let outcome = mgr.on_message_received(false, Some("TEST-ECHO"));
+        assert_eq!(outcome, TestRequestOutcome::SupersededByTraffic);
+        assert!(mgr.pending_test_request().is_none());
+    }
+
+    #[test]
+    fn test_on_message_received_without_pending_reports_none_pending() {
+        let mut mgr = HeartbeatManager::new(Duration::from_secs(30));
+        let outcome = mgr.on_message_received(true, Some("TEST-UNSOLICITED"));
+        assert_eq!(outcome, TestRequestOutcome::NonePending);
+    }
+
+    #[test]
+    fn test_reset_clears_pending_test_request_and_timers() {
+        let mut mgr = HeartbeatManager::new(Duration::from_millis(50));
+        mgr.on_test_request_sent("TEST-RESET".to_string());
+        sleep(Duration::from_millis(80));
+        assert!(mgr.is_timed_out());
+
+        mgr.reset();
+        assert!(mgr.pending_test_request().is_none());
+        assert!(!mgr.is_timed_out());
+        assert!(!mgr.should_send_test_request());
+        assert_eq!(mgr.interval(), Duration::from_millis(50));
+        assert_eq!(mgr.test_request_grace(), MIN_TEST_REQUEST_GRACE);
+    }
+
+    // --- Interval negotiation ------------------------------------------------
+
+    #[test]
+    fn test_negotiate_interval_accepts_the_echoed_value() {
+        let requested = Duration::from_secs(30);
+        assert_eq!(negotiate_interval(requested, 30), Ok(requested));
+    }
+
+    #[test]
+    fn test_negotiate_interval_accepts_zero() {
+        assert_eq!(
+            negotiate_interval(Duration::from_secs(30), 0),
+            Ok(Duration::ZERO)
+        );
+    }
+
+    #[test]
+    fn test_negotiate_interval_accepts_a_differing_value_within_bounds() {
+        assert_eq!(
+            negotiate_interval(Duration::from_secs(30), 60),
+            Ok(Duration::from_secs(60))
+        );
+    }
+
+    #[test]
+    fn test_negotiate_interval_accepts_the_maximum() {
+        assert_eq!(
+            negotiate_interval(Duration::from_secs(30), MAX_HEARTBEAT_INTERVAL_SECS),
+            Ok(Duration::from_secs(MAX_HEARTBEAT_INTERVAL_SECS))
+        );
+    }
+
+    #[test]
+    fn test_negotiate_interval_refuses_above_the_maximum() {
+        let err = negotiate_interval(Duration::from_secs(30), MAX_HEARTBEAT_INTERVAL_SECS + 1);
+        assert_eq!(
+            err,
+            Err(HeartbeatIntervalError {
+                secs: MAX_HEARTBEAT_INTERVAL_SECS + 1,
+                max: MAX_HEARTBEAT_INTERVAL_SECS,
+            })
+        );
+    }
+
+    #[test]
+    fn test_negotiate_interval_refuses_an_absurd_value() {
+        assert!(negotiate_interval(Duration::from_secs(30), u64::MAX).is_err());
+    }
+
+    #[test]
+    fn test_negotiate_interval_accepts_an_out_of_bounds_echo_of_our_own_request() {
+        // A deliberately configured long interval echoed back is our own
+        // choice, not the counterparty pushing us past the ceiling.
+        let requested = Duration::from_secs(MAX_HEARTBEAT_INTERVAL_SECS + 100);
+        assert_eq!(
+            negotiate_interval(requested, MAX_HEARTBEAT_INTERVAL_SECS + 100),
+            Ok(requested)
+        );
     }
 }

--- a/ironfix-session/src/lib.rs
+++ b/ironfix-session/src/lib.rs
@@ -31,7 +31,7 @@ pub mod sequence;
 pub mod state;
 
 pub use config::SessionConfig;
-pub use heartbeat::HeartbeatManager;
+pub use heartbeat::{HeartbeatIntervalError, HeartbeatManager, TestRequestOutcome};
 pub use sequence::{SequenceCounter, SequenceExhausted, SequenceManager};
 pub use state::{
     Active, Connecting, Disconnected, LogonReceived, LogonSent, LogoutPending, Resending, Session,


### PR DESCRIPTION
## Summary

Stops the heartbeat logic from disconnecting sessions that are demonstrably alive, and from destroying itself on a value the counterparty controls.

Closes #10.

## Stack

- **Base branch:** `stack/12-tagvalue-encoder` (PR #36)

## What was wrong

Two of these were **reproduced against a running session** by adversarial review of #25, not inferred from reading the code.

**1. `HeartBtInt = 0` made the session destroy itself.** Zero is legal FIX and means "do not send heartbeats". It was taken literally as a zero-length interval, so `should_send_heartbeat()` was permanently true — the reactor emitted a Heartbeat on **every 100 ms tick**, roughly ten a second — and `is_timed_out()` went true on the first tick after any TestRequest, killing the session about 1.1 seconds in. The value arrives in the counterparty's Logon ack, so this was **remotely triggerable**.

Zero now disables heartbeating and TestRequests as the specification intends, and the negotiated interval is bounded, since it is counterparty-controlled.

**2. A pending TestRequest was cleared only by a Heartbeat echoing the matching TestReqID.** Any other inbound traffic refreshed `last_received` but left the timeout armed, so it fired one interval later regardless. Observed: a venue answered a TestRequest with valid, in-sequence ExecutionReports every 200 ms; six were accepted and delivered to the application, and then the session was torn down as unresponsive.

The realistic triggers are ordinary: several venues answer a TestRequest with a Heartbeat that omits tag 112, and a Heartbeat reordered behind application traffic does the same thing.

`doc/fix_operations.md` says only "if no response, consider session disconnected" and never defines what counts as a response — so the rule is **chosen explicitly and written down** rather than left implicit: any accepted inbound message stops the countdown, while a Heartbeat echoing the TestReqID remains the positive confirmation. That is also what QuickFIX/J does.

**3. The grace period was a magic number.** It derives from the configured interval now.

## Phase 1 checklist

`doc/fix_operations.md` had "Heartbeat / Test Request" **unticked**, with these defects named as the reason. It is ticked here — qualified, because it covers the **initiator** only: there is no Acceptor in `ironfix-engine`, so the acceptor side of the same behaviour does not exist to be correct.

## Tests

Workspace goes to **435 passing**. Defect 2 is covered end to end in `initiator_tests.rs` by a stub acceptor that answers a TestRequest with application traffic — the scenario that found it — rather than only at the unit level, where it would have looked fine.

## Verification

```
cargo test --workspace                                    # 435 passed
cargo clippy --all-targets --all-features -- -D warnings  # clean
cargo fmt --all --check                                   # clean
make doc                                                  # clean
```
