### PR TITLE
fix(tagvalue): frame every spec-defined Length/Data pair, not just FIX 4.4

### DIFF
--- a/ironfix-tagvalue/src/decoder.rs
+++ b/ironfix-tagvalue/src/decoder.rs
@@ -42,6 +42,117 @@ const MAX_LENGTH_DIGITS: usize = 10;
 /// bounded rather than sized from the input.
 const MAX_TAG_DIAGNOSTIC_LEN: usize = 16;
 
+/// Lowest tag number that is a `LENGTH` field framing a paired `DATA` field.
+///
+/// The guard at the top of [`paired_data_tag`]; kept next to the table it
+/// bounds so the two are read together.
+const FIRST_LENGTH_TAG: u32 = 90;
+
+/// Lowest tag number that is a `DATA` field, i.e. the guard at the top of
+/// [`is_data_tag`].
+const FIRST_DATA_TAG: u32 = 89;
+
+/// Reference table of the spec-defined `(length_tag, data_tag)` pairs.
+///
+/// Test-only, and the single source of truth both test modules cross-check
+/// against: [`paired_data_tag`] and [`is_data_tag`] are hand-written `match`
+/// arms, and the encoder's round-trip test walks this table so every pair the
+/// decoder frames by count is proven emittable.
+///
+/// See [`paired_data_tag`] for how the pairs were derived and which versions
+/// they span.
+#[cfg(test)]
+pub(crate) const LENGTH_DATA_PAIRS: [(u32, u32); 83] = [
+    // FIX 4.0
+    (90, 91), // SecureDataLen / SecureData
+    (93, 89), // SignatureLength / Signature
+    (95, 96), // RawDataLength / RawData
+    // FIX 4.2
+    (212, 213), // XmlDataLen / XmlData
+    (348, 349), // EncodedIssuerLen / EncodedIssuer
+    (350, 351), // EncodedSecurityDescLen / EncodedSecurityDesc
+    (352, 353), // EncodedListExecInstLen / EncodedListExecInst
+    (354, 355), // EncodedTextLen / EncodedText
+    (356, 357), // EncodedSubjectLen / EncodedSubject
+    (358, 359), // EncodedHeadlineLen / EncodedHeadline
+    (360, 361), // EncodedAllocTextLen / EncodedAllocText
+    (362, 363), // EncodedUnderlyingIssuerLen / EncodedUnderlyingIssuer
+    (364, 365), // EncodedUnderlyingSecurityDescLen / EncodedUnderlyingSecurityDesc
+    (445, 446), // EncodedListStatusTextLen / EncodedListStatusText
+    // FIX 4.3
+    (618, 619), // EncodedLegIssuerLen / EncodedLegIssuer
+    (621, 622), // EncodedLegSecurityDescLen / EncodedLegSecurityDesc
+    // FIX 5.0 SP1
+    (1184, 1185), // SecurityXMLLen / SecurityXML
+    (1277, 1278), // DerivativeEncodedIssuerLen / DerivativeEncodedIssuer
+    (1280, 1281), // DerivativeEncodedSecurityDescLen / DerivativeEncodedSecurityDesc
+    (1282, 1283), // DerivativeSecurityXMLLen / DerivativeSecurityXML
+    (1397, 1398), // EncodedMktSegmDescLen / EncodedMktSegmDesc
+    (1401, 1402), // EncryptedPasswordLen / EncryptedPassword
+    (1403, 1404), // EncryptedNewPasswordLen / EncryptedNewPassword
+    // FIX 5.0 SP2
+    (1468, 1469),   // EncodedSecurityListDescLen / EncodedSecurityListDesc
+    (1525, 1527),   // EncodedDocumentationTextLen / EncodedDocumentationText
+    (1578, 1579),   // EncodedEventTextLen / EncodedEventText
+    (1620, 1621),   // InstrumentScopeEncodedSecurityDescLen / InstrumentScopeEncodedSecurityDesc
+    (1664, 1665),   // EncodedRejectTextLen / EncodedRejectText
+    (1678, 1697),   // EncodedOptionExpirationDescLen / EncodedOptionExpirationDesc
+    (1733, 1734),   // EncodedFirmAllocTextLen / EncodedFirmAllocText
+    (1871, 1872),   // LegSecurityXMLLen / LegSecurityXML
+    (1874, 1875),   // UnderlyingSecurityXMLLen / UnderlyingSecurityXML
+    (2072, 2073),   // EncodedUnderlyingEventTextLen / EncodedUnderlyingEventText
+    (2074, 2075),   // EncodedLegEventTextLen / EncodedLegEventText
+    (2111, 2112),   // EncodedAttachmentLen / EncodedAttachment
+    (2179, 2180),   // EncodedLegOptionExpirationDescLen / EncodedLegOptionExpirationDesc
+    (2287, 2288), // EncodedUnderlyingOptionExpirationDescLen / EncodedUnderlyingOptionExpirationDesc
+    (2351, 2352), // EncodedComplianceTextLen / EncodedComplianceText
+    (2372, 2371), // EncodedTradeContinuationTextLen / EncodedTradeContinuationText
+    (2481, 2482), // EncodedMDStatisticDescLen / EncodedMDStatisticDesc
+    (2494, 2493), // EncodedLegDocumentationTextLen / EncodedLegDocumentationText
+    (2522, 2521), // EncodedWarningTextLen / EncodedWarningText
+    (2637, 2638), // EncodedMiscFeeSubTypeDescLen / EncodedMiscFeeSubTypeDesc
+    (2651, 2652), // EncodedCommissionDescLen / EncodedCommissionDesc
+    (2665, 2666), // EncodedAllocCommissionDescLen / EncodedAllocCommissionDesc
+    (2715, 2716), // EncodedFinancialInstrumentFullNameLen / EncodedFinancialInstrumentFullName
+    (2718, 2719), // EncodedLegFinancialInstrumentFullNameLen / EncodedLegFinancialInstrumentFullName
+    (2721, 2722), // EncodedUnderlyingFinancialInstrumentFullNameLen / EncodedUnderlyingFinancialInstrumentFullName
+    (2797, 2798), // EncodedMatchExceptionTextLen / EncodedMatchExceptionText
+    (2802, 2801), // EncodedReplaceTextLen / EncodedReplaceText
+    (2809, 2808), // EncodedCancelTextLen / EncodedCancelText
+    (2815, 2814), // EncodedPostTradePaymentDescLen / EncodedPostTradePaymentDesc
+    (40004, 40005), // EncodedAdditionalTermBondDescLen / EncodedAdditionalTermBondDesc
+    (40008, 40009), // EncodedAdditionalTermBondIssuerLen / EncodedAdditionalTermBondIssuer
+    (40978, 40979), // EncodedLegStreamTextLen / EncodedLegStreamText
+    (40980, 40981), // EncodedLegProvisionTextLen / EncodedLegProvisionText
+    (40982, 40983), // EncodedStreamTextLen / EncodedStreamText
+    (40984, 40985), // EncodedPaymentTextLen / EncodedPaymentText
+    (40986, 40987), // EncodedProvisionTextLen / EncodedProvisionText
+    (40988, 40989), // EncodedUnderlyingStreamTextLen / EncodedUnderlyingStreamText
+    (41083, 41084), // EncodedDeliveryStreamCycleDescLen / EncodedDeliveryStreamCycleDesc
+    (41101, 41102), // EncodedMarketDisruptionFallbackUnderlierSecurityDescLen / EncodedMarketDisruptionFallbackUnderlierSecurityDesc
+    (41107, 41108), // EncodedExerciseDescLen / EncodedExerciseDesc
+    (41256, 41257), // EncodedStreamCommodityDescLen / EncodedStreamCommodityDesc
+    (41320, 41321), // EncodedLegAdditionalTermBondDescLen / EncodedLegAdditionalTermBondDesc
+    (41324, 41325), // EncodedLegAdditionalTermBondIssuerLen / EncodedLegAdditionalTermBondIssuer
+    (41458, 41459), // EncodedLegDeliveryStreamCycleDescLen / EncodedLegDeliveryStreamCycleDesc
+    (41476, 41477), // EncodedLegMarketDisruptionFallbackUnderlierSecurityDescLen / EncodedLegMarketDisruptionFallbackUnderlierSecurityDesc
+    (41482, 41483), // EncodedLegExerciseDescLen / EncodedLegExerciseDesc
+    (41653, 41654), // EncodedLegStreamCommodityDescLen / EncodedLegStreamCommodityDesc
+    (41710, 41711), // EncodedUnderlyingAdditionalTermBondDescLen / EncodedUnderlyingAdditionalTermBondDesc
+    (41806, 41807), // EncodedUnderlyingDeliveryStreamCycleDescLen / EncodedUnderlyingDeliveryStreamCycleDesc
+    (41811, 41812), // EncodedUnderlyingExerciseDescLen / EncodedUnderlyingExerciseDesc
+    (41873, 41874), // EncodedUnderlyingMarketDisruptionFallbackUnderlierSecDescLen / EncodedUnderlyingMarketDisruptionFallbackUnderlierSecurityDesc
+    (41969, 41970), // EncodedUnderlyingStreamCommodityDescLen / EncodedUnderlyingStreamCommodityDesc
+    (42025, 42026), // EncodedUnderlyingAdditionalTermBondIssuerLen / EncodedUnderlyingAdditionalTermBondIssuer
+    (42171, 42172), // EncodedUnderlyingProvisionTextLen / EncodedUnderlyingProvisionText
+    (42451, 42452), // LegPaymentStreamFormulaImageLength / LegPaymentStreamFormulaImage
+    (42652, 42653), // PaymentStreamFormulaImageLength / PaymentStreamFormulaImage
+    (42947, 42948), // UnderlyingPaymentStreamFormulaImageLength / UnderlyingPaymentStreamFormulaImage
+    (43109, 42684), // PaymentStreamFormulaLength / PaymentStreamFormula
+    (43110, 42486), // LegPaymentStreamFormulaLength / LegPaymentStreamFormula
+    (43111, 42982), // UnderlyingPaymentStreamFormulaLength / UnderlyingPaymentStreamFormula
+];
+
 /// Returns the `DATA` tag paired with `length_tag`, if any.
 ///
 /// A FIX `DATA` field is a counted byte string whose content may legally
@@ -54,22 +165,42 @@ const MAX_TAG_DIAGNOSTIC_LEN: usize = 16;
 /// resolving it must never require a dictionary lookup: `ironfix-tagvalue`
 /// stays independent of `ironfix-dictionary`.
 ///
-/// The arms below are the complete set for FIX 4.4 (every `type='DATA'` field
-/// in the vendored `spec/FIX44.xml`). Versions above 4.4 add further pairs;
-/// a `DATA` field outside this set still falls back to an SOH scan and is
-/// therefore subject to the truncation this framing exists to prevent.
+/// The arms below are the complete set of `LENGTH`/`DATA` pairs the FIX
+/// specification defines from 4.0 through 5.0 SP2, FIXT.1.1 included — 83
+/// pairs. Each was derived from the QuickFIX dictionary for its version by
+/// taking, for every `type='DATA'` or `type='XMLDATA'` field, the
+/// `type='LENGTH'` field that immediately precedes it in every message and
+/// component carrying it; every `DATA` field resolves to exactly one `LENGTH`
+/// field, no `LENGTH` field frames two different `DATA` fields, and no tag is
+/// both. Tag numbers are never reused across FIX versions, so the union is a
+/// single table rather than one table per version.
+///
+/// Two kinds of `DATA` field remain outside it, and both still fall back to an
+/// SOH scan: user-defined fields (the 5000–9999 and 20000+ ranges FIX reserves
+/// for bilateral use) and anything an Extension Pack adds after 5.0 SP2. The
+/// first cannot be resolved from a fixed table at all — the tag number and its
+/// type are a private agreement between two counterparties, not spec — so
+/// closing that gap would need a per-session extension the caller supplies.
 ///
 /// Written as a `match` rather than a table walk because `slice::get` is not
 /// const-stable, so indexing a const array here would be unchecked indexing.
-/// `LENGTH_DATA_PAIRS` in the tests cross-checks these arms so the two cannot
+/// `LENGTH_DATA_PAIRS` cross-checks these arms in the tests so the two cannot
 /// drift.
 #[inline]
 #[must_use]
 pub(crate) const fn paired_data_tag(length_tag: u32) -> Option<u32> {
+    // No `LENGTH` field is numbered below 90, so one comparison settles every
+    // tag beneath it — including most of the session header — without entering
+    // the table. `test_table_guards_match_the_table_minimums` pins the bound.
+    if length_tag < FIRST_LENGTH_TAG {
+        return None;
+    }
     match length_tag {
-        90 => Some(91),   // SecureDataLen / SecureData
-        93 => Some(89),   // SignatureLength / Signature
-        95 => Some(96),   // RawDataLength / RawData
+        // FIX 4.0
+        90 => Some(91), // SecureDataLen / SecureData
+        93 => Some(89), // SignatureLength / Signature
+        95 => Some(96), // RawDataLength / RawData
+        // FIX 4.2
         212 => Some(213), // XmlDataLen / XmlData
         348 => Some(349), // EncodedIssuerLen / EncodedIssuer
         350 => Some(351), // EncodedSecurityDescLen / EncodedSecurityDesc
@@ -81,8 +212,78 @@ pub(crate) const fn paired_data_tag(length_tag: u32) -> Option<u32> {
         362 => Some(363), // EncodedUnderlyingIssuerLen / EncodedUnderlyingIssuer
         364 => Some(365), // EncodedUnderlyingSecurityDescLen / EncodedUnderlyingSecurityDesc
         445 => Some(446), // EncodedListStatusTextLen / EncodedListStatusText
+        // FIX 4.3
         618 => Some(619), // EncodedLegIssuerLen / EncodedLegIssuer
         621 => Some(622), // EncodedLegSecurityDescLen / EncodedLegSecurityDesc
+        // FIX 5.0 SP1
+        1184 => Some(1185), // SecurityXMLLen / SecurityXML
+        1277 => Some(1278), // DerivativeEncodedIssuerLen / DerivativeEncodedIssuer
+        1280 => Some(1281), // DerivativeEncodedSecurityDescLen / DerivativeEncodedSecurityDesc
+        1282 => Some(1283), // DerivativeSecurityXMLLen / DerivativeSecurityXML
+        1397 => Some(1398), // EncodedMktSegmDescLen / EncodedMktSegmDesc
+        1401 => Some(1402), // EncryptedPasswordLen / EncryptedPassword
+        1403 => Some(1404), // EncryptedNewPasswordLen / EncryptedNewPassword
+        // FIX 5.0 SP2
+        1468 => Some(1469), // EncodedSecurityListDescLen / EncodedSecurityListDesc
+        1525 => Some(1527), // EncodedDocumentationTextLen / EncodedDocumentationText
+        1578 => Some(1579), // EncodedEventTextLen / EncodedEventText
+        1620 => Some(1621), // InstrumentScopeEncodedSecurityDescLen / InstrumentScopeEncodedSecurityDesc
+        1664 => Some(1665), // EncodedRejectTextLen / EncodedRejectText
+        1678 => Some(1697), // EncodedOptionExpirationDescLen / EncodedOptionExpirationDesc
+        1733 => Some(1734), // EncodedFirmAllocTextLen / EncodedFirmAllocText
+        1871 => Some(1872), // LegSecurityXMLLen / LegSecurityXML
+        1874 => Some(1875), // UnderlyingSecurityXMLLen / UnderlyingSecurityXML
+        2072 => Some(2073), // EncodedUnderlyingEventTextLen / EncodedUnderlyingEventText
+        2074 => Some(2075), // EncodedLegEventTextLen / EncodedLegEventText
+        2111 => Some(2112), // EncodedAttachmentLen / EncodedAttachment
+        2179 => Some(2180), // EncodedLegOptionExpirationDescLen / EncodedLegOptionExpirationDesc
+        2287 => Some(2288), // EncodedUnderlyingOptionExpirationDescLen / EncodedUnderlyingOptionExpirationDesc
+        2351 => Some(2352), // EncodedComplianceTextLen / EncodedComplianceText
+        2372 => Some(2371), // EncodedTradeContinuationTextLen / EncodedTradeContinuationText
+        2481 => Some(2482), // EncodedMDStatisticDescLen / EncodedMDStatisticDesc
+        2494 => Some(2493), // EncodedLegDocumentationTextLen / EncodedLegDocumentationText
+        2522 => Some(2521), // EncodedWarningTextLen / EncodedWarningText
+        2637 => Some(2638), // EncodedMiscFeeSubTypeDescLen / EncodedMiscFeeSubTypeDesc
+        2651 => Some(2652), // EncodedCommissionDescLen / EncodedCommissionDesc
+        2665 => Some(2666), // EncodedAllocCommissionDescLen / EncodedAllocCommissionDesc
+        2715 => Some(2716), // EncodedFinancialInstrumentFullNameLen / EncodedFinancialInstrumentFullName
+        2718 => Some(2719), // EncodedLegFinancialInstrumentFullNameLen / EncodedLegFinancialInstrumentFullName
+        2721 => Some(2722), // EncodedUnderlyingFinancialInstrumentFullNameLen / EncodedUnderlyingFinancialInstrumentFullName
+        2797 => Some(2798), // EncodedMatchExceptionTextLen / EncodedMatchExceptionText
+        2802 => Some(2801), // EncodedReplaceTextLen / EncodedReplaceText
+        2809 => Some(2808), // EncodedCancelTextLen / EncodedCancelText
+        2815 => Some(2814), // EncodedPostTradePaymentDescLen / EncodedPostTradePaymentDesc
+        40004 => Some(40005), // EncodedAdditionalTermBondDescLen / EncodedAdditionalTermBondDesc
+        40008 => Some(40009), // EncodedAdditionalTermBondIssuerLen / EncodedAdditionalTermBondIssuer
+        40978 => Some(40979), // EncodedLegStreamTextLen / EncodedLegStreamText
+        40980 => Some(40981), // EncodedLegProvisionTextLen / EncodedLegProvisionText
+        40982 => Some(40983), // EncodedStreamTextLen / EncodedStreamText
+        40984 => Some(40985), // EncodedPaymentTextLen / EncodedPaymentText
+        40986 => Some(40987), // EncodedProvisionTextLen / EncodedProvisionText
+        40988 => Some(40989), // EncodedUnderlyingStreamTextLen / EncodedUnderlyingStreamText
+        41083 => Some(41084), // EncodedDeliveryStreamCycleDescLen / EncodedDeliveryStreamCycleDesc
+        41101 => Some(41102), // EncodedMarketDisruptionFallbackUnderlierSecurityDescLen / EncodedMarketDisruptionFallbackUnderlierSecurityDesc
+        41107 => Some(41108), // EncodedExerciseDescLen / EncodedExerciseDesc
+        41256 => Some(41257), // EncodedStreamCommodityDescLen / EncodedStreamCommodityDesc
+        41320 => Some(41321), // EncodedLegAdditionalTermBondDescLen / EncodedLegAdditionalTermBondDesc
+        41324 => Some(41325), // EncodedLegAdditionalTermBondIssuerLen / EncodedLegAdditionalTermBondIssuer
+        41458 => Some(41459), // EncodedLegDeliveryStreamCycleDescLen / EncodedLegDeliveryStreamCycleDesc
+        41476 => Some(41477), // EncodedLegMarketDisruptionFallbackUnderlierSecurityDescLen / EncodedLegMarketDisruptionFallbackUnderlierSecurityDesc
+        41482 => Some(41483), // EncodedLegExerciseDescLen / EncodedLegExerciseDesc
+        41653 => Some(41654), // EncodedLegStreamCommodityDescLen / EncodedLegStreamCommodityDesc
+        41710 => Some(41711), // EncodedUnderlyingAdditionalTermBondDescLen / EncodedUnderlyingAdditionalTermBondDesc
+        41806 => Some(41807), // EncodedUnderlyingDeliveryStreamCycleDescLen / EncodedUnderlyingDeliveryStreamCycleDesc
+        41811 => Some(41812), // EncodedUnderlyingExerciseDescLen / EncodedUnderlyingExerciseDesc
+        41873 => Some(41874), // EncodedUnderlyingMarketDisruptionFallbackUnderlierSecDescLen / EncodedUnderlyingMarketDisruptionFallbackUnderlierSecurityDesc
+        41969 => Some(41970), // EncodedUnderlyingStreamCommodityDescLen / EncodedUnderlyingStreamCommodityDesc
+        42025 => Some(42026), // EncodedUnderlyingAdditionalTermBondIssuerLen / EncodedUnderlyingAdditionalTermBondIssuer
+        42171 => Some(42172), // EncodedUnderlyingProvisionTextLen / EncodedUnderlyingProvisionText
+        42451 => Some(42452), // LegPaymentStreamFormulaImageLength / LegPaymentStreamFormulaImage
+        42652 => Some(42653), // PaymentStreamFormulaImageLength / PaymentStreamFormulaImage
+        42947 => Some(42948), // UnderlyingPaymentStreamFormulaImageLength / UnderlyingPaymentStreamFormulaImage
+        43109 => Some(42684), // PaymentStreamFormulaLength / PaymentStreamFormula
+        43110 => Some(42486), // LegPaymentStreamFormulaLength / LegPaymentStreamFormula
+        43111 => Some(42982), // UnderlyingPaymentStreamFormulaLength / UnderlyingPaymentStreamFormula
         _ => None,
     }
 }
@@ -96,13 +297,98 @@ pub(crate) const fn paired_data_tag(length_tag: u32) -> Option<u32> {
 /// which would emit a frame no decoder can frame back.
 ///
 /// Written as a `match` for the same reason as [`paired_data_tag`], and
-/// cross-checked against `LENGTH_DATA_PAIRS` in the tests.
+/// cross-checked against `LENGTH_DATA_PAIRS` in the tests. It spans the same
+/// versions and carries the same residual gap.
 #[inline]
 #[must_use]
 pub(crate) const fn is_data_tag(tag: u32) -> bool {
+    if tag < FIRST_DATA_TAG {
+        return false;
+    }
     matches!(
         tag,
-        89 | 91 | 96 | 213 | 349 | 351 | 353 | 355 | 357 | 359 | 361 | 363 | 365 | 446 | 619 | 622
+        89 | 91
+            | 96
+            | 213
+            | 349
+            | 351
+            | 353
+            | 355
+            | 357
+            | 359
+            | 361
+            | 363
+            | 365
+            | 446
+            | 619
+            | 622
+            | 1185
+            | 1278
+            | 1281
+            | 1283
+            | 1398
+            | 1402
+            | 1404
+            | 1469
+            | 1527
+            | 1579
+            | 1621
+            | 1665
+            | 1697
+            | 1734
+            | 1872
+            | 1875
+            | 2073
+            | 2075
+            | 2112
+            | 2180
+            | 2288
+            | 2352
+            | 2371
+            | 2482
+            | 2493
+            | 2521
+            | 2638
+            | 2652
+            | 2666
+            | 2716
+            | 2719
+            | 2722
+            | 2798
+            | 2801
+            | 2808
+            | 2814
+            | 40005
+            | 40009
+            | 40979
+            | 40981
+            | 40983
+            | 40985
+            | 40987
+            | 40989
+            | 41084
+            | 41102
+            | 41108
+            | 41257
+            | 41321
+            | 41325
+            | 41459
+            | 41477
+            | 41483
+            | 41654
+            | 41711
+            | 41807
+            | 41812
+            | 41874
+            | 41970
+            | 42026
+            | 42172
+            | 42452
+            | 42486
+            | 42653
+            | 42684
+            | 42948
+            | 42982
     )
 }
 
@@ -585,29 +871,14 @@ mod tests {
     use ironfix_core::error::MsgTypeError;
     use ironfix_core::message::MSG_TYPE_MAX_LEN;
 
-    /// Reference table of the spec-defined `(length_tag, data_tag)` pairs.
+    /// Every tag number the pair table can be asked about, as an iterator.
     ///
-    /// This is the complete set of `type='DATA'` fields in the vendored FIX 4.4
-    /// specification. It exists to cross-check the match arms of
-    /// [`paired_data_tag`], which is the production lookup.
-    const LENGTH_DATA_PAIRS: [(u32, u32); 16] = [
-        (90, 91),   // SecureDataLen / SecureData
-        (93, 89),   // SignatureLength / Signature
-        (95, 96),   // RawDataLength / RawData
-        (212, 213), // XmlDataLen / XmlData
-        (348, 349), // EncodedIssuerLen / EncodedIssuer
-        (350, 351), // EncodedSecurityDescLen / EncodedSecurityDesc
-        (352, 353), // EncodedListExecInstLen / EncodedListExecInst
-        (354, 355), // EncodedTextLen / EncodedText
-        (356, 357), // EncodedSubjectLen / EncodedSubject
-        (358, 359), // EncodedHeadlineLen / EncodedHeadline
-        (360, 361), // EncodedAllocTextLen / EncodedAllocText
-        (362, 363), // EncodedUnderlyingIssuerLen / EncodedUnderlyingIssuer
-        (364, 365), // EncodedUnderlyingSecurityDescLen / EncodedUnderlyingSecurityDesc
-        (445, 446), // EncodedListStatusTextLen / EncodedListStatusText
-        (618, 619), // EncodedLegIssuerLen / EncodedLegIssuer
-        (621, 622), // EncodedLegSecurityDescLen / EncodedLegSecurityDesc
-    ];
+    /// The two disjoint bands the table occupies, padded on both sides: the
+    /// classic FIX range and the 40000+ range FIX 5.0 SP2 uses for the
+    /// derivatives extension.
+    fn candidate_tags() -> impl Iterator<Item = u32> {
+        (1..=3_000u32).chain(39_000..=44_000u32)
+    }
 
     /// Builds a well-formed frame around `body` with a valid trailing checksum.
     fn build_frame(body: &[u8]) -> Vec<u8> {
@@ -650,11 +921,14 @@ mod tests {
 
     #[test]
     fn test_paired_data_tag_covers_spec_pairs() {
-        assert_eq!(paired_data_tag(95), Some(96));
-        assert_eq!(paired_data_tag(93), Some(89));
-        assert_eq!(paired_data_tag(90), Some(91));
-        assert_eq!(paired_data_tag(354), Some(355));
-        assert_eq!(paired_data_tag(621), Some(622));
+        // One from each version band the table spans.
+        assert_eq!(paired_data_tag(95), Some(96)); // 4.0
+        assert_eq!(paired_data_tag(93), Some(89)); // 4.0, length tag above data tag
+        assert_eq!(paired_data_tag(354), Some(355)); // 4.2
+        assert_eq!(paired_data_tag(621), Some(622)); // 4.3
+        assert_eq!(paired_data_tag(1397), Some(1398)); // 5.0 SP1
+        assert_eq!(paired_data_tag(1678), Some(1697)); // 5.0 SP2, non-adjacent
+        assert_eq!(paired_data_tag(43111), Some(42982)); // 5.0 SP2, five digits
         assert_eq!(paired_data_tag(35), None);
         // No tag is both a length tag and a data tag.
         for (_, data_tag) in LENGTH_DATA_PAIRS {
@@ -664,18 +938,59 @@ mod tests {
 
     #[test]
     fn test_paired_data_tag_matches_the_spec_table() {
-        // The reference table is the FIX 4.4 spec's complete `type='DATA'` set.
-        // Cross-checking it against the match arms catches drift in either.
+        // The reference table is the complete `type='DATA'`/`type='XMLDATA'`
+        // set from FIX 4.0 through 5.0 SP2. Cross-checking it against the match
+        // arms catches drift in either.
         for (length_tag, data_tag) in LENGTH_DATA_PAIRS {
             assert_eq!(paired_data_tag(length_tag), Some(data_tag));
         }
         // Nothing outside the table is treated as a length tag.
         let length_tags: Vec<u32> = LENGTH_DATA_PAIRS.iter().map(|(len, _)| *len).collect();
-        for tag in 1..=700u32 {
+        for tag in candidate_tags() {
             if !length_tags.contains(&tag) {
                 assert_eq!(paired_data_tag(tag), None, "tag {tag} must not be paired");
             }
         }
+    }
+
+    #[test]
+    fn test_length_data_pairs_is_a_bijection() {
+        // A length tag framing two data fields, or a data field claimed by two
+        // length tags, would make the framing ambiguous.
+        let length_tags: Vec<u32> = LENGTH_DATA_PAIRS.iter().map(|(len, _)| *len).collect();
+        let data_tags: Vec<u32> = LENGTH_DATA_PAIRS.iter().map(|(_, data)| *data).collect();
+        for (index, tag) in length_tags.iter().enumerate() {
+            assert_eq!(
+                length_tags.iter().position(|other| other == tag),
+                Some(index),
+                "length tag {tag} appears twice"
+            );
+            assert!(
+                !data_tags.contains(tag),
+                "tag {tag} is both length and data"
+            );
+        }
+        for (index, tag) in data_tags.iter().enumerate() {
+            assert_eq!(
+                data_tags.iter().position(|other| other == tag),
+                Some(index),
+                "data tag {tag} appears twice"
+            );
+        }
+    }
+
+    #[test]
+    fn test_table_guards_match_the_table_minimums() {
+        // Both lookups short-circuit below their bound, so a pair added beneath
+        // one would be silently unreachable.
+        assert_eq!(
+            LENGTH_DATA_PAIRS.iter().map(|(len, _)| *len).min(),
+            Some(FIRST_LENGTH_TAG)
+        );
+        assert_eq!(
+            LENGTH_DATA_PAIRS.iter().map(|(_, data)| *data).min(),
+            Some(FIRST_DATA_TAG)
+        );
     }
 
     #[test]
@@ -977,6 +1292,69 @@ mod tests {
     }
 
     #[test]
+    fn test_decode_post_fix44_data_field_with_embedded_soh_roundtrips() {
+        // 1397/1398 EncodedMktSegmDescLen / EncodedMktSegmDesc, added in
+        // FIX 5.0 SP1: before the table covered it the payload's SOH split the
+        // value and "9=999" was read as a second BodyLength field.
+        let encoded: &[u8] = b"seg\x019=999\x01x";
+        let mut body = Vec::new();
+        body.extend_from_slice(b"35=A\x01");
+        body.extend_from_slice(format!("1397={}\x01", encoded.len()).as_bytes());
+        body.extend_from_slice(b"1398=");
+        body.extend_from_slice(encoded);
+        body.push(SOH);
+        body.extend_from_slice(b"58=after\x01");
+        let msg = build_frame(&body);
+
+        let Ok(decoded) = Decoder::new(&msg).decode() else {
+            panic!("frame with EncodedMktSegmDesc must decode");
+        };
+        assert_eq!(decoded.get_field(1398).map(|f| f.value), Some(encoded));
+        assert_eq!(decoded.get_field_str(58), Some("after"));
+        // 8, 9, 35, 1397, 1398, 58 — no phantom field from inside the payload.
+        assert_eq!(decoded.field_count(), 6);
+    }
+
+    #[test]
+    fn test_decode_five_digit_data_field_with_embedded_soh_roundtrips() {
+        // 43111/42982 UnderlyingPaymentStreamFormulaLength /
+        // UnderlyingPaymentStreamFormula: a FIX 5.0 SP2 pair in the 40000+
+        // band whose length tag is numerically above its data tag.
+        let formula: &[u8] = b"<f a=\"1\"/>\x01<g/>";
+        let mut body = Vec::new();
+        body.extend_from_slice(b"35=A\x01");
+        body.extend_from_slice(format!("43111={}\x01", formula.len()).as_bytes());
+        body.extend_from_slice(b"42982=");
+        body.extend_from_slice(formula);
+        body.push(SOH);
+        body.extend_from_slice(b"58=after\x01");
+        let msg = build_frame(&body);
+
+        let Ok(decoded) = Decoder::new(&msg).decode() else {
+            panic!("frame with UnderlyingPaymentStreamFormula must decode");
+        };
+        assert_eq!(decoded.get_field(42982).map(|f| f.value), Some(formula));
+        assert_eq!(decoded.get_field_str(58), Some("after"));
+        assert_eq!(decoded.field_count(), 6);
+    }
+
+    #[test]
+    fn test_decode_post_fix44_data_field_truncated_payload_is_typed_error() {
+        // The hardening the table buys applies to the new pairs too: a count
+        // reaching past the body is rejected, not silently clamped.
+        let msg = build_frame(b"35=A\x011401=20\x011402=abc\x01");
+
+        assert_eq!(
+            Decoder::new(&msg).decode().err(),
+            Some(DecodeError::InvalidDataLength {
+                data_tag: 1402,
+                declared: 20,
+                available: 4,
+            })
+        );
+    }
+
+    #[test]
     fn test_decode_raw_data_truncated_payload_is_typed_error() {
         // Declares 20 bytes but only 3 are present before the terminator.
         let mut body = Vec::new();
@@ -1275,7 +1653,7 @@ mod tests {
             );
         }
         let data_tags: Vec<u32> = LENGTH_DATA_PAIRS.iter().map(|(_, data)| *data).collect();
-        for tag in 1..=700u32 {
+        for tag in candidate_tags() {
             if !data_tags.contains(&tag) {
                 assert!(!is_data_tag(tag), "tag {tag} must not be a DATA field");
             }

--- a/ironfix-tagvalue/src/encoder.rs
+++ b/ironfix-tagvalue/src/encoder.rs
@@ -1235,27 +1235,11 @@ mod tests {
 
     #[test]
     fn test_encoder_put_data_round_trips_every_spec_pair() {
-        // Each pair the decoder frames by count must also be emittable.
-        let pairs = [
-            (90u32, 91u32),
-            (93, 89),
-            (95, 96),
-            (212, 213),
-            (348, 349),
-            (350, 351),
-            (352, 353),
-            (354, 355),
-            (356, 357),
-            (358, 359),
-            (360, 361),
-            (362, 363),
-            (364, 365),
-            (445, 446),
-            (618, 619),
-            (621, 622),
-        ];
+        // Each pair the decoder frames by count must also be emittable. Walking
+        // the decoder's own reference table means a pair added on one side
+        // cannot be forgotten on the other.
         let payload: &[u8] = b"\x01=\x01";
-        for (length_tag, data_tag) in pairs {
+        for (length_tag, data_tag) in crate::decoder::LENGTH_DATA_PAIRS {
             let mut encoder = Encoder::new("FIX.4.4");
             encoder.put_str(35, "A");
             encoder.put_data(length_tag, data_tag, payload);


### PR DESCRIPTION
## Summary

Extends Length/Data framing from FIX 4.4's 16 pairs to the 83 the specification defines through 5.0 SP2.

Closes #27.

## Stack

- **Base branch:** `stack/12-tagvalue-encoder` (PR #36)

## Why it matters

A FIX `DATA` field is a counted byte string whose content may **legally contain SOH and `=`**, so the decoder frames it by the count its paired `LENGTH` field declares rather than scanning for a delimiter. The pair table covered FIX 4.4 only, while the crate advertises 4.0 through 5.0 SP2 — so any `DATA` field introduced after 4.4 fell back to an SOH scan, which is exactly the truncation and phantom-field injection that framing exists to prevent.

## How the pairs were derived

Not guessed. Each was taken from the QuickFIX dictionary for its version: for every `type='DATA'` or `type='XMLDATA'` field, the `type='LENGTH'` field immediately preceding it in every message and component that carries it. Three invariants were checked across the whole set — every `DATA` field resolves to exactly one `LENGTH` field, no `LENGTH` field frames two different `DATA` fields, and no tag is both. Tag numbers are never reused across FIX versions, so the union is a single table rather than one per version.

A wrong pair would be worse than the gap it closes: it would count-frame a field that carries no count, corrupting a legitimate message.

## What still falls back to an SOH scan

Documented on the function rather than left to be discovered:

- **User-defined fields** (the 5000–9999 and 20000+ ranges FIX reserves for bilateral use). This one cannot be closed by a fixed table at all — the tag number and its type are a private agreement between two counterparties, not specification — so it would need a per-session extension the caller supplies.
- **Anything an Extension Pack adds after 5.0 SP2.**

## Structure

`ironfix-tagvalue` still does not depend on `ironfix-dictionary`: Length/Data pairing is wire *syntax*, a fixed spec-defined tag set, not schema. The production lookup remains a `const fn` `match` (indexing a const array inside a `const fn` would be unchecked indexing, which the rules ban), and the test module's reference table cross-checks the arms so the two cannot drift. The encoder's `put_data` validates against the same table, so the new pairs work in both directions.

## Tests

Workspace goes to **412 passing**.

## Verification

```
cargo test --workspace                                    # 412 passed
cargo clippy --all-targets --all-features -- -D warnings  # clean
cargo fmt --all --check                                   # clean
make doc                                                  # clean
```
