### PR TITLE
fix(dictionary): make the schema the authority it is supposed to be

### DIFF
--- a/ironfix-dictionary/src/lib.rs
+++ b/ironfix-dictionary/src/lib.rs
@@ -12,7 +12,9 @@
 //! - **Schema definitions**: field, message, component and repeating-group
 //!   definitions ([`schema`])
 //! - **Dictionary parsing**: a QuickFIX XML loader
-//!   ([`Dictionary::from_quickfix_xml`]) with a component-recursion depth guard
+//!   ([`Dictionary::from_quickfix_xml`]) with a component-recursion depth guard.
+//!   Loading is treated as untrusted-input parsing: see the [`loader`] module
+//!   docs for the ceilings that bound it.
 //! - **Runtime validation**: message validation against dictionary rules
 //!   ([`Validator`]) — known message type, defined and allowed tags, required
 //!   fields, enum values, repeating-group count and delimiter
@@ -30,14 +32,18 @@
 //! `ironfix-engine` nor `ironfix-transport` validates against a dictionary — a
 //! message that decodes successfully has not been schema-checked unless you
 //! call the validator yourself.
+//!
+//! [`FieldRef`] here is the schema's *reference to a field definition*, not
+//! `ironfix_core::field::FieldRef`, which is a field borrowed from a decoded
+//! buffer. Both names exist in the workspace; always qualify them.
 
 pub mod loader;
 pub mod schema;
 pub mod validator;
 
-pub use loader::DictionaryError;
+pub use loader::{DefinitionKind, DictionaryError, MAX_COMPONENT_DEPTH, MAX_NESTING_DEPTH};
 pub use schema::{
-    ComponentDef, Dictionary, FieldDef, FieldRef, FieldType, GroupDef, MessageCategory, MessageDef,
-    Version,
+    ComponentDef, ComponentRef, Dictionary, FieldDef, FieldRef, FieldType, GroupDef,
+    MessageCategory, MessageDef, UnknownFieldType, Version,
 };
-pub use validator::{ValidationError, Validator};
+pub use validator::{MAX_SCOPE_DEPTH, MAX_SCOPE_NODES, ValidationError, Validator};

--- a/ironfix-dictionary/src/loader.rs
+++ b/ironfix-dictionary/src/loader.rs
@@ -12,30 +12,84 @@
 //!
 //! Venue-specific dialects can be loaded from their own QuickFIX XML files
 //! with [`Dictionary::from_quickfix_xml`].
+//!
+//! # Untrusted input
+//!
+//! A dictionary file is parser input like any wire message, so the loader is
+//! written to the same standard as the decoders: every malformed document
+//! maps to a typed [`DictionaryError`], never to a panic, an unbounded
+//! recursion, or an allocation sized from the document. Two ceilings bound
+//! the work:
+//!
+//! - [`MAX_NESTING_DEPTH`] caps physical XML element nesting, so a file of
+//!   deeply nested `<group>` elements is rejected instead of exhausting the
+//!   stack.
+//! - [`MAX_COMPONENT_DEPTH`] caps how far component references may chain.
+//!
+//! Reference cycles among components are rejected up front
+//! ([`DictionaryError::ComponentCycle`]), dangling component references are
+//! rejected ([`DictionaryError::UnknownComponent`]), and duplicate
+//! definitions are rejected rather than silently overwriting each other
+//! ([`DictionaryError::DuplicateDefinition`]).
 
 use crate::schema::{
-    ComponentDef, Dictionary, FieldDef, FieldRef, FieldType, GroupDef, MessageCategory, MessageDef,
-    Version,
+    ComponentDef, ComponentRef, Dictionary, FieldDef, FieldRef, FieldType, GroupDef,
+    MessageCategory, MessageDef, Version,
 };
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::{Reader, XmlVersion};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::fmt;
 use std::sync::OnceLock;
 
-/// Maximum component nesting depth accepted by the resolver.
+/// Maximum component reference chain length accepted by the loader.
 ///
-/// Guards against reference cycles in malformed dictionaries.
-const MAX_COMPONENT_DEPTH: usize = 32;
+/// A component whose expansion needs more than this many hops is rejected
+/// with [`DictionaryError::NestingTooDeep`]; a component that references
+/// itself, directly or transitively, is rejected with
+/// [`DictionaryError::ComponentCycle`].
+pub const MAX_COMPONENT_DEPTH: usize = 32;
+
+/// Maximum physical XML element nesting depth accepted by the loader.
+///
+/// Bounds the loader's recursion over `<group>`, `<component>`, and
+/// `<field>` elements so that a hostile document of deeply nested elements
+/// is rejected with [`DictionaryError::NestingTooDeep`] instead of
+/// overflowing the stack.
+pub const MAX_NESTING_DEPTH: usize = 32;
 
 /// Embedded QuickFIX FIX 4.4 specification.
 ///
 /// Source: <https://github.com/quickfix/quickfix/blob/master/spec/FIX44.xml>
 const FIX44_XML: &str = include_str!("../spec/FIX44.xml");
 
-static FIX44_DICT: OnceLock<Dictionary> = OnceLock::new();
+static FIX44_DICT: OnceLock<Result<Dictionary, DictionaryError>> = OnceLock::new();
+
+/// The kind of definition a [`DictionaryError::DuplicateDefinition`] refers to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DefinitionKind {
+    /// A `<field>` definition, keyed by name.
+    Field,
+    /// A `<message>` definition, keyed by `msgtype`.
+    Message,
+    /// A `<component>` definition, keyed by name.
+    Component,
+}
+
+impl fmt::Display for DefinitionKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            Self::Field => "field",
+            Self::Message => "message",
+            Self::Component => "component",
+        };
+        f.write_str(name)
+    }
+}
 
 /// Errors produced while loading a dictionary from XML.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
 pub enum DictionaryError {
     /// The XML could not be parsed.
     #[error("XML parse error: {0}")]
@@ -63,9 +117,43 @@ pub enum DictionaryError {
     /// A group has no members, so its delimiter cannot be determined.
     #[error("empty group `{0}`: cannot determine delimiter tag")]
     EmptyGroup(String),
-    /// Components are nested too deeply (likely a reference cycle).
-    #[error("component nesting too deep resolving `{0}` (reference cycle?)")]
+    /// A component references itself, directly or through other components.
+    #[error("component `{0}` is part of a reference cycle")]
     ComponentCycle(String),
+    /// Elements or component references nest past the loader's ceiling.
+    #[error("nesting too deep at `{element}` (limit {limit})")]
+    NestingTooDeep {
+        /// The element or component name at which the ceiling was reached.
+        element: String,
+        /// The ceiling that was exceeded.
+        limit: usize,
+    },
+    /// A field declares a data type that is not a known FIX type.
+    #[error("field `{field}` declares unknown type `{field_type}`")]
+    UnknownFieldType {
+        /// Name of the offending field.
+        field: String,
+        /// The unrecognised type name, as spelled in the document.
+        field_type: String,
+    },
+    /// The same name or message type is defined more than once.
+    #[error("duplicate {kind} definition `{name}`")]
+    DuplicateDefinition {
+        /// Which kind of definition was duplicated.
+        kind: DefinitionKind,
+        /// The duplicated name (or `msgtype`, for a message).
+        name: String,
+    },
+    /// Two field definitions claim the same tag number.
+    #[error("fields `{existing}` and `{duplicate}` both claim tag {tag}")]
+    DuplicateFieldTag {
+        /// The contested tag number.
+        tag: u32,
+        /// Name of the field that claimed the tag first.
+        existing: String,
+        /// Name of the field that claimed it again.
+        duplicate: String,
+    },
 }
 
 impl Dictionary {
@@ -74,11 +162,21 @@ impl Dictionary {
     /// The dictionary is parsed from the bundled QuickFIX `FIX44.xml`
     /// specification on first use and cached for the lifetime of the
     /// process.
-    #[must_use]
-    pub fn fix44() -> &'static Self {
-        FIX44_DICT.get_or_init(|| {
-            Self::from_quickfix_xml(FIX44_XML).expect("embedded FIX 4.4 dictionary is valid")
-        })
+    ///
+    /// FIX 4.4 is the only embedded dictionary. Every other version has to be
+    /// supplied by the caller through [`Dictionary::from_quickfix_xml`].
+    ///
+    /// # Errors
+    /// Returns [`DictionaryError`] if the bundled specification fails to
+    /// load. That cannot happen for an unmodified checkout — `cargo test`
+    /// loads it — so the result is a guarantee rather than a case callers
+    /// are expected to recover from; it exists so that the crate has no
+    /// panicking path at all.
+    pub fn fix44() -> Result<&'static Self, DictionaryError> {
+        match FIX44_DICT.get_or_init(|| load(FIX44_XML)) {
+            Ok(dict) => Ok(dict),
+            Err(err) => Err(err.clone()),
+        }
     }
 
     /// Loads a dictionary from a QuickFIX-format XML specification.
@@ -118,6 +216,8 @@ enum Item {
     Component {
         /// Component name.
         name: String,
+        /// Whether the component is required at this reference.
+        required: bool,
     },
 }
 
@@ -188,7 +288,21 @@ fn parse_version(attrs: &HashMap<String, String>) -> Result<Version, DictionaryE
 }
 
 /// Parses members until the matching end tag `end` is consumed.
-fn parse_items(reader: &mut Reader<&[u8]>, end: &[u8]) -> Result<Vec<Item>, DictionaryError> {
+///
+/// `depth` is the physical XML nesting depth of `end` itself; recursion is
+/// refused past [`MAX_NESTING_DEPTH`], which is what keeps a hostile document
+/// of nested `<group>` elements from exhausting the stack.
+fn parse_items(
+    reader: &mut Reader<&[u8]>,
+    end: &[u8],
+    depth: usize,
+) -> Result<Vec<Item>, DictionaryError> {
+    if depth > MAX_NESTING_DEPTH {
+        return Err(DictionaryError::NestingTooDeep {
+            element: String::from_utf8_lossy(end).into_owned(),
+            limit: MAX_NESTING_DEPTH,
+        });
+    }
     let mut items = Vec::new();
     loop {
         match reader.read_event().map_err(xml_err)? {
@@ -201,6 +315,7 @@ fn parse_items(reader: &mut Reader<&[u8]>, end: &[u8]) -> Result<Vec<Item>, Dict
                     }),
                     b"component" => items.push(Item::Component {
                         name: required_attr(&attrs, "component", "name")?,
+                        required: is_required(&attrs),
                     }),
                     b"group" => items.push(Item::Group {
                         name: required_attr(&attrs, "group", "name")?,
@@ -214,7 +329,7 @@ fn parse_items(reader: &mut Reader<&[u8]>, end: &[u8]) -> Result<Vec<Item>, Dict
                 let attrs = attr_map(&e)?;
                 match e.name().as_ref() {
                     b"group" => {
-                        let inner = parse_items(reader, b"group")?;
+                        let inner = parse_items(reader, b"group", depth + 1)?;
                         items.push(Item::Group {
                             name: required_attr(&attrs, "group", "name")?,
                             required: is_required(&attrs),
@@ -223,16 +338,17 @@ fn parse_items(reader: &mut Reader<&[u8]>, end: &[u8]) -> Result<Vec<Item>, Dict
                     }
                     b"field" => {
                         // Field references never have meaningful children here.
-                        parse_items(reader, b"field")?;
+                        parse_items(reader, b"field", depth + 1)?;
                         items.push(Item::Field {
                             name: required_attr(&attrs, "field", "name")?,
                             required: is_required(&attrs),
                         });
                     }
                     b"component" => {
-                        parse_items(reader, b"component")?;
+                        parse_items(reader, b"component", depth + 1)?;
                         items.push(Item::Component {
                             name: required_attr(&attrs, "component", "name")?,
+                            required: is_required(&attrs),
                         });
                     }
                     _ => {}
@@ -290,9 +406,17 @@ fn field_def(
         .parse()
         .map_err(|_| DictionaryError::InvalidTag(number.clone()))?;
     let name = required_attr(attrs, "field", "name")?;
-    let field_type = required_attr(attrs, "field", "type")?
-        .parse::<FieldType>()
-        .unwrap_or(FieldType::String);
+    let declared_type = required_attr(attrs, "field", "type")?;
+    // An unrecognised type is rejected rather than quietly demoted to
+    // STRING: the dictionary is what answers "what does this tag mean", and
+    // a silent demotion would drop the field's format and enum semantics.
+    let field_type =
+        declared_type
+            .parse::<FieldType>()
+            .map_err(|_| DictionaryError::UnknownFieldType {
+                field: name.clone(),
+                field_type: declared_type.clone(),
+            })?;
 
     let mut def = FieldDef::new(tag, name, field_type);
     if !values.is_empty() {
@@ -326,15 +450,22 @@ impl Resolver<'_> {
 
     /// Returns the tag of the first field reachable in document order,
     /// descending into component references.
+    ///
+    /// Reference cycles are already rejected by [`check_component_graph`]
+    /// before any resolution starts; the depth ceiling here is a second,
+    /// independent bound on the recursion.
     fn first_tag(&self, items: &[Item], depth: usize) -> Result<Option<u32>, DictionaryError> {
         for item in items {
             match item {
                 Item::Field { name, .. } | Item::Group { name, .. } => {
                     return self.tag(name).map(Some);
                 }
-                Item::Component { name } => {
+                Item::Component { name, .. } => {
                     if depth >= MAX_COMPONENT_DEPTH {
-                        return Err(DictionaryError::ComponentCycle(name.clone()));
+                        return Err(DictionaryError::NestingTooDeep {
+                            element: name.clone(),
+                            limit: MAX_COMPONENT_DEPTH,
+                        });
                     }
                     let inner = self
                         .components
@@ -371,12 +502,17 @@ impl Resolver<'_> {
         })
     }
 
-    /// Splits items into field references, resolved groups, and component names.
+    /// Splits items into field references, resolved groups, and component
+    /// references.
+    ///
+    /// Every component reference is existence-checked here, so a typo'd
+    /// `<component name='Nope'/>` fails the load instead of silently
+    /// disappearing from the schema at validation time.
     #[allow(clippy::type_complexity)]
     fn split(
         &self,
         items: &[Item],
-    ) -> Result<(Vec<FieldRef>, Vec<GroupDef>, Vec<String>), DictionaryError> {
+    ) -> Result<(Vec<FieldRef>, Vec<GroupDef>, Vec<ComponentRef>), DictionaryError> {
         let mut fields = Vec::new();
         let mut groups = Vec::new();
         let mut components = Vec::new();
@@ -388,11 +524,89 @@ impl Resolver<'_> {
                     required,
                     items,
                 } => groups.push(self.group(name, *required, items)?),
-                Item::Component { name } => components.push(name.clone()),
+                Item::Component { name, required } => {
+                    if !self.components.contains_key(name) {
+                        return Err(DictionaryError::UnknownComponent(name.clone()));
+                    }
+                    components.push(ComponentRef::new(name.clone(), *required));
+                }
             }
         }
         Ok((fields, groups, components))
     }
+}
+
+/// Traversal state of a component during cycle detection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VisitState {
+    /// On the current depth-first path: reaching it again is a cycle.
+    InProgress,
+    /// Fully expanded already, and acyclic.
+    Done,
+}
+
+/// Rejects reference cycles and dangling references in the component graph.
+///
+/// Runs before any resolution, so the rest of the loader (and every consumer
+/// of the resulting [`Dictionary`]) can walk component references knowing the
+/// graph is a DAG of bounded depth. Components are visited in document order
+/// (`order`) and memoised, which keeps the walk linear in the number of
+/// references.
+fn check_component_graph(
+    components: &HashMap<String, Vec<Item>>,
+    order: &[String],
+) -> Result<(), DictionaryError> {
+    let mut state: HashMap<String, VisitState> = HashMap::new();
+    for name in order {
+        visit_component(name, components, &mut state, 0)?;
+    }
+    Ok(())
+}
+
+/// Depth-first visit of one component definition.
+fn visit_component(
+    name: &str,
+    components: &HashMap<String, Vec<Item>>,
+    state: &mut HashMap<String, VisitState>,
+    depth: usize,
+) -> Result<(), DictionaryError> {
+    match state.get(name) {
+        Some(VisitState::Done) => return Ok(()),
+        Some(VisitState::InProgress) => {
+            return Err(DictionaryError::ComponentCycle(name.to_string()));
+        }
+        None => {}
+    }
+    let Some(items) = components.get(name) else {
+        return Err(DictionaryError::UnknownComponent(name.to_string()));
+    };
+    state.insert(name.to_string(), VisitState::InProgress);
+    visit_items(items, components, state, depth + 1)?;
+    state.insert(name.to_string(), VisitState::Done);
+    Ok(())
+}
+
+/// Depth-first visit of a member list, descending into groups and components.
+fn visit_items(
+    items: &[Item],
+    components: &HashMap<String, Vec<Item>>,
+    state: &mut HashMap<String, VisitState>,
+    depth: usize,
+) -> Result<(), DictionaryError> {
+    if depth > MAX_COMPONENT_DEPTH {
+        return Err(DictionaryError::NestingTooDeep {
+            element: "component".to_string(),
+            limit: MAX_COMPONENT_DEPTH,
+        });
+    }
+    for item in items {
+        match item {
+            Item::Field { .. } => {}
+            Item::Group { items, .. } => visit_items(items, components, state, depth + 1)?,
+            Item::Component { name, .. } => visit_component(name, components, state, depth)?,
+        }
+    }
+    Ok(())
 }
 
 fn load(xml: &str) -> Result<Dictionary, DictionaryError> {
@@ -410,8 +624,8 @@ fn load(xml: &str) -> Result<Dictionary, DictionaryError> {
         match reader.read_event().map_err(xml_err)? {
             Event::Start(e) => match e.name().as_ref() {
                 b"fix" => version = Some(parse_version(&attr_map(&e)?)?),
-                b"header" => header_items = parse_items(&mut reader, b"header")?,
-                b"trailer" => trailer_items = parse_items(&mut reader, b"trailer")?,
+                b"header" => header_items = parse_items(&mut reader, b"header", 1)?,
+                b"trailer" => trailer_items = parse_items(&mut reader, b"trailer", 1)?,
                 b"message" => {
                     let attrs = attr_map(&e)?;
                     let category = if attrs.get("msgcat").map(String::as_str) == Some("admin") {
@@ -423,13 +637,19 @@ fn load(xml: &str) -> Result<Dictionary, DictionaryError> {
                         name: required_attr(&attrs, "message", "name")?,
                         msg_type: required_attr(&attrs, "message", "msgtype")?,
                         category,
-                        items: parse_items(&mut reader, b"message")?,
+                        items: parse_items(&mut reader, b"message", 1)?,
                     });
                 }
                 b"component" => {
                     let attrs = attr_map(&e)?;
                     let name = required_attr(&attrs, "component", "name")?;
-                    let items = parse_items(&mut reader, b"component")?;
+                    let items = parse_items(&mut reader, b"component", 1)?;
+                    if component_irs.contains_key(&name) {
+                        return Err(DictionaryError::DuplicateDefinition {
+                            kind: DefinitionKind::Component,
+                            name,
+                        });
+                    }
                     component_order.push(name.clone());
                     component_irs.insert(name, items);
                 }
@@ -444,8 +664,25 @@ fn load(xml: &str) -> Result<Dictionary, DictionaryError> {
     let version =
         version.ok_or_else(|| DictionaryError::Xml("missing root <fix> element".to_string()))?;
 
+    check_component_graph(&component_irs, &component_order)?;
+
     let mut dict = Dictionary::new(version);
     for def in field_defs {
+        // Last-wins insertion would leave name and tag lookups pointing at
+        // different definitions, so a duplicate is a load error.
+        if dict.fields_by_name.contains_key(&def.name) {
+            return Err(DictionaryError::DuplicateDefinition {
+                kind: DefinitionKind::Field,
+                name: def.name,
+            });
+        }
+        if let Some(existing) = dict.get_field(def.tag) {
+            return Err(DictionaryError::DuplicateFieldTag {
+                tag: def.tag,
+                existing: existing.name.clone(),
+                duplicate: def.name,
+            });
+        }
         dict.add_field(def);
     }
 
@@ -459,7 +696,10 @@ fn load(xml: &str) -> Result<Dictionary, DictionaryError> {
 
     let mut components = Vec::with_capacity(component_order.len());
     for name in &component_order {
-        let (fields, groups, nested) = resolver.split(&component_irs[name])?;
+        let items = component_irs
+            .get(name)
+            .ok_or_else(|| DictionaryError::UnknownComponent(name.clone()))?;
+        let (fields, groups, nested) = resolver.split(items)?;
         components.push(ComponentDef {
             name: name.clone(),
             fields,
@@ -469,7 +709,14 @@ fn load(xml: &str) -> Result<Dictionary, DictionaryError> {
     }
 
     let mut messages = Vec::with_capacity(message_irs.len());
+    let mut seen_msg_types: HashSet<&str> = HashSet::new();
     for ir in &message_irs {
+        if !seen_msg_types.insert(ir.msg_type.as_str()) {
+            return Err(DictionaryError::DuplicateDefinition {
+                kind: DefinitionKind::Message,
+                name: ir.msg_type.clone(),
+            });
+        }
         let (fields, groups, comps) = resolver.split(&ir.items)?;
         messages.push(MessageDef {
             msg_type: ir.msg_type.clone(),
@@ -498,96 +745,174 @@ fn load(xml: &str) -> Result<Dictionary, DictionaryError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fmt::Debug;
+
+    /// Unwraps a `Result` with test context instead of `.unwrap()`.
+    #[track_caller]
+    fn ok<T, E: Debug>(result: Result<T, E>, what: &str) -> T {
+        match result {
+            Ok(value) => value,
+            Err(err) => panic!("{what}: {err:?}"),
+        }
+    }
+
+    /// Unwraps an `Option` with test context instead of `.expect()`.
+    #[track_caller]
+    fn some<T>(value: Option<T>, what: &str) -> T {
+        match value {
+            Some(value) => value,
+            None => panic!("{what}"),
+        }
+    }
+
+    /// Returns the error a load is expected to fail with.
+    #[track_caller]
+    fn load_err(xml: &str) -> DictionaryError {
+        match Dictionary::from_quickfix_xml(xml) {
+            Ok(_) => panic!("expected the dictionary to be rejected, but it loaded"),
+            Err(err) => err,
+        }
+    }
+
+    /// Returns the embedded FIX 4.4 dictionary for a test.
+    #[track_caller]
+    fn fix44() -> &'static Dictionary {
+        ok(Dictionary::fix44(), "embedded FIX 4.4 dictionary loads")
+    }
 
     #[test]
     fn test_fix44_loads() {
-        let dict = Dictionary::fix44();
+        let dict = fix44();
         assert_eq!(dict.version, Version::Fix44);
 
         // Cached: same instance on every call.
-        assert!(std::ptr::eq(dict, Dictionary::fix44()));
+        assert!(std::ptr::eq(dict, fix44()));
     }
 
     #[test]
     fn test_fix44_fields() {
-        let dict = Dictionary::fix44();
+        let dict = fix44();
 
-        let msg_type = dict.get_field(35).expect("MsgType defined");
+        let msg_type = some(dict.get_field(35), "MsgType defined");
         assert_eq!(msg_type.name, "MsgType");
 
-        let cl_ord_id = dict.get_field_by_name("ClOrdID").expect("ClOrdID defined");
+        let cl_ord_id = some(dict.get_field_by_name("ClOrdID"), "ClOrdID defined");
         assert_eq!(cl_ord_id.tag, 11);
 
-        let side = dict.get_field(54).expect("Side defined");
-        let values = side.values.as_ref().expect("Side has enum values");
+        let side = some(dict.get_field(54), "Side defined");
+        let values = some(side.values.as_ref(), "Side has enum values");
         assert!(values.contains_key("1"));
         assert!(values.contains_key("2"));
         assert!(!values.contains_key("X"));
     }
 
     #[test]
-    fn test_fix44_header_and_trailer() {
-        let dict = Dictionary::fix44();
+    fn test_fix44_multiple_value_string_fields_keep_their_type() {
+        // The vendored FIX 4.4 dictionary spells this type
+        // `MULTIPLEVALUESTRING`; every one of its eight fields must survive
+        // the load as `MultipleStringValue`, not as a plain String.
+        let dict = fix44();
+        for (tag, name) in [
+            (18, "ExecInst"),
+            (276, "QuoteCondition"),
+            (277, "TradeCondition"),
+            (286, "OpenCloseSettlFlag"),
+            (291, "FinancialStatus"),
+            (292, "CorporateAction"),
+            (529, "OrderRestrictions"),
+            (546, "Scope"),
+        ] {
+            let def = some(dict.get_field(tag), "multi-value field defined");
+            assert_eq!(def.name, name);
+            assert_eq!(
+                def.field_type,
+                FieldType::MultipleStringValue,
+                "{name}({tag}) lost its multi-value type"
+            );
+        }
+    }
 
-        let sender = dict
-            .header
-            .iter()
-            .find(|f| f.name == "SenderCompID")
-            .expect("SenderCompID in header");
+    #[test]
+    fn test_fix44_header_and_trailer() {
+        let dict = fix44();
+
+        let sender = some(
+            dict.header.iter().find(|f| f.name == "SenderCompID"),
+            "SenderCompID in header",
+        );
         assert_eq!(sender.tag, 49);
         assert!(sender.required);
 
-        let hops = dict
-            .header_groups
-            .iter()
-            .find(|g| g.name == "NoHops")
-            .expect("NoHops group in header");
+        let hops = some(
+            dict.header_groups.iter().find(|g| g.name == "NoHops"),
+            "NoHops group in header",
+        );
         assert_eq!(hops.count_tag, 627);
         assert_eq!(hops.delimiter_tag, 628);
         assert!(!hops.required);
 
-        let checksum = dict
-            .trailer
-            .iter()
-            .find(|f| f.name == "CheckSum")
-            .expect("CheckSum in trailer");
+        let checksum = some(
+            dict.trailer.iter().find(|f| f.name == "CheckSum"),
+            "CheckSum in trailer",
+        );
         assert_eq!(checksum.tag, 10);
         assert!(checksum.required);
     }
 
     #[test]
     fn test_fix44_messages() {
-        let dict = Dictionary::fix44();
+        let dict = fix44();
 
-        let nos = dict.get_message("D").expect("NewOrderSingle defined");
+        let nos = some(dict.get_message("D"), "NewOrderSingle defined");
         assert_eq!(nos.name, "NewOrderSingle");
         assert_eq!(nos.category, MessageCategory::App);
         assert!(nos.fields.iter().any(|f| f.name == "ClOrdID" && f.required));
-        assert!(nos.components.iter().any(|c| c == "Instrument"));
+        assert!(nos.components.iter().any(|c| c.name == "Instrument"));
 
-        let heartbeat = dict.get_message("0").expect("Heartbeat defined");
+        let heartbeat = some(dict.get_message("0"), "Heartbeat defined");
         assert_eq!(heartbeat.category, MessageCategory::Admin);
     }
 
     #[test]
-    fn test_fix44_components_and_groups() {
-        let dict = Dictionary::fix44();
+    fn test_fix44_component_references_keep_their_required_flag() {
+        let dict = fix44();
 
-        let instrument = dict
-            .get_component("Instrument")
-            .expect("Instrument defined");
+        // NewOrderSingle requires <component name='Instrument' required='Y'/>
+        // but only optionally carries Parties.
+        let nos = some(dict.get_message("D"), "NewOrderSingle defined");
+        let instrument = some(
+            nos.components.iter().find(|c| c.name == "Instrument"),
+            "NewOrderSingle references Instrument",
+        );
+        assert!(instrument.required);
+        let parties = some(
+            nos.components.iter().find(|c| c.name == "Parties"),
+            "NewOrderSingle references Parties",
+        );
+        assert!(!parties.required);
+    }
+
+    #[test]
+    fn test_fix44_components_and_groups() {
+        let dict = fix44();
+
+        let instrument = some(dict.get_component("Instrument"), "Instrument defined");
         assert!(instrument.fields.iter().any(|f| f.name == "Symbol"));
 
-        let parties = dict.get_component("Parties").expect("Parties defined");
-        let no_party_ids = parties
-            .groups
-            .iter()
-            .find(|g| g.name == "NoPartyIDs")
-            .expect("NoPartyIDs group");
+        let parties = some(dict.get_component("Parties"), "Parties defined");
+        let no_party_ids = some(
+            parties.groups.iter().find(|g| g.name == "NoPartyIDs"),
+            "NoPartyIDs group",
+        );
         assert_eq!(no_party_ids.count_tag, 453);
         assert_eq!(no_party_ids.delimiter_tag, 448);
         // Nested component reference within the group.
-        assert!(no_party_ids.components.iter().any(|c| c == "PtysSubGrp"));
+        assert!(
+            no_party_ids
+                .components
+                .iter()
+                .any(|c| c.name == "PtysSubGrp")
+        );
     }
 
     #[test]
@@ -638,29 +963,325 @@ mod tests {
     }
 
     #[test]
-    fn test_unsupported_version() {
+    fn test_unsupported_version_is_rejected() {
         let xml = "<fix type='FIX' major='9' minor='9'><fields></fields></fix>";
-        let err = Dictionary::from_quickfix_xml(xml).unwrap_err();
-        assert!(matches!(err, DictionaryError::UnsupportedVersion(_)));
+        assert!(matches!(
+            load_err(xml),
+            DictionaryError::UnsupportedVersion(_)
+        ));
     }
 
     #[test]
-    fn test_unknown_field_reference() {
+    fn test_missing_attribute_is_rejected() {
+        let xml = r"<fix type='FIX' major='4' minor='4'>
+            <header></header><trailer></trailer><messages></messages>
+            <fields><field number='8' type='STRING'/></fields>
+        </fix>";
+        assert_eq!(
+            load_err(xml),
+            DictionaryError::MissingAttribute {
+                element: "field".to_string(),
+                attribute: "name".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_non_numeric_field_number_is_rejected() {
+        let xml = r"<fix type='FIX' major='4' minor='4'>
+            <header></header><trailer></trailer><messages></messages>
+            <fields><field number='8x' name='BeginString' type='STRING'/></fields>
+        </fix>";
+        assert_eq!(load_err(xml), DictionaryError::InvalidTag("8x".to_string()));
+    }
+
+    #[test]
+    fn test_unknown_field_reference_is_rejected() {
         let xml = r"<fix type='FIX' major='4' minor='4'>
             <header><field name='DoesNotExist' required='Y'/></header>
             <trailer></trailer>
             <messages></messages>
             <fields></fields>
         </fix>";
-        let err = Dictionary::from_quickfix_xml(xml).unwrap_err();
         assert_eq!(
-            err,
+            load_err(xml),
             DictionaryError::UnknownFieldName("DoesNotExist".to_string())
         );
     }
 
     #[test]
-    fn test_minimal_dialect() {
+    fn test_unknown_field_type_is_rejected() {
+        let xml = r"<fix type='FIX' major='4' minor='4'>
+            <header></header><trailer></trailer><messages></messages>
+            <fields>
+                <field number='8' name='BeginString' type='NOTATYPE'/>
+            </fields>
+        </fix>";
+        assert_eq!(
+            load_err(xml),
+            DictionaryError::UnknownFieldType {
+                field: "BeginString".to_string(),
+                field_type: "NOTATYPE".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_dangling_component_reference_is_rejected() {
+        let xml = r"<fix type='FIX' major='4' minor='4'>
+            <header></header>
+            <trailer></trailer>
+            <messages>
+                <message name='Ping' msgtype='U1' msgcat='app'>
+                    <component name='Nope' required='N'/>
+                </message>
+            </messages>
+            <components></components>
+            <fields>
+                <field number='112' name='TestReqID' type='STRING'/>
+            </fields>
+        </fix>";
+        assert_eq!(
+            load_err(xml),
+            DictionaryError::UnknownComponent("Nope".to_string())
+        );
+    }
+
+    #[test]
+    fn test_dangling_component_reference_inside_a_component_is_rejected() {
+        let xml = r"<fix type='FIX' major='4' minor='4'>
+            <header></header>
+            <trailer></trailer>
+            <messages></messages>
+            <components>
+                <component name='Outer'>
+                    <component name='Nope' required='N'/>
+                </component>
+            </components>
+            <fields>
+                <field number='112' name='TestReqID' type='STRING'/>
+            </fields>
+        </fix>";
+        assert_eq!(
+            load_err(xml),
+            DictionaryError::UnknownComponent("Nope".to_string())
+        );
+    }
+
+    #[test]
+    fn test_component_cycle_is_rejected() {
+        // Two components that reference each other. Nothing here reaches a
+        // field, so the cycle has to be caught by the graph check rather
+        // than by delimiter discovery.
+        let xml = r"<fix type='FIX' major='4' minor='4'>
+            <header></header>
+            <trailer></trailer>
+            <messages></messages>
+            <components>
+                <component name='Ping'>
+                    <component name='Pong' required='N'/>
+                </component>
+                <component name='Pong'>
+                    <component name='Ping' required='N'/>
+                </component>
+            </components>
+            <fields>
+                <field number='112' name='TestReqID' type='STRING'/>
+            </fields>
+        </fix>";
+        assert!(matches!(load_err(xml), DictionaryError::ComponentCycle(_)));
+    }
+
+    #[test]
+    fn test_self_referential_component_is_rejected() {
+        let xml = r"<fix type='FIX' major='4' minor='4'>
+            <header></header>
+            <trailer></trailer>
+            <messages></messages>
+            <components>
+                <component name='Loop'>
+                    <field name='TestReqID' required='N'/>
+                    <component name='Loop' required='N'/>
+                </component>
+            </components>
+            <fields>
+                <field number='112' name='TestReqID' type='STRING'/>
+            </fields>
+        </fix>";
+        assert_eq!(
+            load_err(xml),
+            DictionaryError::ComponentCycle("Loop".to_string())
+        );
+    }
+
+    #[test]
+    fn test_empty_group_is_rejected() {
+        let xml = r"<fix type='FIX' major='4' minor='4'>
+            <header></header>
+            <trailer></trailer>
+            <messages>
+                <message name='Ping' msgtype='U1' msgcat='app'>
+                    <group name='NoPartyIDs' required='N'></group>
+                </message>
+            </messages>
+            <fields>
+                <field number='453' name='NoPartyIDs' type='NUMINGROUP'/>
+            </fields>
+        </fix>";
+        assert_eq!(
+            load_err(xml),
+            DictionaryError::EmptyGroup("NoPartyIDs".to_string())
+        );
+    }
+
+    #[test]
+    fn test_deeply_nested_groups_are_rejected_without_stack_overflow() {
+        // A hostile document: element nesting far past the ceiling. This must
+        // come back as a typed error rather than exhausting the stack.
+        let depth = MAX_NESTING_DEPTH * 100;
+        let mut xml = String::from(
+            "<fix type='FIX' major='4' minor='4'><header></header><trailer></trailer>\
+             <messages><message name='Ping' msgtype='U1' msgcat='app'>",
+        );
+        for _ in 0..depth {
+            xml.push_str("<group name='NoPartyIDs' required='N'>");
+        }
+        xml.push_str("<field name='TestReqID' required='N'/>");
+        for _ in 0..depth {
+            xml.push_str("</group>");
+        }
+        xml.push_str("</message></messages><fields></fields></fix>");
+
+        assert_eq!(
+            load_err(&xml),
+            DictionaryError::NestingTooDeep {
+                element: "group".to_string(),
+                limit: MAX_NESTING_DEPTH,
+            }
+        );
+    }
+
+    #[test]
+    fn test_long_component_chain_is_rejected() {
+        // A chain of components longer than the component ceiling: acyclic,
+        // so only the depth bound stops it.
+        let mut xml = String::from(
+            "<fix type='FIX' major='4' minor='4'><header></header><trailer></trailer>\
+             <messages></messages><components>",
+        );
+        let links = MAX_COMPONENT_DEPTH + 10;
+        for index in 0..links {
+            xml.push_str(&format!("<component name='C{index}'>"));
+            xml.push_str(&format!("<component name='C{}' required='N'/>", index + 1));
+            xml.push_str("</component>");
+        }
+        xml.push_str(&format!(
+            "<component name='C{links}'><field name='TestReqID' required='N'/></component>"
+        ));
+        xml.push_str(
+            "</components><fields><field number='112' name='TestReqID' type='STRING'/></fields></fix>",
+        );
+
+        assert!(matches!(
+            load_err(&xml),
+            DictionaryError::NestingTooDeep {
+                limit: MAX_COMPONENT_DEPTH,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_duplicate_field_name_is_rejected() {
+        let xml = r"<fix type='FIX' major='4' minor='4'>
+            <header></header><trailer></trailer><messages></messages>
+            <fields>
+                <field number='112' name='TestReqID' type='STRING'/>
+                <field number='113' name='TestReqID' type='STRING'/>
+            </fields>
+        </fix>";
+        assert_eq!(
+            load_err(xml),
+            DictionaryError::DuplicateDefinition {
+                kind: DefinitionKind::Field,
+                name: "TestReqID".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_duplicate_field_tag_is_rejected() {
+        let xml = r"<fix type='FIX' major='4' minor='4'>
+            <header></header><trailer></trailer><messages></messages>
+            <fields>
+                <field number='112' name='TestReqID' type='STRING'/>
+                <field number='112' name='OtherName' type='STRING'/>
+            </fields>
+        </fix>";
+        assert_eq!(
+            load_err(xml),
+            DictionaryError::DuplicateFieldTag {
+                tag: 112,
+                existing: "TestReqID".to_string(),
+                duplicate: "OtherName".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_duplicate_message_type_is_rejected() {
+        let xml = r"<fix type='FIX' major='4' minor='4'>
+            <header></header><trailer></trailer>
+            <messages>
+                <message name='Ping' msgtype='U1' msgcat='app'>
+                    <field name='TestReqID' required='Y'/>
+                </message>
+                <message name='Pong' msgtype='U1' msgcat='app'>
+                    <field name='TestReqID' required='Y'/>
+                </message>
+            </messages>
+            <fields><field number='112' name='TestReqID' type='STRING'/></fields>
+        </fix>";
+        assert_eq!(
+            load_err(xml),
+            DictionaryError::DuplicateDefinition {
+                kind: DefinitionKind::Message,
+                name: "U1".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_duplicate_component_name_is_rejected() {
+        let xml = r"<fix type='FIX' major='4' minor='4'>
+            <header></header><trailer></trailer><messages></messages>
+            <components>
+                <component name='Twice'>
+                    <field name='TestReqID' required='N'/>
+                </component>
+                <component name='Twice'>
+                    <field name='TestReqID' required='N'/>
+                </component>
+            </components>
+            <fields><field number='112' name='TestReqID' type='STRING'/></fields>
+        </fix>";
+        assert_eq!(
+            load_err(xml),
+            DictionaryError::DuplicateDefinition {
+                kind: DefinitionKind::Component,
+                name: "Twice".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_malformed_xml_is_rejected() {
+        let xml = "<fix type='FIX' major='4' minor='4'><header>";
+        assert!(matches!(load_err(xml), DictionaryError::Xml(_)));
+    }
+
+    #[test]
+    fn test_minimal_dialect_loads() {
         let xml = r"<fix type='FIX' major='4' minor='4'>
             <header><field name='BeginString' required='Y'/></header>
             <trailer><field name='CheckSum' required='Y'/></trailer>
@@ -675,9 +1296,9 @@ mod tests {
                 <field number='112' name='TestReqID' type='STRING'/>
             </fields>
         </fix>";
-        let dict = Dictionary::from_quickfix_xml(xml).unwrap();
-        let ping = dict.get_message("U1").expect("custom message defined");
+        let dict = ok(Dictionary::from_quickfix_xml(xml), "dialect loads");
+        let ping = some(dict.get_message("U1"), "custom message defined");
         assert_eq!(ping.name, "Ping");
-        assert_eq!(ping.fields[0].tag, 112);
+        assert_eq!(some(ping.fields.first(), "Ping has a field").tag, 112);
     }
 }

--- a/ironfix-dictionary/src/loader.rs
+++ b/ironfix-dictionary/src/loader.rs
@@ -536,22 +536,36 @@ impl Resolver<'_> {
     }
 }
 
-/// Traversal state of a component during cycle detection.
+/// Traversal state of a component during graph validation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum VisitState {
     /// On the current depth-first path: reaching it again is a cycle.
     InProgress,
-    /// Fully expanded already, and acyclic.
-    Done,
+    /// Fully expanded and acyclic, carrying the height of its subtree — the
+    /// number of nested group/component levels reachable below it, counting
+    /// the component itself. Memoising the measured height rather than a bare
+    /// "done" flag makes the depth ceiling independent of declaration order:
+    /// a leaf-first chain is measured exactly like a root-first one.
+    Done(usize),
 }
 
-/// Rejects reference cycles and dangling references in the component graph.
+/// Rejects reference cycles, dangling references, and over-deep nesting in the
+/// component graph.
 ///
-/// Runs before any resolution, so the rest of the loader (and every consumer
-/// of the resulting [`Dictionary`]) can walk component references knowing the
-/// graph is a DAG of bounded depth. Components are visited in document order
-/// (`order`) and memoised, which keeps the walk linear in the number of
-/// references.
+/// Runs before any resolution, so the rest of the loader — and every consumer
+/// of the resulting [`Dictionary`], including codegen, whose descent has no
+/// ceiling of its own — can walk component references knowing the graph is a
+/// DAG whose depth is bounded by [`MAX_COMPONENT_DEPTH`]. Every component is
+/// entered at depth zero and its measured height is memoised, so the walk is
+/// linear in the number of references and the ceiling is enforced no matter
+/// what order the components are declared in.
+///
+/// # Errors
+///
+/// Returns [`DictionaryError::ComponentCycle`] for a reference cycle,
+/// [`DictionaryError::UnknownComponent`] for a dangling reference, and
+/// [`DictionaryError::NestingTooDeep`] when a component chain is longer than
+/// [`MAX_COMPONENT_DEPTH`].
 fn check_component_graph(
     components: &HashMap<String, Vec<Item>>,
     order: &[String],
@@ -563,15 +577,29 @@ fn check_component_graph(
     Ok(())
 }
 
-/// Depth-first visit of one component definition.
+/// Depth-first visit of one component definition, returning the height of its
+/// subtree: the deepest chain of nested groups and components below it,
+/// counting the component itself.
+///
+/// `depth` bounds the recursion so a long root-first chain from hostile XML is
+/// rejected before it can exhaust the stack. The returned height is memoised
+/// and range-checked, so a leaf-first chain — whose descent stays shallow
+/// because each child is already resolved — is rejected just the same.
+///
+/// # Errors
+///
+/// Returns [`DictionaryError::ComponentCycle`] on re-entry of an in-progress
+/// component, [`DictionaryError::UnknownComponent`] for a dangling reference,
+/// and [`DictionaryError::NestingTooDeep`] once the subtree height exceeds
+/// [`MAX_COMPONENT_DEPTH`].
 fn visit_component(
     name: &str,
     components: &HashMap<String, Vec<Item>>,
     state: &mut HashMap<String, VisitState>,
     depth: usize,
-) -> Result<(), DictionaryError> {
+) -> Result<usize, DictionaryError> {
     match state.get(name) {
-        Some(VisitState::Done) => return Ok(()),
+        Some(VisitState::Done(height)) => return Ok(*height),
         Some(VisitState::InProgress) => {
             return Err(DictionaryError::ComponentCycle(name.to_string()));
         }
@@ -581,32 +609,52 @@ fn visit_component(
         return Err(DictionaryError::UnknownComponent(name.to_string()));
     };
     state.insert(name.to_string(), VisitState::InProgress);
-    visit_items(items, components, state, depth + 1)?;
-    state.insert(name.to_string(), VisitState::Done);
-    Ok(())
+    let height = 1 + visit_items(items, components, state, depth + 1)?;
+    if height > MAX_COMPONENT_DEPTH {
+        return Err(DictionaryError::NestingTooDeep {
+            element: "component".to_string(),
+            limit: MAX_COMPONENT_DEPTH,
+        });
+    }
+    state.insert(name.to_string(), VisitState::Done(height));
+    Ok(height)
 }
 
-/// Depth-first visit of a member list, descending into groups and components.
+/// Depth-first visit of a member list, returning the height of its deepest
+/// nested group or component (zero when it holds only fields).
+///
+/// `depth` is checked on entry so recursion through nested groups or a
+/// root-first component chain cannot exhaust the stack.
+///
+/// # Errors
+///
+/// Propagates any error from [`visit_component`], and returns
+/// [`DictionaryError::NestingTooDeep`] if the recursion itself reaches past
+/// [`MAX_COMPONENT_DEPTH`].
 fn visit_items(
     items: &[Item],
     components: &HashMap<String, Vec<Item>>,
     state: &mut HashMap<String, VisitState>,
     depth: usize,
-) -> Result<(), DictionaryError> {
+) -> Result<usize, DictionaryError> {
     if depth > MAX_COMPONENT_DEPTH {
         return Err(DictionaryError::NestingTooDeep {
             element: "component".to_string(),
             limit: MAX_COMPONENT_DEPTH,
         });
     }
+    let mut height = 0;
     for item in items {
-        match item {
-            Item::Field { .. } => {}
-            Item::Group { items, .. } => visit_items(items, components, state, depth + 1)?,
+        let reach = match item {
+            Item::Field { .. } => 0,
+            Item::Group { items, .. } => 1 + visit_items(items, components, state, depth + 1)?,
             Item::Component { name, .. } => visit_component(name, components, state, depth)?,
+        };
+        if reach > height {
+            height = reach;
         }
     }
-    Ok(())
+    Ok(height)
 }
 
 fn load(xml: &str) -> Result<Dictionary, DictionaryError> {
@@ -1189,6 +1237,66 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn test_long_component_chain_leaf_first_is_rejected() {
+        // The same over-long acyclic chain as the forward-order test, but with
+        // the leaf declared first and every parent after its child. Memoising
+        // a bare "done" flag would let this load at any length, because each
+        // parent finds its child already resolved at depth 1 and never
+        // descends — memoising the measured height rejects it regardless of
+        // declaration order.
+        let mut xml = String::from(
+            "<fix type='FIX' major='4' minor='4'><header></header><trailer></trailer>\
+             <messages></messages><components>",
+        );
+        let links = MAX_COMPONENT_DEPTH + 10;
+        xml.push_str(&format!(
+            "<component name='C{links}'><field name='TestReqID' required='N'/></component>"
+        ));
+        for index in (0..links).rev() {
+            xml.push_str(&format!("<component name='C{index}'>"));
+            xml.push_str(&format!("<component name='C{}' required='N'/>", index + 1));
+            xml.push_str("</component>");
+        }
+        xml.push_str(
+            "</components><fields><field number='112' name='TestReqID' type='STRING'/></fields></fix>",
+        );
+
+        assert!(matches!(
+            load_err(&xml),
+            DictionaryError::NestingTooDeep {
+                limit: MAX_COMPONENT_DEPTH,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_component_chain_at_ceiling_leaf_first_loads() {
+        // A leaf-first chain exactly at the ceiling must still load: the fix
+        // must not reject valid depth, only over-deep nesting.
+        let mut xml = String::from(
+            "<fix type='FIX' major='4' minor='4'><header></header><trailer></trailer>\
+             <messages></messages><components>",
+        );
+        // `links` components chained plus the leaf, giving a subtree height of
+        // exactly MAX_COMPONENT_DEPTH.
+        let links = MAX_COMPONENT_DEPTH - 1;
+        xml.push_str(&format!(
+            "<component name='C{links}'><field name='TestReqID' required='N'/></component>"
+        ));
+        for index in (0..links).rev() {
+            xml.push_str(&format!("<component name='C{index}'>"));
+            xml.push_str(&format!("<component name='C{}' required='N'/>", index + 1));
+            xml.push_str("</component>");
+        }
+        xml.push_str(
+            "</components><fields><field number='112' name='TestReqID' type='STRING'/></fields></fix>",
+        );
+
+        assert!(load(&xml).is_ok());
     }
 
     #[test]

--- a/ironfix-dictionary/src/schema.rs
+++ b/ironfix-dictionary/src/schema.rs
@@ -10,8 +10,14 @@
 //! - [`FieldDef`]: Field definitions with tag, name, and type
 //! - [`MessageDef`]: Message definitions with required/optional fields
 //! - [`ComponentDef`]: Reusable component definitions
+//! - [`ComponentRef`]: A reference to a component, with its own required flag
 //! - [`GroupDef`]: Repeating group definitions
 //! - [`Dictionary`]: Complete FIX version dictionary
+//!
+//! [`FieldType`] carries both the QuickFIX XML spelling of a FIX data type
+//! (via [`FromStr`](std::str::FromStr)) and the on-the-wire form that type
+//! admits (via [`FieldType::is_valid_value`]), so the validator never needs a
+//! second, hard-coded table of what a tag means.
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -126,13 +132,31 @@ impl FieldType {
     }
 }
 
+/// A field type name in a dictionary is not a known FIX data type.
+///
+/// Returned by [`FieldType`]'s [`FromStr`](std::str::FromStr) implementation.
+/// An unknown type name is rejected rather than silently treated as
+/// [`FieldType::String`]: mapping it to `String` would drop the field's
+/// format and multi-value semantics without any diagnostic.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("unknown FIX field type `{0}`")]
+pub struct UnknownFieldType(
+    /// The unrecognised type name, as spelled in the dictionary.
+    pub String,
+);
+
 impl std::str::FromStr for FieldType {
-    type Err = std::convert::Infallible;
+    type Err = UnknownFieldType;
 
     /// Creates a FieldType from a string name.
     ///
+    /// The accepted spellings are those used by QuickFIX XML dictionaries.
+    ///
     /// # Arguments
     /// * `s` - The type name from the FIX dictionary
+    ///
+    /// # Errors
+    /// Returns [`UnknownFieldType`] if `s` is not a known FIX data type name.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(match s.to_uppercase().as_str() {
             "INT" => Self::Int,
@@ -151,7 +175,12 @@ impl std::str::FromStr for FieldType {
             "BOOLEAN" => Self::Boolean,
             "STRING" => Self::String,
             "MULTIPLECHARVALUE" => Self::MultipleCharValue,
-            "MULTIPLESTRINGVALUE" => Self::MultipleStringValue,
+            // `MULTIPLEVALUESTRING` is the spelling the vendored FIX 4.4
+            // QuickFIX dictionary uses for its eight multi-value string
+            // fields (ExecInst(18), QuoteCondition(276), ...);
+            // `MULTIPLESTRINGVALUE` is the later FIX 5.0 spelling. Both name
+            // the same data type.
+            "MULTIPLESTRINGVALUE" | "MULTIPLEVALUESTRING" => Self::MultipleStringValue,
             "COUNTRY" => Self::Country,
             "CURRENCY" => Self::Currency,
             "EXCHANGE" => Self::Exchange,
@@ -168,7 +197,8 @@ impl std::str::FromStr for FieldType {
             "LANGUAGE" => Self::Language,
             "PATTERN" => Self::Pattern,
             "TENOR" => Self::Tenor,
-            _ => Self::String,
+            "RESERVED100PLUS" | "RESERVED1000PLUS" | "RESERVED4000PLUS" => Self::Reserved,
+            _ => return Err(UnknownFieldType(s.to_string())),
         })
     }
 }
@@ -188,6 +218,155 @@ impl FieldType {
                 | Self::TzTimestamp
         )
     }
+
+    /// Returns true if this type carries a space-separated list of values.
+    #[must_use]
+    pub const fn is_multi_value(&self) -> bool {
+        matches!(self, Self::MultipleCharValue | Self::MultipleStringValue)
+    }
+
+    /// Returns true if `value` has the on-the-wire form this type admits.
+    ///
+    /// The check is a *form* check only — it never consults an enumeration,
+    /// a calendar, or an ISO registry. `UtcTimestamp` therefore accepts
+    /// `20260230-25:99:99` (well-formed, impossible) and `Currency` accepts
+    /// `ZZZ`. Types whose FIX form is free text or venue-defined
+    /// ([`String`](Self::String), [`Data`](Self::Data),
+    /// [`Exchange`](Self::Exchange), [`Tenor`](Self::Tenor), the `Tz`
+    /// variants, ...) accept any value.
+    ///
+    /// # Arguments
+    /// * `value` - The field value exactly as it appeared on the wire
+    #[must_use]
+    pub fn is_valid_value(&self, value: &str) -> bool {
+        match self {
+            Self::Int => is_integer(value, true),
+            Self::Length | Self::SeqNum | Self::NumInGroup | Self::TagNum => {
+                is_integer(value, false)
+            }
+            Self::DayOfMonth => {
+                is_integer(value, false) && matches!(value.parse::<u32>(), Ok(1..=31))
+            }
+            Self::Float
+            | Self::Qty
+            | Self::Price
+            | Self::PriceOffset
+            | Self::Amt
+            | Self::Percentage => is_decimal(value),
+            Self::Char => value.chars().count() == 1,
+            Self::Boolean => value == "Y" || value == "N",
+            Self::MultipleCharValue => is_multi_value_list(value, Some(1)),
+            Self::MultipleStringValue => is_multi_value_list(value, None),
+            Self::Country => is_alpha_of_len(value, 2),
+            Self::Currency => is_alpha_of_len(value, 3),
+            Self::MonthYear => is_month_year(value),
+            Self::UtcDateOnly | Self::LocalMktDate => is_digits_of_len(value, 8),
+            Self::UtcTimeOnly => is_time_of_day(value),
+            Self::UtcTimestamp => match value.split_once('-') {
+                Some((date, time)) => is_digits_of_len(date, 8) && is_time_of_day(time),
+                None => false,
+            },
+            Self::String
+            | Self::Exchange
+            | Self::LocalMktTime
+            | Self::TzTimeOnly
+            | Self::TzTimestamp
+            | Self::Data
+            | Self::XmlData
+            | Self::Language
+            | Self::Pattern
+            | Self::Tenor
+            | Self::Reserved => true,
+        }
+    }
+}
+
+/// Returns true for a non-empty run of ASCII digits, optionally signed.
+fn is_integer(value: &str, allow_sign: bool) -> bool {
+    let digits = match value.strip_prefix('-') {
+        Some(rest) if allow_sign => rest,
+        Some(_) => return false,
+        None => value,
+    };
+    !digits.is_empty() && digits.bytes().all(|b| b.is_ascii_digit())
+}
+
+/// Returns true for a FIX decimal: optional sign, digits, at most one point.
+fn is_decimal(value: &str) -> bool {
+    let body = value.strip_prefix('-').unwrap_or(value);
+    let mut digits = 0usize;
+    let mut points = 0usize;
+    for byte in body.bytes() {
+        match byte {
+            b'0'..=b'9' => digits += 1,
+            b'.' => points += 1,
+            _ => return false,
+        }
+    }
+    digits > 0 && points <= 1
+}
+
+/// Returns true for a non-empty space-separated list whose every token is
+/// non-empty and, when `token_len` is set, exactly that many characters.
+fn is_multi_value_list(value: &str, token_len: Option<usize>) -> bool {
+    let mut tokens = 0usize;
+    for token in value.split(' ') {
+        if token.is_empty() {
+            return false;
+        }
+        if let Some(len) = token_len
+            && token.chars().count() != len
+        {
+            return false;
+        }
+        tokens += 1;
+    }
+    tokens > 0
+}
+
+/// Returns true for exactly `len` ASCII alphabetic characters.
+fn is_alpha_of_len(value: &str, len: usize) -> bool {
+    value.len() == len && value.bytes().all(|b| b.is_ascii_alphabetic())
+}
+
+/// Returns true for exactly `len` ASCII digits.
+fn is_digits_of_len(value: &str, len: usize) -> bool {
+    value.len() == len && value.bytes().all(|b| b.is_ascii_digit())
+}
+
+/// Returns true for `YYYYMM`, `YYYYMMDD`, or `YYYYMMww` (week 1-5).
+fn is_month_year(value: &str) -> bool {
+    if is_digits_of_len(value, 6) || is_digits_of_len(value, 8) {
+        return true;
+    }
+    match value.split_at_checked(6) {
+        Some((year_month, week)) => {
+            is_digits_of_len(year_month, 6)
+                && matches!(week.as_bytes(), [b'w', digit] if (b'1'..=b'5').contains(digit))
+        }
+        None => false,
+    }
+}
+
+/// Returns true for `HH:MM:SS` with an optional `.sss` fraction.
+fn is_time_of_day(value: &str) -> bool {
+    let (clock, fraction) = match value.split_once('.') {
+        Some((clock, fraction)) => (clock, Some(fraction)),
+        None => (value, None),
+    };
+    if let Some(fraction) = fraction
+        && !(matches!(fraction.len(), 1..=9) && fraction.bytes().all(|b| b.is_ascii_digit()))
+    {
+        return false;
+    }
+    let mut parts = 0usize;
+    for part in clock.split(':') {
+        if !is_digits_of_len(part, 2) {
+            return false;
+        }
+        parts += 1;
+    }
+    parts == 3
 }
 
 /// Definition of a FIX field.
@@ -249,6 +428,38 @@ pub struct FieldRef {
     pub required: bool,
 }
 
+/// Reference to a component from a message, component, or group.
+///
+/// The reference carries its own `required` flag: the same component is
+/// mandatory in one message and optional in another, so requiredness belongs
+/// to the reference and not to the [`ComponentDef`]. Dropping it makes every
+/// component look required, which turns an optional component's required
+/// members into spurious
+/// [`MissingRequiredField`](crate::ValidationError::MissingRequiredField)
+/// errors.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ComponentRef {
+    /// Name of the referenced component.
+    pub name: String,
+    /// Whether the component is required where it is referenced.
+    pub required: bool,
+}
+
+impl ComponentRef {
+    /// Creates a component reference.
+    ///
+    /// # Arguments
+    /// * `name` - Name of the referenced component
+    /// * `required` - Whether the component is required at this reference
+    #[must_use]
+    pub fn new(name: impl Into<String>, required: bool) -> Self {
+        Self {
+            name: name.into(),
+            required,
+        }
+    }
+}
+
 /// Definition of a repeating group.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GroupDef {
@@ -264,7 +475,7 @@ pub struct GroupDef {
     pub groups: Vec<GroupDef>,
     /// Components used within each group entry.
     #[serde(default)]
-    pub components: Vec<String>,
+    pub components: Vec<ComponentRef>,
     /// Whether the group is required.
     pub required: bool,
 }
@@ -279,7 +490,7 @@ pub struct ComponentDef {
     /// Groups in this component.
     pub groups: Vec<GroupDef>,
     /// Nested components.
-    pub components: Vec<String>,
+    pub components: Vec<ComponentRef>,
 }
 
 /// Definition of a FIX message.
@@ -296,7 +507,7 @@ pub struct MessageDef {
     /// Groups in this message.
     pub groups: Vec<GroupDef>,
     /// Components used in this message.
-    pub components: Vec<String>,
+    pub components: Vec<ComponentRef>,
 }
 
 /// Message category.
@@ -441,14 +652,101 @@ mod tests {
     }
 
     #[test]
-    fn test_field_type_from_str() {
-        assert_eq!("INT".parse::<FieldType>().unwrap(), FieldType::Int);
-        assert_eq!("STRING".parse::<FieldType>().unwrap(), FieldType::String);
+    fn test_field_type_from_str_known_names_map() {
+        assert_eq!("INT".parse::<FieldType>(), Ok(FieldType::Int));
+        assert_eq!("STRING".parse::<FieldType>(), Ok(FieldType::String));
         assert_eq!(
-            "UTCTIMESTAMP".parse::<FieldType>().unwrap(),
-            FieldType::UtcTimestamp
+            "UTCTIMESTAMP".parse::<FieldType>(),
+            Ok(FieldType::UtcTimestamp)
         );
-        assert_eq!("unknown".parse::<FieldType>().unwrap(), FieldType::String);
+        assert_eq!(
+            "RESERVED100PLUS".parse::<FieldType>(),
+            Ok(FieldType::Reserved)
+        );
+    }
+
+    #[test]
+    fn test_field_type_from_str_both_multi_value_string_spellings_map() {
+        // The vendored FIX 4.4 dictionary spells it `MULTIPLEVALUESTRING`;
+        // FIX 5.0 spells the same type `MULTIPLESTRINGVALUE`.
+        assert_eq!(
+            "MULTIPLEVALUESTRING".parse::<FieldType>(),
+            Ok(FieldType::MultipleStringValue)
+        );
+        assert_eq!(
+            "MULTIPLESTRINGVALUE".parse::<FieldType>(),
+            Ok(FieldType::MultipleStringValue)
+        );
+        assert!(FieldType::MultipleStringValue.is_multi_value());
+    }
+
+    #[test]
+    fn test_field_type_from_str_unknown_name_is_rejected() {
+        assert_eq!(
+            "NOTATYPE".parse::<FieldType>(),
+            Err(UnknownFieldType("NOTATYPE".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_field_type_is_valid_value_numeric_forms() {
+        assert!(FieldType::Int.is_valid_value("-42"));
+        assert!(!FieldType::Int.is_valid_value("abc"));
+        assert!(!FieldType::Int.is_valid_value(""));
+        assert!(!FieldType::SeqNum.is_valid_value("-1"));
+        assert!(FieldType::Price.is_valid_value("1.25"));
+        assert!(!FieldType::Price.is_valid_value("1..2"));
+        assert!(!FieldType::Qty.is_valid_value("1.2.3"));
+        assert!(FieldType::DayOfMonth.is_valid_value("31"));
+        assert!(!FieldType::DayOfMonth.is_valid_value("32"));
+    }
+
+    #[test]
+    fn test_field_type_is_valid_value_scalar_forms() {
+        assert!(FieldType::Boolean.is_valid_value("Y"));
+        assert!(!FieldType::Boolean.is_valid_value("Q"));
+        assert!(FieldType::Char.is_valid_value("1"));
+        assert!(!FieldType::Char.is_valid_value("12"));
+        assert!(FieldType::Currency.is_valid_value("EUR"));
+        assert!(!FieldType::Currency.is_valid_value("EU"));
+        assert!(FieldType::Country.is_valid_value("ES"));
+        assert!(!FieldType::Country.is_valid_value("E1"));
+        // Free-form types accept anything.
+        assert!(FieldType::String.is_valid_value("anything at all"));
+        assert!(FieldType::Exchange.is_valid_value("XMAD"));
+    }
+
+    #[test]
+    fn test_field_type_is_valid_value_temporal_forms() {
+        assert!(FieldType::UtcTimestamp.is_valid_value("20260712-10:00:00"));
+        assert!(FieldType::UtcTimestamp.is_valid_value("20260712-10:00:00.123"));
+        assert!(!FieldType::UtcTimestamp.is_valid_value("20260712 10:00:00"));
+        assert!(!FieldType::UtcTimestamp.is_valid_value("20260712-10:00"));
+        assert!(FieldType::UtcTimeOnly.is_valid_value("10:00:00"));
+        assert!(FieldType::UtcDateOnly.is_valid_value("20260712"));
+        assert!(!FieldType::LocalMktDate.is_valid_value("2026-07-12"));
+        assert!(FieldType::MonthYear.is_valid_value("202607"));
+        assert!(FieldType::MonthYear.is_valid_value("20260712"));
+        assert!(FieldType::MonthYear.is_valid_value("202607w3"));
+        assert!(!FieldType::MonthYear.is_valid_value("202607w9"));
+    }
+
+    #[test]
+    fn test_field_type_is_valid_value_multi_value_forms() {
+        assert!(FieldType::MultipleStringValue.is_valid_value("1 2"));
+        assert!(!FieldType::MultipleStringValue.is_valid_value(""));
+        assert!(!FieldType::MultipleStringValue.is_valid_value("1  2"));
+        assert!(FieldType::MultipleCharValue.is_valid_value("A B"));
+        assert!(!FieldType::MultipleCharValue.is_valid_value("AB C"));
+    }
+
+    #[test]
+    fn test_component_ref_carries_its_own_required_flag() {
+        let required = ComponentRef::new("Instrument", true);
+        let optional = ComponentRef::new("Instrument", false);
+        assert_eq!(required.name, optional.name);
+        assert!(required.required);
+        assert!(!optional.required);
     }
 
     #[test]

--- a/ironfix-dictionary/src/schema.rs
+++ b/ironfix-dictionary/src/schema.rs
@@ -348,14 +348,18 @@ fn is_month_year(value: &str) -> bool {
     }
 }
 
-/// Returns true for `HH:MM:SS` with an optional `.sss` fraction.
+/// Returns true for `HH:MM:SS` with an optional fractional second.
+///
+/// The fraction may carry 1 to 12 digits, spanning millisecond through
+/// picosecond precision — FIX 5.0 SP2 / FIXT.1.1 permit up to 12 fractional
+/// digits, so capping shorter would let the dictionary overrule the spec.
 fn is_time_of_day(value: &str) -> bool {
     let (clock, fraction) = match value.split_once('.') {
         Some((clock, fraction)) => (clock, Some(fraction)),
         None => (value, None),
     };
     if let Some(fraction) = fraction
-        && !(matches!(fraction.len(), 1..=9) && fraction.bytes().all(|b| b.is_ascii_digit()))
+        && !(matches!(fraction.len(), 1..=12) && fraction.bytes().all(|b| b.is_ascii_digit()))
     {
         return false;
     }
@@ -729,6 +733,20 @@ mod tests {
         assert!(FieldType::MonthYear.is_valid_value("20260712"));
         assert!(FieldType::MonthYear.is_valid_value("202607w3"));
         assert!(!FieldType::MonthYear.is_valid_value("202607w9"));
+    }
+
+    #[test]
+    fn test_field_type_is_valid_value_fractional_second_precision() {
+        // FIX 5.0 SP2 / FIXT.1.1 admit up to 12 fractional digits: milli (3),
+        // micro (6), nano (9), and picosecond (12) precision are all legal.
+        assert!(FieldType::UtcTimestamp.is_valid_value("20260712-10:00:00.123"));
+        assert!(FieldType::UtcTimestamp.is_valid_value("20260712-10:00:00.123456789"));
+        assert!(FieldType::UtcTimestamp.is_valid_value("20260712-10:00:00.123456789012"));
+        assert!(FieldType::UtcTimeOnly.is_valid_value("10:00:00.123456789012"));
+        // 13 digits exceeds picosecond precision and stays rejected.
+        assert!(!FieldType::UtcTimestamp.is_valid_value("20260712-10:00:00.1234567890123"));
+        // A fraction marker with no digits is still malformed.
+        assert!(!FieldType::UtcTimestamp.is_valid_value("20260712-10:00:00."));
     }
 
     #[test]

--- a/ironfix-dictionary/src/validator.rs
+++ b/ironfix-dictionary/src/validator.rs
@@ -9,26 +9,57 @@
 //! [`Validator`] checks a parsed [`RawMessage`] against a [`Dictionary`]:
 //!
 //! - the message type must be defined
-//! - every tag must be defined in the dictionary and allowed for the message
+//! - every tag must be defined in the dictionary, and must be allowed at the
+//!   place in the message where it appears
 //! - required header, body, and trailer fields must be present
+//! - a field's value must have the form its [`FieldType`] admits
 //! - enumerated fields must carry a defined value
-//! - repeating groups must declare a count matching the delimiter
-//!   occurrences, and entries must start with the delimiter tag
+//! - no tag may repeat at the same structural level
+//! - repeating groups must be *parseable*: the entries of a group follow its
+//!   count field contiguously, each entry starts with the group's delimiter
+//!   tag, no tag repeats inside one entry, and the number of entries actually
+//!   present matches the declared count
+//!
+//! # How groups are checked
+//!
+//! Group structure is checked by walking the fields positionally rather than
+//! by counting tag occurrences message-wide. Starting at a group's count
+//! field, the validator consumes the run of fields that belong to that
+//! group's member set, opening a new entry at every delimiter tag and
+//! recursing into nested groups. The run ends at the first field that is not
+//! a member, so entries detached from their count field are not silently
+//! absorbed, and two different groups that happen to share a delimiter tag
+//! can no longer be confused for one another.
 //!
 //! Notes:
 //! - `CheckSum(10)` presence is not re-checked: the tag-value decoder
 //!   already consumes and verifies it, so it never appears among the
 //!   parsed fields.
-//! - Required fields *inside* repeating group entries are not validated
-//!   per-entry; group membership is validated via the count/delimiter
-//!   checks above.
+//! - Required fields *inside* repeating group entries are still not
+//!   validated per-entry; only the entry structure above is.
+//! - The validator is a standalone, opt-in facility. It is not invoked by
+//!   the codec or by the engine.
 
-use crate::schema::{Dictionary, FieldType, GroupDef, MessageDef};
+use crate::schema::{ComponentRef, Dictionary, FieldType, GroupDef, MessageDef};
 use ironfix_core::message::RawMessage;
 use std::collections::{HashMap, HashSet};
 
+/// Maximum group/component nesting the validator will expand.
+///
+/// A [`Dictionary`] produced by the loader is a DAG of bounded depth, but one
+/// built by hand or deserialised from an untrusted document need not be, so
+/// the expansion carries its own ceiling.
+pub const MAX_SCOPE_DEPTH: usize = 32;
+
+/// Maximum number of groups and components expanded for a single message.
+///
+/// Bounds the total work of expanding a pathological schema, independently of
+/// [`MAX_SCOPE_DEPTH`].
+pub const MAX_SCOPE_NODES: usize = 4096;
+
 /// A single validation failure.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
 pub enum ValidationError {
     /// The message type (tag 35) is not defined in the dictionary.
     #[error("unknown message type `{msg_type}`")]
@@ -58,6 +89,18 @@ pub enum ValidationError {
         /// The message type being validated.
         msg_type: String,
     },
+    /// A field's value does not have the form its data type requires.
+    #[error("value `{value}` is not a valid {field_type:?} for field {name}({tag})")]
+    InvalidFieldFormat {
+        /// Field tag.
+        tag: u32,
+        /// Field name.
+        name: String,
+        /// The offending value.
+        value: String,
+        /// The type the dictionary declares for this field.
+        field_type: FieldType,
+    },
     /// An enumerated field carries a value outside its defined set.
     #[error("invalid value `{value}` for field {name}({tag})")]
     InvalidEnumValue {
@@ -67,6 +110,26 @@ pub enum ValidationError {
         name: String,
         /// The offending value.
         value: String,
+    },
+    /// The same tag appears twice at the message level.
+    #[error("tag {name}({tag}) appears more than once in the message")]
+    DuplicateTag {
+        /// The repeated tag.
+        tag: u32,
+        /// Field name.
+        name: String,
+    },
+    /// The same tag appears twice inside one repeating group entry.
+    #[error("tag {name}({tag}) appears more than once in an entry of group {group}({count_tag})")]
+    RepeatedTagInGroupEntry {
+        /// Count field tag (NumInGroup) of the group.
+        count_tag: u32,
+        /// Group name.
+        group: String,
+        /// The repeated tag.
+        tag: u32,
+        /// Field name.
+        name: String,
     },
     /// A group count field does not hold a valid number.
     #[error("invalid count value `{value}` for group count field {name}({tag})")]
@@ -78,23 +141,23 @@ pub enum ValidationError {
         /// The offending value.
         value: String,
     },
-    /// The declared group count does not match the delimiter occurrences.
+    /// The declared group count does not match the entries actually present.
     #[error(
-        "group {name}({count_tag}) declares {declared} entries but found {actual} occurrences of delimiter tag {delimiter_tag}"
+        "group {name}({count_tag}) declares {declared} entries but {actual} entries follow it, each led by delimiter tag {delimiter_tag}"
     )]
     GroupCountMismatch {
         /// Count field tag (NumInGroup).
         count_tag: u32,
         /// Group name.
         name: String,
-        /// Sum of declared entry counts.
+        /// Declared entry count.
         declared: u64,
-        /// Observed delimiter occurrences.
+        /// Entries actually found following the count field.
         actual: u64,
         /// Delimiter tag expected to start each entry.
         delimiter_tag: u32,
     },
-    /// A non-empty group is not immediately followed by its delimiter tag.
+    /// A group entry does not start with the group's delimiter tag.
     #[error(
         "group {name}({count_tag}) entries must start with delimiter tag {expected}, found tag {found}"
     )]
@@ -105,7 +168,7 @@ pub enum ValidationError {
         name: String,
         /// Expected delimiter tag.
         expected: u32,
-        /// Tag actually found after the count field.
+        /// Tag actually found where an entry should have started.
         found: u32,
     },
     /// A required repeating group is absent.
@@ -116,31 +179,222 @@ pub enum ValidationError {
         /// Group name.
         name: String,
     },
+    /// The message schema references a component the dictionary does not define.
+    ///
+    /// Dictionaries produced by the loader cannot contain a dangling
+    /// reference; this reports one in a dictionary assembled by other means.
+    #[error("message schema references undefined component `{name}`")]
+    UnknownComponent {
+        /// Name of the missing component.
+        name: String,
+    },
+    /// The schema nests groups or components past the validator's ceiling.
+    #[error("schema for `{name}` nests deeper than the validator's limit of {limit}")]
+    SchemaTooDeep {
+        /// Name of the group or component at which the ceiling was reached.
+        name: String,
+        /// The ceiling that was exceeded.
+        limit: usize,
+    },
+    /// Expanding the schema for this message exceeded the validator's budget.
+    #[error("schema expansion exceeded the validator's limit of {limit} nodes")]
+    SchemaTooLarge {
+        /// The ceiling that was exceeded.
+        limit: usize,
+    },
 }
 
-/// Group metadata collected for count/delimiter validation.
-#[derive(Debug)]
-struct GroupCheck {
-    count_tag: u32,
-    name: String,
-    delimiter_tag: u32,
-    required: bool,
-}
-
-/// Tags and groups reachable for a given message type.
+/// One structural level of a message: the message body itself, or the
+/// members of a single repeating-group entry.
 #[derive(Debug, Default)]
-struct Scope {
+struct Level {
+    /// Tags that may appear at this level, including group count tags.
     allowed: HashSet<u32>,
+    /// Tags that must appear at this level, with their field names.
     required: Vec<(u32, String)>,
-    groups: Vec<GroupCheck>,
+    /// Groups that may open at this level, keyed by count tag.
+    groups: HashMap<u32, GroupNode>,
 }
 
-impl Scope {
+impl Level {
     fn add_field(&mut self, tag: u32, name: &str, required: bool) {
         self.allowed.insert(tag);
         if required {
             self.required.push((tag, name.to_string()));
         }
+    }
+}
+
+/// A repeating group and the level formed by one of its entries.
+#[derive(Debug)]
+struct GroupNode {
+    count_tag: u32,
+    name: String,
+    delimiter_tag: u32,
+    required: bool,
+    entry: Level,
+}
+
+/// Expands a [`MessageDef`] into the level tree the walker validates against.
+struct ScopeBuilder<'d> {
+    dict: &'d Dictionary,
+    budget: usize,
+    errors: Vec<ValidationError>,
+}
+
+impl<'d> ScopeBuilder<'d> {
+    fn new(dict: &'d Dictionary) -> Self {
+        Self {
+            dict,
+            budget: MAX_SCOPE_NODES,
+            errors: Vec::new(),
+        }
+    }
+
+    /// Charges one node against the budget and checks the depth ceiling.
+    fn spend(&mut self, name: &str, depth: usize) -> bool {
+        if depth > MAX_SCOPE_DEPTH {
+            self.errors.push(ValidationError::SchemaTooDeep {
+                name: name.to_string(),
+                limit: MAX_SCOPE_DEPTH,
+            });
+            return false;
+        }
+        match self.budget.checked_sub(1) {
+            Some(remaining) => {
+                self.budget = remaining;
+                true
+            }
+            None => {
+                if !self.errors.contains(&ValidationError::SchemaTooLarge {
+                    limit: MAX_SCOPE_NODES,
+                }) {
+                    self.errors.push(ValidationError::SchemaTooLarge {
+                        limit: MAX_SCOPE_NODES,
+                    });
+                }
+                false
+            }
+        }
+    }
+
+    /// Builds the message level: header, trailer, body fields, groups, and
+    /// directly referenced components.
+    fn build(&mut self, msg_def: &MessageDef) -> Level {
+        let mut level = Level::default();
+        let mut path = HashSet::new();
+
+        for field in &self.dict.header {
+            level.add_field(field.tag, &field.name, field.required);
+        }
+        for group in &self.dict.header_groups {
+            self.add_group(&mut level, group, group.required, true, 0, &mut path);
+        }
+        for field in &self.dict.trailer {
+            level.add_field(field.tag, &field.name, field.required);
+        }
+        for group in &self.dict.trailer_groups {
+            self.add_group(&mut level, group, group.required, true, 0, &mut path);
+        }
+
+        for field in &msg_def.fields {
+            level.add_field(field.tag, &field.name, field.required);
+        }
+        for group in &msg_def.groups {
+            self.add_group(&mut level, group, group.required, true, 0, &mut path);
+        }
+        for component in &msg_def.components {
+            self.add_component(&mut level, component, true, 0, &mut path);
+        }
+
+        level
+    }
+
+    /// Adds a group to `level` and builds the level formed by one entry.
+    ///
+    /// `collect_required` is false inside group entries: a member's required
+    /// flag applies per entry, which is deliberately not validated.
+    fn add_group(
+        &mut self,
+        level: &mut Level,
+        group: &GroupDef,
+        required: bool,
+        collect_required: bool,
+        depth: usize,
+        path: &mut HashSet<String>,
+    ) {
+        if !self.spend(&group.name, depth) {
+            return;
+        }
+        level.allowed.insert(group.count_tag);
+
+        let mut entry = Level::default();
+        entry.allowed.insert(group.delimiter_tag);
+        for field in &group.fields {
+            entry.allowed.insert(field.tag);
+        }
+        for nested in &group.groups {
+            self.add_group(&mut entry, nested, nested.required, false, depth + 1, path);
+        }
+        for component in &group.components {
+            self.add_component(&mut entry, component, false, depth + 1, path);
+        }
+
+        // A group already present at this level keeps its first expansion;
+        // two groups sharing a count tag at one level is a schema defect,
+        // not something to resolve here.
+        level.groups.entry(group.count_tag).or_insert(GroupNode {
+            count_tag: group.count_tag,
+            name: group.name.clone(),
+            delimiter_tag: group.delimiter_tag,
+            required: required && collect_required,
+            entry,
+        });
+    }
+
+    /// Expands a component reference into `level`.
+    ///
+    /// `collect_required` says whether requiredness is meaningful where the
+    /// reference sits; combined with the reference's own flag it gives the
+    /// effective requiredness, so a component's required members can only
+    /// make a message invalid when the reference that pulled it in was
+    /// itself required.
+    fn add_component(
+        &mut self,
+        level: &mut Level,
+        reference: &ComponentRef,
+        collect_required: bool,
+        depth: usize,
+        path: &mut HashSet<String>,
+    ) {
+        if !self.spend(&reference.name, depth) {
+            return;
+        }
+        let Some(component) = self.dict.get_component(&reference.name) else {
+            self.errors.push(ValidationError::UnknownComponent {
+                name: reference.name.clone(),
+            });
+            return;
+        };
+        // A cycle can only reach here through a hand-built dictionary; the
+        // loader rejects one. Expanding a component twice at different
+        // places is legitimate, so the guard is per path, not global.
+        if !path.insert(reference.name.clone()) {
+            return;
+        }
+
+        let required = collect_required && reference.required;
+        for field in &component.fields {
+            level.add_field(field.tag, &field.name, required && field.required);
+        }
+        for group in &component.groups {
+            self.add_group(level, group, group.required, required, depth + 1, path);
+        }
+        for nested in &component.components {
+            self.add_component(level, nested, required, depth + 1, path);
+        }
+
+        path.remove(&reference.name);
     }
 }
 
@@ -171,50 +425,50 @@ impl<'d> Validator<'d> {
             return Err(vec![ValidationError::UnknownMsgType { msg_type }]);
         };
 
-        let scope = self.collect_scope(msg_def);
-        let mut errors = Vec::new();
+        let mut builder = ScopeBuilder::new(self.dict);
+        let level = builder.build(msg_def);
+        let mut errors = builder.errors;
 
         let fields: Vec<_> = msg.fields().collect();
-        let mut occurrences: HashMap<u32, u64> = HashMap::new();
+
+        // Value-level checks apply wherever a field sits.
         for field in &fields {
-            *occurrences.entry(field.tag).or_default() += 1;
+            self.check_value(field, &mut errors);
         }
 
-        // Per-field checks: defined, allowed, enum value.
-        for field in &fields {
-            let Some(def) = self.dict.get_field(field.tag) else {
-                errors.push(ValidationError::UnknownTag { tag: field.tag });
+        // Structural walk over the message level.
+        let mut seen: HashSet<u32> = HashSet::new();
+        let mut index = 0;
+        while let Some(field) = fields.get(index) {
+            let tag = field.tag;
+            let Some(def) = self.dict.get_field(tag) else {
+                // Already reported as UnknownTag by the value pass.
+                index += 1;
                 continue;
             };
-            if !scope.allowed.contains(&field.tag) {
+            if !seen.insert(tag) {
+                errors.push(ValidationError::DuplicateTag {
+                    tag,
+                    name: def.name.clone(),
+                });
+            }
+            if let Some(group) = level.groups.get(&tag) {
+                index = self.walk_group(&fields, index, group, &mut errors);
+                continue;
+            }
+            if !level.allowed.contains(&tag) {
                 errors.push(ValidationError::FieldNotAllowedForMessage {
-                    tag: field.tag,
+                    tag,
                     msg_type: msg_type.clone(),
                 });
             }
-            if let Some(values) = &def.values {
-                let value = String::from_utf8_lossy(field.value);
-                let valid = match def.field_type {
-                    FieldType::MultipleCharValue | FieldType::MultipleStringValue => value
-                        .split(' ')
-                        .filter(|part| !part.is_empty())
-                        .all(|part| values.contains_key(part)),
-                    _ => values.contains_key(value.as_ref()),
-                };
-                if !valid {
-                    errors.push(ValidationError::InvalidEnumValue {
-                        tag: field.tag,
-                        name: def.name.clone(),
-                        value: value.into_owned(),
-                    });
-                }
-            }
+            index += 1;
         }
 
-        // Required fields. CheckSum(10) is consumed by the decoder and
-        // never appears among the parsed fields, so it is skipped here.
-        for (tag, name) in &scope.required {
-            if *tag != 10 && !occurrences.contains_key(tag) {
+        // Required fields. CheckSum(10) is consumed by the decoder and never
+        // appears among the parsed fields, so it is skipped here.
+        for (tag, name) in &level.required {
+            if *tag != 10 && !seen.contains(tag) {
                 errors.push(ValidationError::MissingRequiredField {
                     tag: *tag,
                     name: name.clone(),
@@ -222,9 +476,13 @@ impl<'d> Validator<'d> {
             }
         }
 
-        // Repeating groups: count vs delimiter occurrences, entry ordering.
-        for group in &scope.groups {
-            self.validate_group(group, &fields, &occurrences, &mut errors);
+        for group in level.groups.values() {
+            if group.required && !seen.contains(&group.count_tag) {
+                errors.push(ValidationError::MissingRequiredGroup {
+                    count_tag: group.count_tag,
+                    name: group.name.clone(),
+                });
+            }
         }
 
         if errors.is_empty() {
@@ -234,169 +492,179 @@ impl<'d> Validator<'d> {
         }
     }
 
-    fn validate_group(
+    /// Checks that a field is defined, well-formed for its type, and — when
+    /// enumerated — carries a defined value.
+    fn check_value(
         &self,
-        group: &GroupCheck,
-        fields: &[&ironfix_core::field::FieldRef<'_>],
-        occurrences: &HashMap<u32, u64>,
+        field: &ironfix_core::field::FieldRef<'_>,
         errors: &mut Vec<ValidationError>,
     ) {
-        let count_occurrences = occurrences.get(&group.count_tag).copied().unwrap_or(0);
-        if count_occurrences == 0 {
-            if group.required {
-                errors.push(ValidationError::MissingRequiredGroup {
-                    count_tag: group.count_tag,
-                    name: group.name.clone(),
-                });
-            }
+        let Some(def) = self.dict.get_field(field.tag) else {
+            errors.push(ValidationError::UnknownTag { tag: field.tag });
+            return;
+        };
+        let value = String::from_utf8_lossy(field.value);
+        if !def.field_type.is_valid_value(&value) {
+            errors.push(ValidationError::InvalidFieldFormat {
+                tag: field.tag,
+                name: def.name.clone(),
+                value: value.into_owned(),
+                field_type: def.field_type,
+            });
             return;
         }
-
-        // Sum the declared counts across all occurrences of the count tag
-        // (nested repetition makes the count tag itself repeat); the total
-        // must match the total delimiter occurrences.
-        let mut declared: u64 = 0;
-        for (index, field) in fields.iter().enumerate() {
-            if field.tag != group.count_tag {
-                continue;
-            }
-            let value = String::from_utf8_lossy(field.value);
-            let Ok(count) = value.parse::<u64>() else {
-                errors.push(ValidationError::InvalidGroupCount {
-                    tag: group.count_tag,
-                    name: group.name.clone(),
-                    value: value.into_owned(),
-                });
-                return;
-            };
-            declared += count;
-
-            // A non-empty group's first entry must start immediately after
-            // the count field with the delimiter tag.
-            if count > 0
-                && let Some(next) = fields.get(index + 1)
-                && next.tag != group.delimiter_tag
-            {
-                errors.push(ValidationError::GroupDelimiterMismatch {
-                    count_tag: group.count_tag,
-                    name: group.name.clone(),
-                    expected: group.delimiter_tag,
-                    found: next.tag,
-                });
-            }
-        }
-
-        let actual = occurrences.get(&group.delimiter_tag).copied().unwrap_or(0);
-        if declared != actual {
-            errors.push(ValidationError::GroupCountMismatch {
-                count_tag: group.count_tag,
-                name: group.name.clone(),
-                declared,
-                actual,
-                delimiter_tag: group.delimiter_tag,
+        let Some(values) = &def.values else {
+            return;
+        };
+        // A multi-value field carries a space-separated list, and every
+        // token has to be in the enumeration. The form check above already
+        // guarantees the tokens are non-empty.
+        let valid = if def.field_type.is_multi_value() {
+            value.split(' ').all(|token| values.contains_key(token))
+        } else {
+            values.contains_key(value.as_ref())
+        };
+        if !valid {
+            errors.push(ValidationError::InvalidEnumValue {
+                tag: field.tag,
+                name: def.name.clone(),
+                value: value.into_owned(),
             });
         }
     }
 
-    /// Collects every tag reachable for the message: header, trailer,
-    /// body fields, components (recursively), and repeating groups.
-    fn collect_scope(&self, msg_def: &MessageDef) -> Scope {
-        let mut scope = Scope::default();
-        let mut visited = HashSet::new();
-
-        for field in &self.dict.header {
-            scope.add_field(field.tag, &field.name, field.required);
-        }
-        for group in &self.dict.header_groups {
-            self.add_group(&mut scope, group, group.required, &mut visited);
-        }
-        for field in &self.dict.trailer {
-            scope.add_field(field.tag, &field.name, field.required);
-        }
-        for group in &self.dict.trailer_groups {
-            self.add_group(&mut scope, group, group.required, &mut visited);
-        }
-
-        for field in &msg_def.fields {
-            scope.add_field(field.tag, &field.name, field.required);
-        }
-        for group in &msg_def.groups {
-            self.add_group(&mut scope, group, group.required, &mut visited);
-        }
-        for component in &msg_def.components {
-            self.add_component(&mut scope, component, true, &mut visited);
-        }
-
-        scope
-    }
-
-    /// Adds a group's count tag and (recursively) its member tags.
+    /// Walks one group instance, starting at its count field.
     ///
-    /// Member fields are allowed but never required at message level:
-    /// their requiredness applies within each entry, which is not
-    /// validated per-entry.
-    fn add_group(
+    /// Returns the index of the first field after the group.
+    fn walk_group(
         &self,
-        scope: &mut Scope,
-        group: &GroupDef,
-        required: bool,
-        visited: &mut HashSet<String>,
-    ) {
-        scope.allowed.insert(group.count_tag);
-        scope.groups.push(GroupCheck {
-            count_tag: group.count_tag,
-            name: group.name.clone(),
-            delimiter_tag: group.delimiter_tag,
-            required,
-        });
-        for field in &group.fields {
-            scope.allowed.insert(field.tag);
-        }
-        for nested in &group.groups {
-            self.add_group(scope, nested, false, visited);
-        }
-        for component in &group.components {
-            self.add_component(scope, component, false, visited);
-        }
-    }
-
-    /// Expands a component reference into the scope.
-    ///
-    /// `top_level` is true only for components referenced directly by the
-    /// message body; only there can a component's required fields make the
-    /// message invalid when absent.
-    fn add_component(
-        &self,
-        scope: &mut Scope,
-        name: &str,
-        top_level: bool,
-        visited: &mut HashSet<String>,
-    ) {
-        if !visited.insert(name.to_string()) {
-            return;
-        }
-        let Some(component) = self.dict.get_component(name) else {
-            return;
+        fields: &[&ironfix_core::field::FieldRef<'_>],
+        index: usize,
+        group: &GroupNode,
+        errors: &mut Vec<ValidationError>,
+    ) -> usize {
+        let Some(count_field) = fields.get(index) else {
+            return index;
         };
-        for field in &component.fields {
-            scope.add_field(field.tag, &field.name, top_level && field.required);
+        let count_value = String::from_utf8_lossy(count_field.value);
+        let declared = match count_value.parse::<u64>() {
+            Ok(declared) => Some(declared),
+            Err(_) => {
+                errors.push(ValidationError::InvalidGroupCount {
+                    tag: group.count_tag,
+                    name: group.name.clone(),
+                    value: count_value.into_owned(),
+                });
+                None
+            }
+        };
+
+        let mut cursor = index + 1;
+        let mut entries: u64 = 0;
+        let mut unparseable = false;
+        let mut seen_in_entry: HashSet<u32> = HashSet::new();
+
+        while let Some(field) = fields.get(cursor) {
+            let tag = field.tag;
+            if tag == group.delimiter_tag {
+                let Some(next) = entries.checked_add(1) else {
+                    break;
+                };
+                entries = next;
+                seen_in_entry.clear();
+                seen_in_entry.insert(tag);
+                cursor += 1;
+                continue;
+            }
+            if !group.entry.allowed.contains(&tag) {
+                // First field that is not a member of this group: the group
+                // ends here, and whatever follows belongs to the outer level.
+                break;
+            }
+            if entries == 0 {
+                // Members appear before any delimiter, so the first entry is
+                // not delimiter-led and the group cannot be split into
+                // entries unambiguously.
+                errors.push(ValidationError::GroupDelimiterMismatch {
+                    count_tag: group.count_tag,
+                    name: group.name.clone(),
+                    expected: group.delimiter_tag,
+                    found: tag,
+                });
+                unparseable = true;
+                entries = 1;
+                seen_in_entry.clear();
+            }
+            if !seen_in_entry.insert(tag) {
+                errors.push(ValidationError::RepeatedTagInGroupEntry {
+                    count_tag: group.count_tag,
+                    group: group.name.clone(),
+                    tag,
+                    name: self
+                        .dict
+                        .get_field(tag)
+                        .map_or_else(String::new, |def| def.name.clone()),
+                });
+                unparseable = true;
+            }
+            cursor = match group.entry.groups.get(&tag) {
+                Some(nested) => self.walk_group(fields, cursor, nested, errors),
+                None => cursor + 1,
+            };
         }
-        for group in &component.groups {
-            self.add_group(scope, group, top_level && group.required, visited);
+
+        if let Some(declared) = declared
+            && !unparseable
+            && declared != entries
+        {
+            errors.push(ValidationError::GroupCountMismatch {
+                count_tag: group.count_tag,
+                name: group.name.clone(),
+                declared,
+                actual: entries,
+                delimiter_tag: group.delimiter_tag,
+            });
         }
-        for nested in &component.components {
-            self.add_component(scope, nested, false, visited);
-        }
+
+        cursor
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::schema::Dictionary;
+    // `FieldRef` is ambiguous across the workspace, so the schema one is
+    // always spelled with a qualifier here; `ironfix_core::field::FieldRef`
+    // appears in full above.
+    use crate::schema::FieldRef as SchemaFieldRef;
+    use crate::schema::{ComponentDef, Dictionary, FieldDef, MessageCategory};
     use ironfix_tagvalue::Decoder;
+    use std::fmt::Debug;
 
     const SOH: char = '\x01';
+
+    /// Unwraps a `Result` with test context instead of `.unwrap()`.
+    #[track_caller]
+    fn ok<T, E: Debug>(result: Result<T, E>, what: &str) -> T {
+        match result {
+            Ok(value) => value,
+            Err(err) => panic!("{what}: {err:?}"),
+        }
+    }
+
+    /// Returns the errors a validation is expected to produce.
+    #[track_caller]
+    fn errors(result: Result<(), Vec<ValidationError>>) -> Vec<ValidationError> {
+        match result {
+            Ok(()) => panic!("expected the message to be rejected, but it validated"),
+            Err(errors) => errors,
+        }
+    }
+
+    #[track_caller]
+    fn fix44() -> &'static Dictionary {
+        ok(Dictionary::fix44(), "embedded FIX 4.4 dictionary loads")
+    }
 
     /// Builds a message, recomputing BodyLength (9) from the actual body so the
     /// decoder's declared-vs-actual length check passes.
@@ -428,11 +696,17 @@ mod tests {
         )
     }
 
-    fn validate(fields: &[&str]) -> Result<(), Vec<ValidationError>> {
+    #[track_caller]
+    fn validate_with(dict: &Dictionary, fields: &[&str]) -> Result<(), Vec<ValidationError>> {
         let msg = build(fields);
         let mut decoder = Decoder::new(msg.as_bytes()).with_checksum_validation(false);
-        let raw = decoder.decode().expect("test message decodes");
-        Validator::new(Dictionary::fix44()).validate(&raw)
+        let raw = ok(decoder.decode(), "test message decodes");
+        Validator::new(dict).validate(&raw)
+    }
+
+    #[track_caller]
+    fn validate(fields: &[&str]) -> Result<(), Vec<ValidationError>> {
+        validate_with(fix44(), fields)
     }
 
     const HEADER: [&str; 7] = [
@@ -453,7 +727,7 @@ mod tests {
     }
 
     #[test]
-    fn test_valid_new_order_single() {
+    fn test_validate_new_order_single_valid_passes() {
         let result = validate(&with_header(&[
             "11=ORDER-1",
             "55=EURUSD",
@@ -465,32 +739,30 @@ mod tests {
     }
 
     #[test]
-    fn test_missing_required_field() {
+    fn test_validate_missing_required_field_is_reported() {
         // OrdType(40) omitted.
-        let errors = validate(&with_header(&[
+        let found = errors(validate(&with_header(&[
             "11=ORDER-1",
             "55=EURUSD",
             "54=1",
             "60=20260712-10:00:00",
-        ]))
-        .unwrap_err();
-        assert!(errors.contains(&ValidationError::MissingRequiredField {
+        ])));
+        assert!(found.contains(&ValidationError::MissingRequiredField {
             tag: 40,
             name: "OrdType".to_string(),
         }));
     }
 
     #[test]
-    fn test_invalid_enum_value() {
-        let errors = validate(&with_header(&[
+    fn test_validate_invalid_enum_value_is_reported() {
+        let found = errors(validate(&with_header(&[
             "11=ORDER-1",
             "55=EURUSD",
             "54=X",
             "60=20260712-10:00:00",
             "40=1",
-        ]))
-        .unwrap_err();
-        assert!(errors.contains(&ValidationError::InvalidEnumValue {
+        ])));
+        assert!(found.contains(&ValidationError::InvalidEnumValue {
             tag: 54,
             name: "Side".to_string(),
             value: "X".to_string(),
@@ -498,41 +770,159 @@ mod tests {
     }
 
     #[test]
-    fn test_unknown_tag() {
-        let errors = validate(&with_header(&[
+    fn test_validate_multiple_value_string_accepts_a_list_of_defined_tokens() {
+        // ExecInst(18) is MULTIPLEVALUESTRING in the vendored FIX 4.4
+        // dictionary: `1 2` is two defined tokens and must pass.
+        let result = validate(&with_header(&[
+            "11=ORDER-1",
+            "18=1 2",
+            "55=EURUSD",
+            "54=1",
+            "60=20260712-10:00:00",
+            "40=1",
+        ]));
+        assert_eq!(result, Ok(()));
+    }
+
+    #[test]
+    fn test_validate_multiple_value_string_rejects_an_undefined_token() {
+        // `T` is not among the ExecInst values the vendored dictionary
+        // defines, so the list is rejected even though `1` is valid.
+        let found = errors(validate(&with_header(&[
+            "11=ORDER-1",
+            "18=1 T",
+            "55=EURUSD",
+            "54=1",
+            "60=20260712-10:00:00",
+            "40=1",
+        ])));
+        assert!(found.contains(&ValidationError::InvalidEnumValue {
+            tag: 18,
+            name: "ExecInst".to_string(),
+            value: "1 T".to_string(),
+        }));
+    }
+
+    #[test]
+    fn test_validate_multiple_value_string_rejects_an_empty_token() {
+        let found = errors(validate(&with_header(&[
+            "11=ORDER-1",
+            "18=1  2",
+            "55=EURUSD",
+            "54=1",
+            "60=20260712-10:00:00",
+            "40=1",
+        ])));
+        assert!(found.contains(&ValidationError::InvalidFieldFormat {
+            tag: 18,
+            name: "ExecInst".to_string(),
+            value: "1  2".to_string(),
+            field_type: FieldType::MultipleStringValue,
+        }));
+    }
+
+    #[test]
+    fn test_validate_unknown_tag_is_reported() {
+        let found = errors(validate(&with_header(&[
             "11=ORDER-1",
             "55=EURUSD",
             "54=1",
             "60=20260712-10:00:00",
             "40=1",
             "20000=zzz",
-        ]))
-        .unwrap_err();
-        assert!(errors.contains(&ValidationError::UnknownTag { tag: 20000 }));
+        ])));
+        assert!(found.contains(&ValidationError::UnknownTag { tag: 20000 }));
     }
 
     #[test]
-    fn test_field_not_allowed_for_message() {
+    fn test_validate_field_not_allowed_for_message_is_reported() {
         // AvgPx(6) is defined in FIX 4.4 but not part of NewOrderSingle.
-        let errors = validate(&with_header(&[
+        let found = errors(validate(&with_header(&[
             "11=ORDER-1",
             "55=EURUSD",
             "54=1",
             "60=20260712-10:00:00",
             "40=1",
             "6=1.5",
-        ]))
-        .unwrap_err();
-        assert!(
-            errors.contains(&ValidationError::FieldNotAllowedForMessage {
-                tag: 6,
-                msg_type: "D".to_string(),
-            })
-        );
+        ])));
+        assert!(found.contains(&ValidationError::FieldNotAllowedForMessage {
+            tag: 6,
+            msg_type: "D".to_string(),
+        }));
     }
 
     #[test]
-    fn test_valid_group() {
+    fn test_validate_group_member_outside_its_group_is_not_allowed() {
+        // PartyID(448) only exists inside the NoPartyIDs group; on its own it
+        // is not a NewOrderSingle field.
+        let found = errors(validate(&with_header(&[
+            "11=ORDER-1",
+            "448=BROKER-A",
+            "55=EURUSD",
+            "54=1",
+            "60=20260712-10:00:00",
+            "40=1",
+        ])));
+        assert!(found.contains(&ValidationError::FieldNotAllowedForMessage {
+            tag: 448,
+            msg_type: "D".to_string(),
+        }));
+    }
+
+    #[test]
+    fn test_validate_duplicate_tag_at_message_level_is_reported() {
+        let found = errors(validate(&with_header(&[
+            "11=ORDER-1",
+            "55=EURUSD",
+            "55=GBPUSD",
+            "54=1",
+            "60=20260712-10:00:00",
+            "40=1",
+        ])));
+        assert!(found.contains(&ValidationError::DuplicateTag {
+            tag: 55,
+            name: "Symbol".to_string(),
+        }));
+    }
+
+    #[test]
+    fn test_validate_malformed_value_is_reported_for_its_type() {
+        // OrderQty(38) is a QTY: `1..2` has no decimal form.
+        let found = errors(validate(&with_header(&[
+            "11=ORDER-1",
+            "55=EURUSD",
+            "54=1",
+            "38=1..2",
+            "60=20260712-10:00:00",
+            "40=1",
+        ])));
+        assert!(found.contains(&ValidationError::InvalidFieldFormat {
+            tag: 38,
+            name: "OrderQty".to_string(),
+            value: "1..2".to_string(),
+            field_type: FieldType::Qty,
+        }));
+    }
+
+    #[test]
+    fn test_validate_malformed_timestamp_is_reported() {
+        let found = errors(validate(&with_header(&[
+            "11=ORDER-1",
+            "55=EURUSD",
+            "54=1",
+            "60=not-a-time",
+            "40=1",
+        ])));
+        assert!(found.contains(&ValidationError::InvalidFieldFormat {
+            tag: 60,
+            name: "TransactTime".to_string(),
+            value: "not-a-time".to_string(),
+            field_type: FieldType::UtcTimestamp,
+        }));
+    }
+
+    #[test]
+    fn test_validate_group_valid_entries_pass() {
         // Parties: NoPartyIDs(453)=2, each entry starting with PartyID(448).
         let result = validate(&with_header(&[
             "11=ORDER-1",
@@ -552,8 +942,8 @@ mod tests {
     }
 
     #[test]
-    fn test_group_count_mismatch() {
-        let errors = validate(&with_header(&[
+    fn test_validate_group_count_mismatch_is_reported() {
+        let found = errors(validate(&with_header(&[
             "11=ORDER-1",
             "453=2",
             "448=BROKER-A",
@@ -561,9 +951,8 @@ mod tests {
             "54=1",
             "60=20260712-10:00:00",
             "40=1",
-        ]))
-        .unwrap_err();
-        assert!(errors.contains(&ValidationError::GroupCountMismatch {
+        ])));
+        assert!(found.contains(&ValidationError::GroupCountMismatch {
             count_tag: 453,
             name: "NoPartyIDs".to_string(),
             declared: 2,
@@ -573,9 +962,62 @@ mod tests {
     }
 
     #[test]
-    fn test_group_delimiter_mismatch() {
+    fn test_validate_group_second_entry_not_delimiter_led_is_rejected() {
+        // 453=2|448=A|447=D|447=D|448=B: the repeated PartyIDSource(447)
+        // means the second entry never starts, so the group is unparseable
+        // even though two 448s are present and the count says two.
+        let found = errors(validate(&with_header(&[
+            "11=ORDER-1",
+            "453=2",
+            "448=BROKER-A",
+            "447=D",
+            "447=D",
+            "448=BROKER-B",
+            "55=EURUSD",
+            "54=1",
+            "60=20260712-10:00:00",
+            "40=1",
+        ])));
+        assert!(found.contains(&ValidationError::RepeatedTagInGroupEntry {
+            count_tag: 453,
+            group: "NoPartyIDs".to_string(),
+            tag: 447,
+            name: "PartyIDSource".to_string(),
+        }));
+    }
+
+    #[test]
+    fn test_validate_group_detached_entry_is_rejected() {
+        // The second entry is separated from the group by Symbol(55), so it
+        // is not part of the group run: one entry found, two declared, and
+        // the stray 448 is not a message-level field.
+        let found = errors(validate(&with_header(&[
+            "11=ORDER-1",
+            "453=2",
+            "448=BROKER-A",
+            "55=EURUSD",
+            "448=BROKER-B",
+            "54=1",
+            "60=20260712-10:00:00",
+            "40=1",
+        ])));
+        assert!(found.contains(&ValidationError::GroupCountMismatch {
+            count_tag: 453,
+            name: "NoPartyIDs".to_string(),
+            declared: 2,
+            actual: 1,
+            delimiter_tag: 448,
+        }));
+        assert!(found.contains(&ValidationError::FieldNotAllowedForMessage {
+            tag: 448,
+            msg_type: "D".to_string(),
+        }));
+    }
+
+    #[test]
+    fn test_validate_group_delimiter_mismatch_is_reported() {
         // Entry starts with PartyRole(452) instead of PartyID(448).
-        let errors = validate(&with_header(&[
+        let found = errors(validate(&with_header(&[
             "11=ORDER-1",
             "453=1",
             "452=1",
@@ -584,9 +1026,8 @@ mod tests {
             "54=1",
             "60=20260712-10:00:00",
             "40=1",
-        ]))
-        .unwrap_err();
-        assert!(errors.contains(&ValidationError::GroupDelimiterMismatch {
+        ])));
+        assert!(found.contains(&ValidationError::GroupDelimiterMismatch {
             count_tag: 453,
             name: "NoPartyIDs".to_string(),
             expected: 448,
@@ -595,8 +1036,8 @@ mod tests {
     }
 
     #[test]
-    fn test_invalid_group_count_value() {
-        let errors = validate(&with_header(&[
+    fn test_validate_group_count_value_not_a_number_is_reported() {
+        let found = errors(validate(&with_header(&[
             "11=ORDER-1",
             "453=abc",
             "448=BROKER-A",
@@ -604,19 +1045,199 @@ mod tests {
             "54=1",
             "60=20260712-10:00:00",
             "40=1",
-        ]))
-        .unwrap_err();
-        assert!(errors.contains(&ValidationError::InvalidGroupCount {
+        ])));
+        assert!(found.contains(&ValidationError::InvalidGroupCount {
             tag: 453,
             name: "NoPartyIDs".to_string(),
             value: "abc".to_string(),
         }));
     }
 
+    /// Builds a dialect whose message carries two distinct groups that share
+    /// a delimiter tag.
+    fn dialect_with_two_groups_sharing_a_delimiter() -> Dictionary {
+        let mut dict = dialect_with_optional_component();
+        for (tag, name, field_type) in [
+            (100, "NoFirst", FieldType::NumInGroup),
+            (101, "NoSecond", FieldType::NumInGroup),
+            (200, "SharedDelimiter", FieldType::String),
+        ] {
+            dict.add_field(FieldDef::new(tag, name, field_type));
+        }
+        let member = SchemaFieldRef {
+            tag: 200,
+            name: "SharedDelimiter".to_string(),
+            required: true,
+        };
+        let group = |count_tag: u32, name: &str| GroupDef {
+            count_tag,
+            name: name.to_string(),
+            delimiter_tag: 200,
+            fields: vec![member.clone()],
+            groups: Vec::new(),
+            components: Vec::new(),
+            required: false,
+        };
+        dict.add_message(MessageDef {
+            msg_type: "U4".to_string(),
+            name: "TwoGroups".to_string(),
+            category: MessageCategory::App,
+            fields: Vec::new(),
+            groups: vec![group(100, "NoFirst"), group(101, "NoSecond")],
+            components: Vec::new(),
+        });
+        dict
+    }
+
     #[test]
-    fn test_unknown_msg_type_is_rejected_by_dictionary() {
+    fn test_validate_groups_sharing_a_delimiter_are_counted_separately() {
+        // Each group's entries are counted from its own count field, so one
+        // group's entries can no longer be credited to the other.
+        let dict = dialect_with_two_groups_sharing_a_delimiter();
+        let result = validate_with(
+            &dict,
+            &[
+                "8=FIX.4.4",
+                "9=100",
+                "35=U4",
+                "49=SENDER",
+                "56=TARGET",
+                "34=1",
+                "100=1",
+                "200=FIRST",
+                "101=2",
+                "200=SECOND-A",
+                "200=SECOND-B",
+                "10=000",
+            ],
+        );
+        assert_eq!(result, Ok(()));
+    }
+
+    #[test]
+    fn test_validate_groups_sharing_a_delimiter_still_catch_their_own_mismatch() {
+        let dict = dialect_with_two_groups_sharing_a_delimiter();
+        let found = errors(validate_with(
+            &dict,
+            &[
+                "8=FIX.4.4",
+                "9=100",
+                "35=U4",
+                "49=SENDER",
+                "56=TARGET",
+                "34=1",
+                "100=2",
+                "200=FIRST",
+                "101=1",
+                "200=SECOND",
+                "10=000",
+            ],
+        ));
+        assert_eq!(
+            found,
+            vec![ValidationError::GroupCountMismatch {
+                count_tag: 100,
+                name: "NoFirst".to_string(),
+                declared: 2,
+                actual: 1,
+                delimiter_tag: 200,
+            }]
+        );
+    }
+
+    #[test]
+    fn test_validate_nested_group_entries_pass() {
+        // PtysSubGrp: NoPartySubIDs(802) nests inside a NoPartyIDs entry.
+        let result = validate(&with_header(&[
+            "11=ORDER-1",
+            "453=1",
+            "448=BROKER-A",
+            "447=D",
+            "452=1",
+            "802=2",
+            "523=SUB-1",
+            "803=1",
+            "523=SUB-2",
+            "803=2",
+            "55=EURUSD",
+            "54=1",
+            "60=20260712-10:00:00",
+            "40=1",
+        ]));
+        assert_eq!(result, Ok(()));
+    }
+
+    #[test]
+    fn test_validate_nested_group_count_mismatch_is_reported() {
+        let found = errors(validate(&with_header(&[
+            "11=ORDER-1",
+            "453=1",
+            "448=BROKER-A",
+            "802=2",
+            "523=SUB-1",
+            "55=EURUSD",
+            "54=1",
+            "60=20260712-10:00:00",
+            "40=1",
+        ])));
+        assert!(found.contains(&ValidationError::GroupCountMismatch {
+            count_tag: 802,
+            name: "NoPartySubIDs".to_string(),
+            declared: 2,
+            actual: 1,
+            delimiter_tag: 523,
+        }));
+    }
+
+    #[test]
+    fn test_validate_missing_required_group_is_reported() {
+        // MarketDataRequest(V) requires NoMDEntryTypes(267) and
+        // NoRelatedSym(146); omitting both must name both groups.
+        let found = errors(validate(&[
+            "8=FIX.4.4",
+            "9=100",
+            "35=V",
+            "49=SENDER",
+            "56=TARGET",
+            "34=1",
+            "52=20260712-10:00:00",
+            "262=REQ-1",
+            "263=1",
+            "264=1",
+            "10=000",
+        ]));
+        assert!(found.contains(&ValidationError::MissingRequiredGroup {
+            count_tag: 267,
+            name: "NoMDEntryTypes".to_string(),
+        }));
+        assert!(found.contains(&ValidationError::MissingRequiredGroup {
+            count_tag: 146,
+            name: "NoRelatedSym".to_string(),
+        }));
+    }
+
+    #[test]
+    fn test_scope_expansion_fits_every_fix44_message() {
+        // The ceilings must accommodate the real dictionary: no message in
+        // FIX 4.4 may hit the depth or budget limit, or its own schema would
+        // be reported as an error against every message of that type.
+        let dict = fix44();
+        for msg_def in dict.messages() {
+            let mut builder = ScopeBuilder::new(dict);
+            let _ = builder.build(msg_def);
+            assert_eq!(
+                builder.errors,
+                Vec::new(),
+                "expanding {} exhausted a validator ceiling",
+                msg_def.name
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_unknown_msg_type_is_rejected() {
         // U-prefixed custom types decode fine but are not in FIX 4.4.
-        let msg = build(&[
+        let found = errors(validate(&[
             "8=FIX.4.4",
             "9=100",
             "35=U9",
@@ -625,14 +1246,9 @@ mod tests {
             "34=1",
             "52=20260712-10:00:00",
             "10=000",
-        ]);
-        let mut decoder = Decoder::new(msg.as_bytes()).with_checksum_validation(false);
-        let raw = decoder.decode().expect("test message decodes");
-        let errors = Validator::new(Dictionary::fix44())
-            .validate(&raw)
-            .unwrap_err();
+        ]));
         assert_eq!(
-            errors,
+            found,
             vec![ValidationError::UnknownMsgType {
                 msg_type: "U9".to_string(),
             }]
@@ -640,7 +1256,7 @@ mod tests {
     }
 
     #[test]
-    fn test_valid_heartbeat() {
+    fn test_validate_heartbeat_valid_passes() {
         let result = validate(&[
             "8=FIX.4.4",
             "9=60",
@@ -655,9 +1271,9 @@ mod tests {
     }
 
     #[test]
-    fn test_missing_required_header_field() {
+    fn test_validate_missing_required_header_field_is_reported() {
         // SendingTime(52) omitted.
-        let errors = validate(&[
+        let found = errors(validate(&[
             "8=FIX.4.4",
             "9=60",
             "35=0",
@@ -665,11 +1281,257 @@ mod tests {
             "56=TARGET",
             "34=2",
             "10=000",
-        ])
-        .unwrap_err();
-        assert!(errors.contains(&ValidationError::MissingRequiredField {
+        ]));
+        assert!(found.contains(&ValidationError::MissingRequiredField {
             tag: 52,
             name: "SendingTime".to_string(),
         }));
+    }
+
+    /// Builds a dialect whose message carries one required and one optional
+    /// component, each with a required member.
+    fn dialect_with_optional_component() -> Dictionary {
+        let mut dict = Dictionary::new(crate::schema::Version::Fix44);
+        for (tag, name, field_type) in [
+            (8, "BeginString", FieldType::String),
+            (9, "BodyLength", FieldType::Length),
+            (10, "CheckSum", FieldType::String),
+            (34, "MsgSeqNum", FieldType::SeqNum),
+            (35, "MsgType", FieldType::String),
+            (49, "SenderCompID", FieldType::String),
+            (56, "TargetCompID", FieldType::String),
+            (52, "SendingTime", FieldType::UtcTimestamp),
+            (55, "Symbol", FieldType::String),
+            (44, "Price", FieldType::Price),
+        ] {
+            dict.add_field(FieldDef::new(tag, name, field_type));
+        }
+        let required = |tag: u32, name: &str| SchemaFieldRef {
+            tag,
+            name: name.to_string(),
+            required: true,
+        };
+        dict.header = vec![
+            required(8, "BeginString"),
+            required(9, "BodyLength"),
+            required(35, "MsgType"),
+            required(49, "SenderCompID"),
+            required(56, "TargetCompID"),
+            required(34, "MsgSeqNum"),
+        ];
+        dict.trailer = vec![required(10, "CheckSum")];
+        dict.add_component(ComponentDef {
+            name: "Instrument".to_string(),
+            fields: vec![required(55, "Symbol")],
+            groups: Vec::new(),
+            components: Vec::new(),
+        });
+        dict.add_component(ComponentDef {
+            name: "PriceBlock".to_string(),
+            fields: vec![required(44, "Price")],
+            groups: Vec::new(),
+            components: Vec::new(),
+        });
+        dict.add_message(MessageDef {
+            msg_type: "U1".to_string(),
+            name: "Ping".to_string(),
+            category: MessageCategory::App,
+            fields: Vec::new(),
+            groups: Vec::new(),
+            components: vec![
+                ComponentRef::new("Instrument", true),
+                ComponentRef::new("PriceBlock", false),
+            ],
+        });
+        dict
+    }
+
+    #[test]
+    fn test_validate_optional_component_members_are_not_required() {
+        // PriceBlock is referenced with required='N', so its required
+        // member Price(44) must not be demanded of every message.
+        let dict = dialect_with_optional_component();
+        let result = validate_with(
+            &dict,
+            &[
+                "8=FIX.4.4",
+                "9=100",
+                "35=U1",
+                "49=SENDER",
+                "56=TARGET",
+                "34=1",
+                "55=EURUSD",
+                "10=000",
+            ],
+        );
+        assert_eq!(result, Ok(()));
+    }
+
+    #[test]
+    fn test_validate_required_component_members_are_still_required() {
+        let dict = dialect_with_optional_component();
+        let found = errors(validate_with(
+            &dict,
+            &[
+                "8=FIX.4.4",
+                "9=100",
+                "35=U1",
+                "49=SENDER",
+                "56=TARGET",
+                "34=1",
+                "44=1.25",
+                "10=000",
+            ],
+        ));
+        assert!(found.contains(&ValidationError::MissingRequiredField {
+            tag: 55,
+            name: "Symbol".to_string(),
+        }));
+    }
+
+    #[test]
+    fn test_validate_undefined_component_reference_is_reported() {
+        let mut dict = dialect_with_optional_component();
+        dict.add_message(MessageDef {
+            msg_type: "U2".to_string(),
+            name: "Pong".to_string(),
+            category: MessageCategory::App,
+            fields: Vec::new(),
+            groups: Vec::new(),
+            components: vec![ComponentRef::new("Nope", true)],
+        });
+        let found = errors(validate_with(
+            &dict,
+            &[
+                "8=FIX.4.4",
+                "9=100",
+                "35=U2",
+                "49=SENDER",
+                "56=TARGET",
+                "34=1",
+                "10=000",
+            ],
+        ));
+        assert!(found.contains(&ValidationError::UnknownComponent {
+            name: "Nope".to_string(),
+        }));
+    }
+
+    /// Validates a bare `U3` message against `dict`.
+    #[track_caller]
+    fn validate_u3(dict: &Dictionary) -> Result<(), Vec<ValidationError>> {
+        validate_with(
+            dict,
+            &[
+                "8=FIX.4.4",
+                "9=100",
+                "35=U3",
+                "49=SENDER",
+                "56=TARGET",
+                "34=1",
+                "10=000",
+            ],
+        )
+    }
+
+    #[test]
+    fn test_validate_component_chain_past_the_depth_ceiling_is_reported() {
+        // The loader would reject a chain this long, but a dictionary built
+        // by hand can hold one: the expansion stops at the ceiling and says
+        // so instead of recursing.
+        let mut dict = dialect_with_optional_component();
+        let links = MAX_SCOPE_DEPTH + 10;
+        for index in 0..links {
+            dict.add_component(ComponentDef {
+                name: format!("C{index}"),
+                fields: Vec::new(),
+                groups: Vec::new(),
+                components: vec![ComponentRef::new(format!("C{}", index + 1), true)],
+            });
+        }
+        dict.add_component(ComponentDef {
+            name: format!("C{links}"),
+            fields: Vec::new(),
+            groups: Vec::new(),
+            components: Vec::new(),
+        });
+        dict.add_message(MessageDef {
+            msg_type: "U3".to_string(),
+            name: "Deep".to_string(),
+            category: MessageCategory::App,
+            fields: Vec::new(),
+            groups: Vec::new(),
+            components: vec![ComponentRef::new("C0", true)],
+        });
+
+        let found = errors(validate_u3(&dict));
+        assert!(
+            found.iter().any(|error| matches!(
+                error,
+                ValidationError::SchemaTooDeep {
+                    limit: MAX_SCOPE_DEPTH,
+                    ..
+                }
+            )),
+            "expected a depth ceiling report, got {found:?}"
+        );
+    }
+
+    #[test]
+    fn test_validate_schema_past_the_node_budget_is_reported() {
+        let mut dict = dialect_with_optional_component();
+        dict.add_message(MessageDef {
+            msg_type: "U3".to_string(),
+            name: "Wide".to_string(),
+            category: MessageCategory::App,
+            fields: Vec::new(),
+            groups: Vec::new(),
+            components: (0..=MAX_SCOPE_NODES)
+                .map(|_| ComponentRef::new("Instrument", false))
+                .collect(),
+        });
+
+        let found = errors(validate_u3(&dict));
+        assert!(
+            found.contains(&ValidationError::SchemaTooLarge {
+                limit: MAX_SCOPE_NODES,
+            }),
+            "expected a node budget report, got {found:?}"
+        );
+    }
+
+    #[test]
+    fn test_validate_cyclic_component_schema_terminates() {
+        // The loader rejects a cycle, but a dictionary assembled by hand can
+        // still hold one: expansion must terminate rather than recurse
+        // forever.
+        let mut dict = dialect_with_optional_component();
+        dict.add_component(ComponentDef {
+            name: "Loop".to_string(),
+            fields: Vec::new(),
+            groups: Vec::new(),
+            components: vec![ComponentRef::new("Loop", true)],
+        });
+        dict.add_message(MessageDef {
+            msg_type: "U3".to_string(),
+            name: "Looping".to_string(),
+            category: MessageCategory::App,
+            fields: Vec::new(),
+            groups: Vec::new(),
+            components: vec![ComponentRef::new("Loop", true)],
+        });
+        let result = validate_with(
+            &dict,
+            &[
+                "8=FIX.4.4",
+                "9=100",
+                "35=U3",
+                "49=SENDER",
+                "56=TARGET",
+                "34=1",
+                "10=000",
+            ],
+        );
+        assert_eq!(result, Ok(()));
     }
 }


### PR DESCRIPTION
## Summary

Makes the dictionary and validator correct about structure — the one thing they exist to be authoritative about.

Closes #14.

## Stack

- **Base branch:** `stack/12-tagvalue-encoder` (PR #36)

## What was wrong

**The validator accepted messages whose structure did not match the schema.** Repeating groups whose count or delimiter disagreed with the definition validated clean. Since the validator is the only check that would catch a malformed group, this is the central defect rather than a detail.

**Component references were stored as bare names**, which discards per-reference requiredness. A component that is optional in one message and required in another was therefore treated as required everywhere — a false reject on one message and a false accept on another, from the same bug.

**`MULTIPLEVALUESTRING` was not recognised**, despite the vendored FIX 4.4 dictionary using exactly that spelling. Those fields silently fell back to a plain string, so their enum domain was never validated at all.

**The loader is an untrusted-input parser and was not treated as one.** It recursed without a depth bound on hostile XML, silently turned an unknown external field type into a string, and could finish loading with dangling or cyclic component references when delimiter discovery did not traverse them. Each is now a typed error with a documented ceiling. Group counts use checked arithmetic.

**`DictionaryError` and `ValidationError` were the last two public error enums in the workspace still exhaustive.** Both are `#[non_exhaustive]` now, which completes the set begun in #23.

## What was deliberately not touched

`spec/FIX44.xml` is vendored verbatim from QuickFIX under its licence. Where the loader disagreed with the file, **the loader was wrong** — the fix is always on the Rust side.

The `Validator` is still **not invoked** by the engine or the codec. It remains opt-in and unwired; that is a known documented gap and closing it is a separate decision, not something to smuggle in here. This PR makes the validator correct for whoever does call it.

No table of field types or required flags is hard-coded: the schema answers, which is the rule this crate exists to uphold.

## Tests

Workspace goes to **452 passing**, with a test per defect and one per hostile-XML case: depth, cycle, dangling reference, unknown type.

## Verification

```
cargo test --workspace                                    # 452 passed
cargo clippy --all-targets --all-features -- -D warnings  # clean
cargo fmt --all --check                                   # clean
make doc                                                  # clean
```
