### PR TITLE
fix(fast): correct presence-map semantics per operator

### DIFF
--- a/ironfix-fast/src/decoder.rs
+++ b/ironfix-fast/src/decoder.rs
@@ -22,8 +22,6 @@
 //! differs per entry point. Every error here is fatal for the frame, so a
 //! caller must not resume from a partially advanced offset; restart from a
 //! known frame boundary instead.
-//! declared length that has not been validated against the bytes actually
-//! available.
 
 use crate::error::FastError;
 use crate::operators::DictionaryValue;
@@ -44,8 +42,8 @@ pub(crate) const SIGN_BIT: u8 = 0x40;
 
 /// Maximum number of bytes a stop-bit encoded 64-bit integer may occupy.
 ///
-/// A 64-bit value carries at most 64 significant bits at seven payload
-/// bits per byte; a signed value needs nine payload bytes
+/// A 64-bit value carries at most 64 significant bits at seven payload bits
+/// per byte; a signed value needs nine payload bytes
 /// plus one sign-carry byte, so ten bytes is the longest legal encoding of
 /// either `i64::MIN` / `i64::MAX` or `u64::MAX`.
 ///
@@ -68,6 +66,25 @@ pub(crate) fn read_byte(data: &[u8], offset: &mut usize) -> Result<u8, FastError
     // cannot overflow a `usize`.
     *offset += 1;
     Ok(byte)
+}
+
+/// Writes `value` into `dict` under `key`, reusing the stored key when it is
+/// already there.
+///
+/// Operator state is rewritten for the same handful of fields on every message,
+/// so the interesting case is the one that must not allocate: an entry that
+/// already exists is overwritten in place, and only a key seen for the first
+/// time is copied into the map.
+pub(crate) fn store(
+    dict: &mut HashMap<String, DictionaryValue>,
+    key: &str,
+    value: DictionaryValue,
+) {
+    if let Some(slot) = dict.get_mut(key) {
+        *slot = value;
+    } else {
+        dict.insert(key.to_owned(), value);
+    }
 }
 
 /// FAST protocol decoder.
@@ -224,6 +241,106 @@ impl FastDecoder {
                 .ok_or(FastError::IntegerOverflow),
         }
     }
+
+    /// Decodes a nullable signed integer.
+    ///
+    /// FAST biases only the non-negative half of the range: zero is NULL, a
+    /// positive encoded value is one more than the value it denotes, and a
+    /// negative encoded value denotes itself. This is the counterpart of
+    /// [`FastEncoder::encode_nullable_int`](crate::FastEncoder::encode_nullable_int),
+    /// and the bias lives here rather than in every caller for the same reason
+    /// it does for the unsigned form.
+    ///
+    /// The representable domain is `i64::MIN..=i64::MAX - 1`.
+    ///
+    /// # Arguments
+    /// * `data` - The input bytes
+    /// * `offset` - Current position (will be updated)
+    ///
+    /// # Returns
+    /// The decoded value, or `None` for NULL.
+    ///
+    /// # Errors
+    /// Returns [`FastError::UnexpectedEof`] if the input ends mid-value, or
+    /// [`FastError::IntegerOverflow`] if the encoding is over-long or denotes a
+    /// value outside `i64`.
+    pub fn decode_nullable_int(data: &[u8], offset: &mut usize) -> Result<Option<i64>, FastError> {
+        let raw = Self::decode_int(data, offset)?;
+
+        if raw == 0 {
+            return Ok(None);
+        }
+
+        if raw < 0 {
+            // Negative values carry no bias.
+            return Ok(Some(raw));
+        }
+
+        raw.checked_sub(1)
+            .map(Some)
+            .ok_or(FastError::IntegerOverflow)
+    }
+
+    /// Decodes a nullable ASCII string.
+    ///
+    /// The nullable string forms shift each of the FAST 1.1 special encodings
+    /// by one leading `0x00`: a lone stop byte is NULL, `0x00 0x80` is the
+    /// empty string, and `0x00 0x00 0x80` is the one-character NUL string. Any
+    /// other encoding beginning with `0x00` is over-long and is rejected. This
+    /// is the counterpart of
+    /// [`FastEncoder::encode_nullable_ascii`](crate::FastEncoder::encode_nullable_ascii).
+    ///
+    /// # Arguments
+    /// * `data` - The input bytes
+    /// * `offset` - Current position (will be updated)
+    ///
+    /// # Returns
+    /// The decoded string, or `None` for NULL.
+    ///
+    /// # Errors
+    /// Returns [`FastError::UnexpectedEof`] if the stop bit is never reached
+    /// before the end of `data`, or [`FastError::InvalidString`] for an
+    /// over-long encoding with a leading `0x00`.
+    pub fn decode_nullable_ascii(
+        data: &[u8],
+        offset: &mut usize,
+    ) -> Result<Option<String>, FastError> {
+        let first_byte = *data.get(*offset).ok_or(FastError::UnexpectedEof)?;
+
+        if first_byte == STOP_BIT {
+            *offset += 1;
+            return Ok(None);
+        }
+
+        if first_byte == 0x00 {
+            let second_index = offset.checked_add(1).ok_or(FastError::UnexpectedEof)?;
+            let second_byte = *data.get(second_index).ok_or(FastError::UnexpectedEof)?;
+
+            if second_byte == STOP_BIT {
+                *offset = second_index
+                    .checked_add(1)
+                    .ok_or(FastError::UnexpectedEof)?;
+                return Ok(Some(String::new()));
+            }
+
+            if second_byte != 0x00 {
+                return Err(FastError::InvalidString);
+            }
+
+            let third_index = second_index
+                .checked_add(1)
+                .ok_or(FastError::UnexpectedEof)?;
+            if *data.get(third_index).ok_or(FastError::UnexpectedEof)? != STOP_BIT {
+                return Err(FastError::InvalidString);
+            }
+
+            *offset = third_index.checked_add(1).ok_or(FastError::UnexpectedEof)?;
+            return Ok(Some(String::from('\0')));
+        }
+
+        Self::read_ascii_run(data, offset).map(Some)
+    }
+
     /// Decodes an ASCII string using stop-bit encoding.
     ///
     /// Follows the FAST 1.1 string encodings: a lone stop byte (`0x80`) is the
@@ -259,6 +376,18 @@ impl FastDecoder {
             return Ok(String::from('\0'));
         }
 
+        Self::read_ascii_run(data, offset)
+    }
+
+    /// Reads a stop-bit terminated run of ASCII characters.
+    ///
+    /// This is the general string form, shared by the nullable and non-nullable
+    /// entry points once each has handled its own special encodings.
+    ///
+    /// # Errors
+    /// Returns [`FastError::UnexpectedEof`] if the stop bit is never reached
+    /// before the end of `data`.
+    fn read_ascii_run(data: &[u8], offset: &mut usize) -> Result<String, FastError> {
         // Locate the stop byte first, so the buffer is sized once from bytes
         // that are actually present rather than grown geometrically -- which
         // otherwise costs twice the field size in peak heap. The scan is
@@ -282,28 +411,74 @@ impl FastDecoder {
         Ok(result)
     }
 
-    /// Decodes a length-prefixed byte vector.
+    /// Decodes a length-prefixed byte vector, borrowing it from the input.
+    ///
+    /// The returned slice points into `data`, so decoding a byte field costs
+    /// neither an allocation nor a copy: a caller materialises an owned value
+    /// only when it needs one to outlive the buffer — which, for a FAST field,
+    /// is only true when it becomes operator state.
     ///
     /// The declared length is validated against the bytes actually remaining
-    /// **before** it is narrowed to a `usize` or used to size an allocation,
-    /// so a hostile length prefix can never over-allocate or index out of
-    /// bounds.
+    /// **before** it is narrowed to a `usize` or used to bound a slice, so a
+    /// hostile length prefix can never index out of bounds.
     ///
     /// # Arguments
     /// * `data` - The input bytes
     /// * `offset` - Current position (will be updated)
     ///
     /// # Returns
-    /// The decoded bytes.
+    /// The decoded bytes, borrowed from `data`.
     ///
     /// # Errors
     /// Returns [`FastError::UnexpectedEof`] if the length prefix is truncated
     /// or declares more bytes than remain in `data`, or
     /// [`FastError::IntegerOverflow`] if the length prefix itself is not a
     /// valid unsigned integer.
-    pub fn decode_bytes(data: &[u8], offset: &mut usize) -> Result<Vec<u8>, FastError> {
+    pub fn decode_bytes<'a>(data: &'a [u8], offset: &mut usize) -> Result<&'a [u8], FastError> {
         let declared_length = Self::decode_uint(data, offset)?;
+        Self::take_bytes(data, offset, declared_length)
+    }
 
+    /// Decodes a nullable length-prefixed byte vector, borrowing it from the
+    /// input.
+    ///
+    /// The length prefix is a nullable unsigned integer, so a lone stop byte is
+    /// NULL and every other length is biased by one. This is the counterpart of
+    /// [`FastEncoder::encode_nullable_bytes`](crate::FastEncoder::encode_nullable_bytes).
+    ///
+    /// # Arguments
+    /// * `data` - The input bytes
+    /// * `offset` - Current position (will be updated)
+    ///
+    /// # Returns
+    /// The decoded bytes borrowed from `data`, or `None` for NULL.
+    ///
+    /// # Errors
+    /// Returns [`FastError::UnexpectedEof`] if the length prefix is truncated
+    /// or declares more bytes than remain in `data`, or
+    /// [`FastError::IntegerOverflow`] if the length prefix is not a valid
+    /// unsigned integer.
+    pub fn decode_nullable_bytes<'a>(
+        data: &'a [u8],
+        offset: &mut usize,
+    ) -> Result<Option<&'a [u8]>, FastError> {
+        match Self::decode_nullable_uint(data, offset)? {
+            Some(declared_length) => Self::take_bytes(data, offset, declared_length).map(Some),
+            None => Ok(None),
+        }
+    }
+
+    /// Borrows `declared_length` bytes from `data` at `offset`, validating the
+    /// length against the bytes actually present before it is used.
+    ///
+    /// # Errors
+    /// Returns [`FastError::UnexpectedEof`] if `declared_length` exceeds the
+    /// bytes remaining in `data`.
+    fn take_bytes<'a>(
+        data: &'a [u8],
+        offset: &mut usize,
+        declared_length: u64,
+    ) -> Result<&'a [u8], FastError> {
         let remaining = data
             .len()
             .checked_sub(*offset)
@@ -317,10 +492,7 @@ impl FastDecoder {
         }
 
         let end = offset.checked_add(length).ok_or(FastError::UnexpectedEof)?;
-        let bytes = data
-            .get(*offset..end)
-            .ok_or(FastError::UnexpectedEof)?
-            .to_vec();
+        let bytes = data.get(*offset..end).ok_or(FastError::UnexpectedEof)?;
         *offset = end;
 
         Ok(bytes)
@@ -350,8 +522,12 @@ impl FastDecoder {
     }
 
     /// Sets a value in the global dictionary.
-    pub fn set_global(&mut self, key: impl Into<String>, value: DictionaryValue) {
-        self.global_dict.insert(key.into(), value);
+    ///
+    /// Overwriting an entry that already exists reuses its key, so the steady
+    /// state — the same fields updated message after message — allocates
+    /// nothing. Only the first write of a given key allocates.
+    pub fn set_global(&mut self, key: impl AsRef<str>, value: DictionaryValue) {
+        store(&mut self.global_dict, key.as_ref(), value);
     }
 
     /// Gets a value from a template dictionary.
@@ -363,16 +539,15 @@ impl FastDecoder {
     }
 
     /// Sets a value in a template dictionary.
-    pub fn set_template(
-        &mut self,
-        template_id: u32,
-        key: impl Into<String>,
-        value: DictionaryValue,
-    ) {
-        self.template_dicts
-            .entry(template_id)
-            .or_default()
-            .insert(key.into(), value);
+    ///
+    /// As with [`FastDecoder::set_global`], overwriting an existing entry
+    /// reuses its key and allocates nothing.
+    pub fn set_template(&mut self, template_id: u32, key: impl AsRef<str>, value: DictionaryValue) {
+        store(
+            self.template_dicts.entry(template_id).or_default(),
+            key.as_ref(),
+            value,
+        );
     }
 
     /// Returns the last used template ID.
@@ -791,9 +966,29 @@ mod tests {
         let mut offset = 0;
         assert_eq!(
             FastDecoder::decode_bytes(&bytes, &mut offset),
-            Ok(vec![1, 2, 3])
+            Ok(&[1, 2, 3][..])
         );
         assert_eq!(offset, bytes.len());
+    }
+
+    #[test]
+    fn test_decode_bytes_borrows_from_the_input() {
+        // The decoded field must point into the caller's buffer, not a copy of
+        // it: that is what makes decoding a byte field allocation-free.
+        let data = [0x83, 1, 2, 3];
+        let mut offset = 0;
+        let decoded = FastDecoder::decode_bytes(&data, &mut offset);
+        let payload = data.get(1..4);
+
+        assert!(decoded.is_ok());
+        assert!(payload.is_some());
+
+        if let (Ok(decoded), Some(payload)) = (decoded, payload) {
+            assert!(
+                std::ptr::eq(decoded.as_ptr(), payload.as_ptr()),
+                "the decoded slice must borrow the input buffer, not copy it"
+            );
+        }
     }
 
     #[test]
@@ -802,9 +997,186 @@ mod tests {
         let mut offset = 0;
         assert_eq!(
             FastDecoder::decode_bytes(&data, &mut offset),
-            Ok(Vec::new())
+            Ok(&[][..] as &[u8])
         );
         assert_eq!(offset, 1);
+    }
+
+    #[test]
+    fn test_decode_nullable_bytes_round_trips_through_the_encoder() {
+        for value in [None, Some(&[][..]), Some(&[1, 2, 3][..]), Some(&[0xFF][..])] {
+            let mut encoder = FastEncoder::new();
+            assert_eq!(encoder.encode_nullable_bytes(value), Ok(()));
+            let buffer = encoder.finish();
+
+            let mut offset = 0;
+            assert_eq!(
+                FastDecoder::decode_nullable_bytes(&buffer, &mut offset),
+                Ok(value),
+                "nullable bytes round trip {value:?}"
+            );
+            assert_eq!(offset, buffer.len(), "the whole value must be consumed");
+        }
+    }
+
+    #[test]
+    fn test_decode_nullable_bytes_lone_stop_byte_is_null() {
+        let mut offset = 0;
+        assert_eq!(
+            FastDecoder::decode_nullable_bytes(&[0x80], &mut offset),
+            Ok(None)
+        );
+        assert_eq!(offset, 1);
+    }
+
+    #[test]
+    fn test_decode_nullable_bytes_huge_declared_length_is_unexpected_eof() {
+        // A biased length of u64::MAX with a three-byte body.
+        let mut data = vec![0x01, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0xFF];
+        data.extend_from_slice(&[1, 2, 3]);
+
+        let mut offset = 0;
+        assert_eq!(
+            FastDecoder::decode_nullable_bytes(&data, &mut offset),
+            Err(FastError::UnexpectedEof)
+        );
+    }
+
+    #[test]
+    fn test_decode_nullable_int_round_trips_through_the_encoder() {
+        for value in [
+            None,
+            Some(0),
+            Some(1),
+            Some(-1),
+            Some(63),
+            Some(64),
+            Some(-64),
+            Some(-65),
+            Some(i64::MIN),
+            Some(i64::MAX - 1),
+        ] {
+            let mut encoder = FastEncoder::new();
+            assert_eq!(encoder.encode_nullable_int(value), Ok(()));
+            let buffer = encoder.finish();
+
+            let mut offset = 0;
+            assert_eq!(
+                FastDecoder::decode_nullable_int(&buffer, &mut offset),
+                Ok(value),
+                "nullable int round trip {value:?}"
+            );
+            assert_eq!(offset, buffer.len(), "the whole value must be consumed");
+        }
+    }
+
+    #[test]
+    fn test_decode_nullable_int_biases_only_the_non_negative_half() {
+        // Zero is NULL, positive values carry the bias, negative ones do not.
+        let cases: [(&[u8], Option<i64>); 4] = [
+            (&[0x80], None),
+            (&[0x81], Some(0)),
+            (&[0x82], Some(1)),
+            (&[0xFF], Some(-1)),
+        ];
+
+        for (encoded, expected) in cases {
+            let mut offset = 0;
+            assert_eq!(
+                FastDecoder::decode_nullable_int(encoded, &mut offset),
+                Ok(expected),
+                "{encoded:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_encode_nullable_int_rejects_the_value_outside_its_domain() {
+        let mut encoder = FastEncoder::new();
+        assert_eq!(
+            encoder.encode_nullable_int(Some(i64::MAX)),
+            Err(FastError::IntegerOverflow)
+        );
+        assert!(
+            encoder.is_empty(),
+            "an overflowing value must not be biased into the NULL representation"
+        );
+    }
+
+    #[test]
+    fn test_decode_nullable_ascii_round_trips_through_the_encoder() {
+        for value in [None, Some(""), Some("\0"), Some("A"), Some("EURUSD")] {
+            let mut encoder = FastEncoder::new();
+            assert_eq!(encoder.encode_nullable_ascii(value), Ok(()));
+            let buffer = encoder.finish();
+
+            let mut offset = 0;
+            assert_eq!(
+                FastDecoder::decode_nullable_ascii(&buffer, &mut offset),
+                Ok(value.map(str::to_string)),
+                "nullable ascii round trip {value:?}"
+            );
+            assert_eq!(offset, buffer.len(), "the whole value must be consumed");
+        }
+    }
+
+    #[test]
+    fn test_decode_nullable_ascii_special_forms_are_shifted_by_one_zero_byte() {
+        // Each nullable form is its non-nullable counterpart with one more
+        // leading 0x00; confusing the two shifts every value in the message.
+        let cases: [(&[u8], Option<&str>); 3] = [
+            (&[0x80], None),
+            (&[0x00, 0x80], Some("")),
+            (&[0x00, 0x00, 0x80], Some("\0")),
+        ];
+
+        for (encoded, expected) in cases {
+            let mut offset = 0;
+            assert_eq!(
+                FastDecoder::decode_nullable_ascii(encoded, &mut offset),
+                Ok(expected.map(str::to_string)),
+                "{encoded:?}"
+            );
+            assert_eq!(offset, encoded.len());
+        }
+    }
+
+    #[test]
+    fn test_decode_nullable_ascii_over_long_leading_zero_is_invalid_string() {
+        for data in [
+            &[0x00, b'a' | 0x80][..],
+            &[0x00, 0x00, b'a' | 0x80][..],
+            &[0x00, 0x00, 0x00, 0x80][..],
+        ] {
+            let mut offset = 0;
+            assert_eq!(
+                FastDecoder::decode_nullable_ascii(data, &mut offset),
+                Err(FastError::InvalidString),
+                "{data:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_decode_nullable_ascii_truncated_leading_zeros_is_unexpected_eof() {
+        for data in [&[0x00][..], &[0x00, 0x00][..]] {
+            let mut offset = 0;
+            assert_eq!(
+                FastDecoder::decode_nullable_ascii(data, &mut offset),
+                Err(FastError::UnexpectedEof),
+                "{data:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_encode_nullable_ascii_leading_nul_string_is_invalid_string() {
+        let mut encoder = FastEncoder::new();
+        assert_eq!(
+            encoder.encode_nullable_ascii(Some("\0a")),
+            Err(FastError::InvalidString)
+        );
+        assert!(encoder.is_empty(), "nothing may reach the wire on error");
     }
 
     #[test]

--- a/ironfix-fast/src/encoder.rs
+++ b/ironfix-fast/src/encoder.rs
@@ -13,7 +13,7 @@
 //! [`MAX_INT_ENCODED_LEN`] for an integer, so the encoder can never emit a
 //! frame its own decoder would reject.
 
-use crate::decoder::{MAX_INT_ENCODED_LEN, PAYLOAD_BITS, PAYLOAD_MASK, SIGN_BIT, STOP_BIT};
+use crate::decoder::{MAX_INT_ENCODED_LEN, PAYLOAD_BITS, PAYLOAD_MASK, SIGN_BIT, STOP_BIT, store};
 use crate::error::FastError;
 use crate::operators::DictionaryValue;
 use smallvec::SmallVec;
@@ -201,6 +201,97 @@ impl FastEncoder {
         Ok(())
     }
 
+    /// Encodes a nullable signed integer.
+    ///
+    /// FAST biases only the non-negative half of the range: `None` is the
+    /// single stop byte `0x80`, a non-negative value is encoded one higher than
+    /// it is, and a negative value is encoded as itself. The representable
+    /// domain is therefore `i64::MIN..=i64::MAX - 1`: `Some(i64::MAX)` has no
+    /// encoding and is rejected rather than silently biased into the `None`
+    /// representation.
+    ///
+    /// # Arguments
+    /// * `value` - The optional value to encode
+    ///
+    /// # Errors
+    /// Returns [`FastError::IntegerOverflow`] for `Some(i64::MAX)`.
+    pub fn encode_nullable_int(&mut self, value: Option<i64>) -> Result<(), FastError> {
+        match value {
+            Some(v) if v < 0 => self.encode_int(v),
+            Some(v) => {
+                let biased = v.checked_add(1).ok_or(FastError::IntegerOverflow)?;
+                self.encode_int(biased);
+            }
+            None => self.buffer.push(STOP_BIT),
+        }
+
+        Ok(())
+    }
+
+    /// Encodes a nullable ASCII string.
+    ///
+    /// The nullable string forms shift each of the FAST 1.1 special encodings
+    /// by one leading `0x00`: `None` is a lone stop byte (`0x80`), the empty
+    /// string is `0x00 0x80`, and the one-character NUL string is
+    /// `0x00 0x00 0x80`. A longer string beginning with NUL has no legal
+    /// representation and is refused rather than written to the wire in a form
+    /// the decoder must reject.
+    ///
+    /// # Arguments
+    /// * `value` - The optional string to encode
+    ///
+    /// # Errors
+    /// Returns [`FastError::InvalidString`] if `value` contains a non-ASCII
+    /// character, or if it begins with a NUL and is longer than one character.
+    pub fn encode_nullable_ascii(&mut self, value: Option<&str>) -> Result<(), FastError> {
+        let Some(value) = value else {
+            self.buffer.push(STOP_BIT);
+            return Ok(());
+        };
+
+        if !value.is_ascii() {
+            return Err(FastError::InvalidString);
+        }
+
+        match value.as_bytes() {
+            [] => {
+                self.buffer.extend_from_slice(&[0x00, STOP_BIT]);
+                Ok(())
+            }
+            [0x00] => {
+                self.buffer.extend_from_slice(&[0x00, 0x00, STOP_BIT]);
+                Ok(())
+            }
+            [0x00, ..] => Err(FastError::InvalidString),
+            _ => self.encode_ascii(value),
+        }
+    }
+
+    /// Encodes a nullable byte vector with a nullable length prefix.
+    ///
+    /// `None` is a lone stop byte; any other value carries a length prefix
+    /// biased by one, matching
+    /// [`FastDecoder::decode_nullable_bytes`](crate::FastDecoder::decode_nullable_bytes).
+    ///
+    /// # Arguments
+    /// * `value` - The optional bytes to encode
+    ///
+    /// # Errors
+    /// Returns [`FastError::IntegerOverflow`] if the length of `value` cannot
+    /// be represented in the biased nullable domain.
+    pub fn encode_nullable_bytes(&mut self, value: Option<&[u8]>) -> Result<(), FastError> {
+        match value {
+            Some(bytes) => {
+                let length = u64::try_from(bytes.len()).map_err(|_| FastError::IntegerOverflow)?;
+                self.encode_nullable_uint(Some(length))?;
+                self.buffer.extend_from_slice(bytes);
+            }
+            None => self.buffer.push(STOP_BIT),
+        }
+
+        Ok(())
+    }
+
     /// Returns the encoded bytes.
     #[must_use]
     pub fn finish(self) -> Vec<u8> {
@@ -244,8 +335,12 @@ impl FastEncoder {
     }
 
     /// Sets a value in the global dictionary.
-    pub fn set_global(&mut self, key: impl Into<String>, value: DictionaryValue) {
-        self.global_dict.insert(key.into(), value);
+    ///
+    /// Overwriting an entry that already exists reuses its key, so the steady
+    /// state — the same fields updated message after message — allocates
+    /// nothing. Only the first write of a given key allocates.
+    pub fn set_global(&mut self, key: impl AsRef<str>, value: DictionaryValue) {
+        store(&mut self.global_dict, key.as_ref(), value);
     }
 
     /// Appends `bytes` — accumulated least significant byte first — to `out` in

--- a/ironfix-fast/src/error.rs
+++ b/ironfix-fast/src/error.rs
@@ -35,10 +35,15 @@ pub enum FastError {
         max_bytes: usize,
     },
 
-    /// A presence map bit was requested after every bit had been consumed.
+    /// Every encoded presence-map bit has been consumed.
     ///
-    /// A truncated presence map must not read as "all remaining fields
-    /// absent"; exhaustion is an explicit protocol error.
+    /// This is a primitive-level signal from
+    /// [`PresenceMap::next_bit`](crate::PresenceMap::next_bit), not a decode
+    /// failure. Per FAST v1.1 §6.3.1 a presence map carries an infinite implied
+    /// suffix of zero bits, so a field past the encoded bits is absent; the
+    /// operator layer reads this exhaustion as absent and does not surface it.
+    /// It is exposed so a caller that wants the strict encoded length can tell
+    /// where the encoded bits end.
     #[error("presence map exhausted")]
     PresenceMapExhausted,
 

--- a/ironfix-fast/src/lib.rs
+++ b/ironfix-fast/src/lib.rs
@@ -12,28 +12,40 @@
 //! It uses techniques like stop-bit encoding, presence maps, and field operators
 //! to achieve high compression ratios.
 //!
-//! ## What this crate provides
+//! ## What this crate implements
 //!
-//! These are encoding *primitives*, not a complete FAST implementation:
+//! - **Stop-bit encoding**: unsigned and signed integers, ASCII strings and
+//!   byte vectors, each in a nullable and a non-nullable form, encoder and
+//!   decoder paired so every encoding this crate emits is one it accepts back.
+//! - **Presence maps**: [`PresenceMap`] decodes a map with a size ceiling and
+//!   encodes it in the minimal form.
+//! - **Field operators**: the [`Operator`] table, and the
+//!   rule that decides — from the operator, the field's optionality and the
+//!   presence map — whether a field's value is in the stream, comes from the
+//!   template's initial value, comes from the operator dictionary, or is
+//!   absent. That decision is
+//!   [`Operator::transfer`](operators::Operator::transfer), and it is the piece
+//!   that keeps a positional presence map aligned.
 //!
-//! - **Stop-bit encoding**: integer and string encode/decode
-//! - **Presence maps**: [`PresenceMap`] / [`PresenceMapBuilder`], tracking which
-//!   optional fields are present
-//! - **Field operators**: [`operators::Operator`] — copy, delta, increment,
-//!   tail and default — with per-template and global
-//!   [`operators::DictionaryScope`] for previous-value state
+//! ## What this crate does not implement yet
 //!
-//! ## Not provided
+//! There is **no template layer**: nothing here parses a FAST template XML
+//! file, holds a field sequence, or applies an operator to produce a value.
+//! Concretely, still missing are the template model (field identity, type,
+//! optionality and initial value), operator *application* (delta arithmetic,
+//! increment, tail combination), the decimal codec that pairs a mantissa with
+//! an exponent, and sequence decoding with its length ceiling. Several
+//! [`FastError`] variants exist for that work and are not constructed yet.
 //!
-//! - **No template definitions and no template XML parser.** Templates are
-//!   referred to only by numeric id, for scoping the previous-value dictionary;
-//!   nothing here reads a FAST template file or describes a message structure.
-//! - **No transport.** There is no UDP multicast receiver and no A/B feed
-//!   arbitration.
-//! - **Not wired into the engine.** This crate sits parallel to
-//!   `ironfix-tagvalue`, depends only on `ironfix-core`, and is not used by the
-//!   session or engine path. Driving it is the caller's job — see the `fast_*`
-//!   examples in `ironfix-example`.
+//! Two consequences are worth stating plainly. This crate cannot decode a FAST
+//! message end to end — it decodes the fields of one, given something else that
+//! knows their order. And because a presence map's bits are only meaningful
+//! against a known field count, the padding bits inside its last byte are
+//! indistinguishable here from genuinely absent fields; closing that gap needs
+//! the template layer.
+//!
+//! `ironfix-fast` is also not wired into the session path: it is parallel to
+//! `ironfix-tagvalue`, not downstream of it.
 //!
 //! ## Untrusted input
 //!
@@ -60,4 +72,5 @@ pub mod pmap;
 pub use decoder::{FastDecoder, MAX_INT_ENCODED_LEN};
 pub use encoder::FastEncoder;
 pub use error::FastError;
+pub use operators::{DictionaryScope, DictionaryValue, FieldTransfer, Operator};
 pub use pmap::{MAX_PMAP_BYTES, PresenceMap, PresenceMapBuilder};

--- a/ironfix-fast/src/operators.rs
+++ b/ironfix-fast/src/operators.rs
@@ -148,29 +148,47 @@ impl Operator {
     /// its value comes from.
     ///
     /// This is the pmap-consuming half of FAST field decoding: it advances the
-    /// map by exactly the number of bits [`Operator::requires_pmap`] says this
-    /// field owns — zero or one — so a sequence of calls stays aligned with the
+    /// map by the number of bits [`Operator::requires_pmap`] says this field
+    /// owns — zero or one — so a sequence of calls stays aligned with the
     /// sender. Reading the value itself is the caller's job, because it needs
     /// the field's type and initial value.
+    ///
+    /// Per FAST v1.1 §6.3.1 a presence map carries an infinite implied suffix
+    /// of zero bits: once the encoded bits are used up, every further
+    /// pmap-owning field reads a zero bit and is therefore absent. FAST has no
+    /// too-short presence map, so a map that ends before the template's last
+    /// pmap field is legal — it is the minimal form a conformant sender emits
+    /// when the trailing fields are absent — and decodes without error. A field
+    /// that reads the implied suffix does not advance the map, which stays at
+    /// its end and answers zero for every later field, keeping the sequence
+    /// aligned all the same.
     ///
     /// # Arguments
     /// * `optional` - Whether the field is optional (nullable) in its template
     /// * `pmap` - The message's presence map, positioned at this field's bit
     ///
     /// # Errors
-    /// Returns [`FastError::PresenceMapExhausted`] if this field owns a bit and
-    /// the map has none left. A map that runs out is a truncated map, and
-    /// treating the missing bits as "absent" would let a short message decode
-    /// as a valid one.
+    /// A presence map that ends before this field's bit is not an error: the
+    /// bit reads as absent per the zero-suffix rule above. The `Result` is
+    /// retained so that any other primitive-level presence-map failure can
+    /// propagate rather than be silently read as absent.
     pub fn transfer(
         &self,
         optional: bool,
         pmap: &mut PresenceMap,
     ) -> Result<FieldTransfer, FastError> {
         // Consume the bit first, and exactly once, so the map stays aligned
-        // whichever arm below answers.
+        // whichever arm below answers. FAST v1.1 §6.3.1 defines the presence
+        // map as carrying an infinite implied suffix of zero bits, so a field
+        // whose bit lies past the encoded map is absent (0), not a truncation —
+        // FAST has no too-short presence map. Only that exhaustion is read as
+        // absent; any other primitive-level error still propagates.
         let present = if self.requires_pmap(optional) {
-            Some(pmap.next_bit()?)
+            match pmap.next_bit() {
+                Ok(bit) => Some(bit),
+                Err(FastError::PresenceMapExhausted) => Some(false),
+                Err(other) => return Err(other),
+            }
         } else {
             None
         };
@@ -469,12 +487,27 @@ mod tests {
     }
 
     #[test]
-    fn test_operator_transfer_without_a_bit_is_presence_map_exhausted() {
-        // A truncated map must not read as "every remaining field is absent".
+    fn test_operator_transfer_past_the_encoded_map_reads_as_absent() {
+        // FAST v1.1 §6.3.1: a bit past the encoded presence map is the implied
+        // zero suffix — absent — not a truncation error. A Copy field with an
+        // empty map therefore falls back to the dictionary, without error, and
+        // the exhausted map does not advance.
         let mut pmap = PresenceMap::new();
         assert_eq!(
             Operator::Copy.transfer(false, &mut pmap),
-            Err(FastError::PresenceMapExhausted)
+            Ok(FieldTransfer::Dictionary)
+        );
+        assert_eq!(
+            pmap.position(),
+            0,
+            "the implied zero suffix does not advance the map"
+        );
+
+        // An optional constant past the end is likewise absent, not an error.
+        let mut pmap = PresenceMap::new();
+        assert_eq!(
+            Operator::Constant.transfer(true, &mut pmap),
+            Ok(FieldTransfer::Absent)
         );
 
         // The operators that own no bit are unaffected by an empty map.
@@ -483,6 +516,51 @@ mod tests {
             Operator::Delta.transfer(true, &mut pmap),
             Ok(FieldTransfer::Stream)
         );
+    }
+
+    #[test]
+    fn test_operator_transfer_eight_plus_fields_over_one_byte_map_honours_zero_suffix() {
+        // A conformant peer whose trailing pmap-owning fields are absent emits a
+        // legal one-byte (seven data-bit) presence map. A template with ten Copy
+        // fields must decode it: the seven encoded bits drive the first seven
+        // fields, and the remaining three read the implied zero suffix as absent
+        // — with no `PresenceMapExhausted`.
+        //
+        // 0b1101_0101: stop bit set, payload bits (6..0) = 1_0_1_0_1_0_1.
+        let data = [0b1101_0101];
+        let mut offset = 0;
+        let decoded = PresenceMap::decode(&data, &mut offset);
+        assert!(decoded.is_ok());
+
+        if let Ok(mut pmap) = decoded {
+            // A Copy field is `Stream` on a set bit and `Dictionary` on a clear
+            // or implied-zero bit. The first seven entries are the encoded bits;
+            // the last three are the implied zero suffix.
+            let expected = [
+                FieldTransfer::Stream,     // bit 1
+                FieldTransfer::Dictionary, // bit 0
+                FieldTransfer::Stream,     // bit 1
+                FieldTransfer::Dictionary, // bit 0
+                FieldTransfer::Stream,     // bit 1
+                FieldTransfer::Dictionary, // bit 0
+                FieldTransfer::Stream,     // bit 1
+                FieldTransfer::Dictionary, // implied zero
+                FieldTransfer::Dictionary, // implied zero
+                FieldTransfer::Dictionary, // implied zero
+            ];
+
+            for (index, want) in expected.iter().enumerate() {
+                assert_eq!(
+                    Operator::Copy.transfer(false, &mut pmap),
+                    Ok(*want),
+                    "field {index} on a legal one-byte map"
+                );
+            }
+
+            // Only the seven encoded bits were consumed; the implied suffix does
+            // not advance the map past its end.
+            assert_eq!(pmap.position(), 7, "only the encoded bits are consumed");
+        }
     }
 
     #[test]

--- a/ironfix-fast/src/operators.rs
+++ b/ironfix-fast/src/operators.rs
@@ -8,7 +8,21 @@
 //!
 //! Operators define how field values are encoded and decoded relative to
 //! previous values in the dictionary.
+//!
+//! The one thing this module must get right is **which operators occupy a bit
+//! in the presence map**, because the presence map is positional: a field that
+//! takes a bit it should not have — or skips one it should have taken —
+//! shifts every later bit and silently corrupts the rest of the message. The
+//! matrix lives in [`Operator::requires_pmap`] and is applied in
+//! [`Operator::transfer`], which is the only place the two are allowed to
+//! disagree with each other (they cannot: the second calls the first).
+//!
+//! Note that the answer depends on whether the field is optional — a constant
+//! field takes a bit only when it is optional — so the matrix cannot be
+//! expressed as one boolean per operator.
 
+use crate::error::FastError;
+use crate::pmap::PresenceMap;
 use serde::{Deserialize, Serialize};
 
 /// FAST field operator types.
@@ -31,8 +45,46 @@ pub enum Operator {
     Tail,
 }
 
+/// Where the value of a field comes from, once the presence map has been
+/// consulted.
+///
+/// This is the decision an operator makes for one field occurrence; applying it
+/// — reading the value, adding a delta, incrementing, combining a tail — needs
+/// the field's type and initial value, which live in a template. See the
+/// crate-level docs for what this crate does and does not implement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FieldTransfer {
+    /// The value is encoded in the stream and must be read from it.
+    ///
+    /// For an optional field this is the nullable representation, so the value
+    /// read may itself be NULL.
+    Stream,
+    /// The value is the initial value declared for the field in the template.
+    ///
+    /// If an optional field declares no initial value, FAST defines the result
+    /// as absent; if a mandatory field declares none, the template is in error.
+    /// Neither can be decided here, because an initial value belongs to the
+    /// template.
+    InitialValue,
+    /// The value is derived from the operator's dictionary entry — the previous
+    /// value of the field.
+    ///
+    /// When that entry is undefined the fallback is the initial value, and
+    /// failing that the field is absent (optional) or the message is in error
+    /// (mandatory). As with [`FieldTransfer::InitialValue`], resolving it needs
+    /// the template.
+    Dictionary,
+    /// The field has no value in this message.
+    Absent,
+}
+
 impl Operator {
-    /// Returns true if this operator uses the dictionary.
+    /// Returns true if this operator keeps state in the operator dictionary.
+    ///
+    /// Copy, increment, delta and tail all decode against the previous value of
+    /// the field; constant and default read their fallback from the template's
+    /// initial value instead, and a field with no operator has no fallback at
+    /// all.
     #[must_use]
     pub const fn uses_dictionary(&self) -> bool {
         matches!(
@@ -41,26 +93,116 @@ impl Operator {
         )
     }
 
-    /// Returns true if this operator requires a presence map bit.
+    /// Returns true if a field with this operator occupies a bit in the
+    /// presence map.
+    ///
+    /// The presence map is positional, so this answer must be exact: a field
+    /// that takes a bit it should not have shifts every later bit and corrupts
+    /// the remainder of the message. Per FAST v1.1 §6.3 (field operators) and
+    /// the operator table in its appendix:
+    ///
+    /// | Operator | Mandatory | Optional | Why |
+    /// |---|---|---|---|
+    /// | [`Operator::None`] | no | no | the value is always in the stream, so there is nothing for a bit to say |
+    /// | [`Operator::Constant`] | no | **yes** | the value is never in the stream; when optional, the bit is the only thing that distinguishes the constant from absent |
+    /// | [`Operator::Default`] | yes | yes | the bit selects between a value in the stream and the initial value |
+    /// | [`Operator::Copy`] | yes | yes | the bit selects between a value in the stream and the previous value |
+    /// | [`Operator::Increment`] | yes | yes | the bit selects between a value in the stream and the previous value plus one |
+    /// | [`Operator::Delta`] | no | no | the delta is always in the stream; an optional delta signals absence with a NULL delta, not with a bit |
+    /// | [`Operator::Tail`] | yes | yes | the bit selects between a tail in the stream and the previous value |
+    ///
+    /// # Arguments
+    /// * `optional` - Whether the field is optional (nullable) in its template
     #[must_use]
-    pub const fn requires_pmap(&self) -> bool {
-        matches!(
-            self,
-            Self::None | Self::Copy | Self::Increment | Self::Delta | Self::Tail
-        )
+    pub const fn requires_pmap(&self, optional: bool) -> bool {
+        match self {
+            // The value is always transferred, so no bit is needed.
+            Self::None | Self::Delta => false,
+            // A mandatory constant is fully determined by the template; an
+            // optional one needs a bit to say present-or-absent.
+            Self::Constant => optional,
+            Self::Default | Self::Copy | Self::Increment | Self::Tail => true,
+        }
     }
 
-    /// Returns true if the value can be absent from the stream.
+    /// Returns true if the field's value may be omitted from the stream.
+    ///
+    /// "Omitted" here means *not transferred* — the decoder reconstructs the
+    /// value from the template or the dictionary. It is not the same question
+    /// as whether the field may be null, which is the field's optionality and
+    /// not a property of its operator.
+    ///
+    /// A constant value is never transferred, so it can always be omitted; a
+    /// delta is always transferred, as is a field with no operator. The
+    /// remaining operators omit the value whenever their presence map bit is
+    /// clear.
     #[must_use]
     pub const fn can_be_absent(&self) -> bool {
-        matches!(
-            self,
-            Self::Default | Self::Copy | Self::Increment | Self::Delta | Self::Tail
-        )
+        match self {
+            Self::None | Self::Delta => false,
+            Self::Constant | Self::Default | Self::Copy | Self::Increment | Self::Tail => true,
+        }
+    }
+
+    /// Consumes this field's presence map bit, if it has one, and reports where
+    /// its value comes from.
+    ///
+    /// This is the pmap-consuming half of FAST field decoding: it advances the
+    /// map by exactly the number of bits [`Operator::requires_pmap`] says this
+    /// field owns — zero or one — so a sequence of calls stays aligned with the
+    /// sender. Reading the value itself is the caller's job, because it needs
+    /// the field's type and initial value.
+    ///
+    /// # Arguments
+    /// * `optional` - Whether the field is optional (nullable) in its template
+    /// * `pmap` - The message's presence map, positioned at this field's bit
+    ///
+    /// # Errors
+    /// Returns [`FastError::PresenceMapExhausted`] if this field owns a bit and
+    /// the map has none left. A map that runs out is a truncated map, and
+    /// treating the missing bits as "absent" would let a short message decode
+    /// as a valid one.
+    pub fn transfer(
+        &self,
+        optional: bool,
+        pmap: &mut PresenceMap,
+    ) -> Result<FieldTransfer, FastError> {
+        // Consume the bit first, and exactly once, so the map stays aligned
+        // whichever arm below answers.
+        let present = if self.requires_pmap(optional) {
+            Some(pmap.next_bit()?)
+        } else {
+            None
+        };
+
+        // `None` for an operator that always owns a bit is unreachable, but it
+        // is spelled out rather than left to a wildcard that would also swallow
+        // a future operator.
+        Ok(match (self, present) {
+            // Always transferred, with or without a template.
+            (Self::None | Self::Delta, _) => FieldTransfer::Stream,
+            // The value never travels: a mandatory constant is fully determined
+            // by the template, and an optional one uses its bit only to say
+            // whether the constant applies at all.
+            (Self::Constant, None | Some(true)) => FieldTransfer::InitialValue,
+            (Self::Constant, Some(false)) => FieldTransfer::Absent,
+            (Self::Default, Some(true)) => FieldTransfer::Stream,
+            (Self::Default, Some(false) | None) => FieldTransfer::InitialValue,
+            (Self::Copy | Self::Increment | Self::Tail, Some(true)) => FieldTransfer::Stream,
+            (Self::Copy | Self::Increment | Self::Tail, Some(false) | None) => {
+                FieldTransfer::Dictionary
+            }
+        })
     }
 }
 
 /// Dictionary scope for operator state.
+///
+/// Only [`DictionaryScope::Global`] and [`DictionaryScope::Template`] have
+/// backing storage in this crate today — see
+/// [`FastDecoder`](crate::FastDecoder). [`DictionaryScope::Type`] is part of the
+/// FAST model and is named here, but nothing stores against it yet; it arrives
+/// with the template layer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
 pub enum DictionaryScope {
     /// Global dictionary shared across all templates.
@@ -69,6 +211,8 @@ pub enum DictionaryScope {
     /// Template-specific dictionary.
     Template,
     /// Type-specific dictionary.
+    ///
+    /// Not backed by storage in this crate yet.
     Type,
 }
 
@@ -105,20 +249,36 @@ impl DictionaryValue {
         matches!(self, Self::Empty)
     }
 
-    /// Returns the value as an i64, if applicable.
+    /// Returns the value as an `i64`, if it is an integer that fits.
+    ///
+    /// A value stored as [`DictionaryValue::UInt`] is readable here whenever it
+    /// is within `i64` range, and `None` otherwise. Reading across the two
+    /// integer variants matters because nothing forces the writer and the
+    /// reader of a dictionary entry to agree on signedness — a copy or
+    /// increment operator that stored a `UInt` must still be able to read its
+    /// own previous value back. The conversion is range-checked, never
+    /// truncating: an out-of-range value is `None`, not a wrapped number.
     #[must_use]
     pub const fn as_i64(&self) -> Option<i64> {
         match self {
             Self::Int(v) => Some(*v),
+            // The guard makes the cast exact.
+            Self::UInt(v) if *v <= i64::MAX as u64 => Some(*v as i64),
             _ => None,
         }
     }
 
-    /// Returns the value as a u64, if applicable.
+    /// Returns the value as a `u64`, if it is a non-negative integer.
+    ///
+    /// The mirror of [`DictionaryValue::as_i64`]: a value stored as
+    /// [`DictionaryValue::Int`] is readable here when it is non-negative, and
+    /// `None` when it is negative rather than a wrapped positive number.
     #[must_use]
     pub const fn as_u64(&self) -> Option<u64> {
         match self {
             Self::UInt(v) => Some(*v),
+            // The guard makes the cast exact.
+            Self::Int(v) if *v >= 0 => Some(*v as u64),
             _ => None,
         }
     }
@@ -128,6 +288,34 @@ impl DictionaryValue {
     pub fn as_str(&self) -> Option<&str> {
         match self {
             Self::String(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    /// Returns the value as a byte slice, if applicable.
+    ///
+    /// A [`DictionaryValue::String`] answers with its UTF-8 bytes, so a tail or
+    /// delta operator working on bytes can read back a value another operator
+    /// stored as a string.
+    #[must_use]
+    pub fn as_bytes(&self) -> Option<&[u8]> {
+        match self {
+            Self::Bytes(b) => Some(b),
+            Self::String(s) => Some(s.as_bytes()),
+            _ => None,
+        }
+    }
+
+    /// Returns the value as a decimal `(mantissa, exponent)` pair, if
+    /// applicable.
+    ///
+    /// The pair is the FAST wire form. Converting it to a
+    /// `rust_decimal::Decimal` is the typed seam and belongs to the caller;
+    /// this crate never represents a price as a floating-point number.
+    #[must_use]
+    pub const fn as_decimal(&self) -> Option<(i64, i32)> {
+        match self {
+            Self::Decimal(mantissa, exponent) => Some((*mantissa, *exponent)),
             _ => None,
         }
     }
@@ -148,12 +336,153 @@ mod tests {
         assert!(Operator::Tail.uses_dictionary());
     }
 
+    /// Every operator, so a new one cannot be added without the matrix tests
+    /// below failing to cover it.
+    const ALL_OPERATORS: [Operator; 7] = [
+        Operator::None,
+        Operator::Constant,
+        Operator::Default,
+        Operator::Copy,
+        Operator::Increment,
+        Operator::Delta,
+        Operator::Tail,
+    ];
+
     #[test]
-    fn test_operator_requires_pmap() {
-        assert!(Operator::None.requires_pmap());
-        assert!(!Operator::Constant.requires_pmap());
-        assert!(!Operator::Default.requires_pmap());
-        assert!(Operator::Copy.requires_pmap());
+    fn test_operator_requires_pmap_matches_the_fast_matrix() {
+        // (operator, mandatory answer, optional answer) per FAST v1.1 §6.3.
+        let matrix: [(Operator, bool, bool); 7] = [
+            // No operator: the value is always in the stream.
+            (Operator::None, false, false),
+            // Constant: a bit only when optional, to say present or absent.
+            (Operator::Constant, false, true),
+            // Default: the bit selects stream value or initial value.
+            (Operator::Default, true, true),
+            // Copy: the bit selects stream value or previous value.
+            (Operator::Copy, true, true),
+            // Increment: the bit selects stream value or previous value + 1.
+            (Operator::Increment, true, true),
+            // Delta: the delta is always in the stream; absence is a NULL delta.
+            (Operator::Delta, false, false),
+            // Tail: the bit selects a tail in the stream or the previous value.
+            (Operator::Tail, true, true),
+        ];
+
+        assert_eq!(
+            matrix.len(),
+            ALL_OPERATORS.len(),
+            "the matrix must cover every operator"
+        );
+
+        for (operator, mandatory, optional) in matrix {
+            assert_eq!(
+                operator.requires_pmap(false),
+                mandatory,
+                "{operator:?} mandatory"
+            );
+            assert_eq!(
+                operator.requires_pmap(true),
+                optional,
+                "{operator:?} optional"
+            );
+        }
+    }
+
+    #[test]
+    fn test_operator_can_be_absent_matches_the_fast_matrix() {
+        // "Absent" is "not transferred": constant never travels, delta and a
+        // field with no operator always do, the rest depend on their bit.
+        let matrix: [(Operator, bool); 7] = [
+            (Operator::None, false),
+            (Operator::Constant, true),
+            (Operator::Default, true),
+            (Operator::Copy, true),
+            (Operator::Increment, true),
+            (Operator::Delta, false),
+            (Operator::Tail, true),
+        ];
+
+        for (operator, expected) in matrix {
+            assert_eq!(operator.can_be_absent(), expected, "{operator:?}");
+        }
+    }
+
+    #[test]
+    fn test_operator_transfer_consumes_exactly_the_bits_requires_pmap_claims() {
+        // The invariant the whole positional presence map rests on: `transfer`
+        // advances the map by one bit when `requires_pmap` says so and by none
+        // otherwise, for every operator and both optionalities.
+        for operator in ALL_OPERATORS {
+            for optional in [false, true] {
+                let mut pmap = PresenceMap::from_bits(vec![true, true]);
+                assert!(
+                    operator.transfer(optional, &mut pmap).is_ok(),
+                    "{operator:?} optional={optional}"
+                );
+
+                let expected = usize::from(operator.requires_pmap(optional));
+                assert_eq!(
+                    pmap.position(),
+                    expected,
+                    "{operator:?} optional={optional} consumed the wrong number of bits"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_operator_transfer_resolves_the_source_of_the_value() {
+        // (operator, optional, bit, expected source)
+        let cases: [(Operator, bool, bool, FieldTransfer); 12] = [
+            // No operator and delta ignore the map entirely.
+            (Operator::None, false, false, FieldTransfer::Stream),
+            (Operator::None, true, false, FieldTransfer::Stream),
+            (Operator::Delta, false, false, FieldTransfer::Stream),
+            (Operator::Delta, true, false, FieldTransfer::Stream),
+            // A mandatory constant is fully determined by the template.
+            (
+                Operator::Constant,
+                false,
+                false,
+                FieldTransfer::InitialValue,
+            ),
+            // An optional constant uses its bit to say present or absent.
+            (Operator::Constant, true, true, FieldTransfer::InitialValue),
+            (Operator::Constant, true, false, FieldTransfer::Absent),
+            // Default falls back to the initial value.
+            (Operator::Default, false, true, FieldTransfer::Stream),
+            (Operator::Default, false, false, FieldTransfer::InitialValue),
+            // The stateful operators fall back to the dictionary.
+            (Operator::Copy, false, false, FieldTransfer::Dictionary),
+            (Operator::Increment, true, false, FieldTransfer::Dictionary),
+            (Operator::Tail, false, true, FieldTransfer::Stream),
+        ];
+
+        for (operator, optional, bit, expected) in cases {
+            let mut pmap = PresenceMap::from_bits(vec![bit]);
+            assert_eq!(
+                operator.transfer(optional, &mut pmap),
+                Ok(expected),
+                "{operator:?} optional={optional} bit={bit}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_operator_transfer_without_a_bit_is_presence_map_exhausted() {
+        // A truncated map must not read as "every remaining field is absent".
+        let mut pmap = PresenceMap::new();
+        assert_eq!(
+            Operator::Copy.transfer(false, &mut pmap),
+            Err(FastError::PresenceMapExhausted)
+        );
+
+        // The operators that own no bit are unaffected by an empty map.
+        let mut pmap = PresenceMap::new();
+        assert_eq!(
+            Operator::Delta.transfer(true, &mut pmap),
+            Ok(FieldTransfer::Stream)
+        );
     }
 
     #[test]
@@ -166,5 +495,49 @@ mod tests {
 
         let str_val = DictionaryValue::String("test".to_string());
         assert_eq!(str_val.as_str(), Some("test"));
+    }
+
+    #[test]
+    fn test_dictionary_value_integer_accessors_read_across_both_variants() {
+        // A copy or increment operator must be able to read back a value it
+        // stored, whichever integer variant the writer chose.
+        assert_eq!(DictionaryValue::Int(42).as_u64(), Some(42));
+        assert_eq!(DictionaryValue::UInt(42).as_i64(), Some(42));
+    }
+
+    #[test]
+    fn test_dictionary_value_integer_accessors_reject_out_of_range_values() {
+        // Out of range is `None`, never a wrapped number.
+        assert_eq!(DictionaryValue::Int(-1).as_u64(), None);
+        assert_eq!(DictionaryValue::UInt(u64::MAX).as_i64(), None);
+
+        // The boundary itself is representable in both directions.
+        assert_eq!(DictionaryValue::Int(0).as_u64(), Some(0));
+        assert_eq!(
+            DictionaryValue::Int(i64::MAX).as_u64(),
+            Some(i64::MAX as u64)
+        );
+        assert_eq!(
+            DictionaryValue::UInt(i64::MAX as u64).as_i64(),
+            Some(i64::MAX)
+        );
+    }
+
+    #[test]
+    fn test_dictionary_value_byte_and_decimal_accessors() {
+        assert_eq!(
+            DictionaryValue::Bytes(vec![1, 2, 3]).as_bytes(),
+            Some(&[1, 2, 3][..])
+        );
+        assert_eq!(
+            DictionaryValue::String("ab".to_string()).as_bytes(),
+            Some(&b"ab"[..])
+        );
+        assert_eq!(
+            DictionaryValue::Decimal(1234, -2).as_decimal(),
+            Some((1234, -2))
+        );
+        assert_eq!(DictionaryValue::Undefined.as_decimal(), None);
+        assert_eq!(DictionaryValue::Empty.as_bytes(), None);
     }
 }

--- a/ironfix-fast/src/pmap.rs
+++ b/ironfix-fast/src/pmap.rs
@@ -10,10 +10,15 @@
 //! are present in a FAST message. It uses stop-bit encoding where the high
 //! bit of each byte indicates whether more bytes follow.
 //!
-//! Two hardening rules apply, because a presence map is attacker-controlled
-//! input: its encoded size is capped by [`MAX_PMAP_BYTES`], and running off
-//! the end of the map is an explicit [`FastError::PresenceMapExhausted`]
-//! rather than a fabricated "field absent" answer.
+//! Two rules apply, because a presence map is attacker-controlled input. Its
+//! encoded size is capped by [`MAX_PMAP_BYTES`], which bounds the work a hostile
+//! map can cost. Beyond that encoded size the map is not truncated: FAST v1.1
+//! §6.3.1 defines an infinite implied suffix of zero bits, so every field past
+//! the encoded bits is absent (0). The primitive [`PresenceMap::next_bit`]
+//! reports that the encoded bits are used up with
+//! [`FastError::PresenceMapExhausted`]; the operator layer
+//! ([`Operator::transfer`](crate::Operator::transfer)) applies the zero suffix
+//! by reading that exhaustion as absent.
 //!
 //! On the way out, [`PresenceMap::encode`] emits the minimal form — no
 //! trailing all-absent bytes — because that is what a conformant FAST receiver
@@ -114,34 +119,33 @@ impl PresenceMap {
         Ok(Self { bits, position: 0 })
     }
 
-    /// Consumes and returns the next bit from the presence map.
+    /// Consumes and returns the next encoded bit from the presence map.
     ///
     /// # Returns
     /// `true` if the corresponding field is present, `false` otherwise.
     ///
     /// # Errors
-    /// Returns [`FastError::PresenceMapExhausted`] once every decoded bit has
-    /// been consumed, rather than answering "absent" forever.
+    /// Returns [`FastError::PresenceMapExhausted`] once every encoded bit has
+    /// been consumed. This is a primitive-level signal, not a decode failure:
+    /// per FAST v1.1 §6.3.1 a presence map carries an infinite implied suffix of
+    /// zero bits, so reading past the encoded bits means the field is absent
+    /// (0). The primitive does not fabricate that zero itself; the operator
+    /// layer ([`Operator::transfer`](crate::Operator::transfer)) applies the
+    /// zero suffix by mapping this exhaustion to absent, so a caller that wants
+    /// the strict encoded length can still see where it ends. A failed read
+    /// does not advance the position.
     ///
     /// # Granularity
     ///
-    /// A decoded map always holds a multiple of seven bits, because that is
-    /// what the wire encoding carries: a sender meaning one present bit emits
-    /// a single byte, and this map then offers seven. Those six padding bits
-    /// read as "absent" and are indistinguishable here from real absent
-    /// fields — the primitive layer never sees the template, so it cannot know
-    /// how many bits were meant. Exhaustion therefore only fires at a
-    /// seven-bit boundary.
-    ///
-    /// The mirror of that is over-rejection: a sender that omits trailing
-    /// all-absent bytes — which is the minimal form, and what
-    /// [`PresenceMap::encode`] itself emits — produces a map shorter than the
-    /// template's field count, and reads past its end error here rather than
-    /// yielding "absent". A caller that knows how many fields to expect, and
-    /// therefore knows a short map is legal rather than truncated, reads with
-    /// [`PresenceMap::bit`] and treats `None` as absent. Resolving it inside
-    /// `next_bit` would need that field count, which belongs to the template
-    /// layer this crate does not yet implement — see the crate-level docs.
+    /// A decoded map always holds a multiple of seven bits, because that is what
+    /// the wire encoding carries: a sender meaning one present bit emits a
+    /// single byte, and this map then offers seven. Those six padding bits read
+    /// as absent and are indistinguishable here from the implied zero suffix —
+    /// the primitive layer never sees the template, so both simply mean the
+    /// field is absent. Exhaustion therefore fires only at a seven-bit boundary,
+    /// and everything past it is absent all the same. A caller that already
+    /// knows how many fields to expect may instead read with
+    /// [`PresenceMap::bit`], which answers `None` past the end.
     #[inline]
     pub fn next_bit(&mut self) -> Result<bool, FastError> {
         let bit = *self
@@ -207,10 +211,12 @@ impl PresenceMap {
     /// The consequence is that `encode` followed by
     /// [`PresenceMap::decode`] does not round-trip bit count: the decoded map
     /// is as short as the last set bit allows, and every bit past its end is
-    /// absent. A reader that knows how many fields to expect uses
-    /// [`PresenceMap::bit`], which answers `None` past the end, rather than
-    /// [`PresenceMap::next_bit`], which treats running off the end as the
-    /// protocol error it is for a reader that does not.
+    /// absent per the FAST zero-suffix rule. A reader consults
+    /// [`PresenceMap::bit`], which answers `None` past the end, or reads through
+    /// the operator layer, which treats a bit past the end as absent; the
+    /// primitive [`PresenceMap::next_bit`] instead reports
+    /// [`FastError::PresenceMapExhausted`] so a caller can still see where the
+    /// encoded bits end.
     ///
     /// # Returns
     /// The encoded bytes with stop-bit encoding.
@@ -398,6 +404,9 @@ mod tests {
 
     #[test]
     fn test_presence_map_next_bit_past_the_end_is_exhausted() {
+        // The primitive reports where the encoded bits end; it does not fabricate
+        // the FAST zero suffix. Applying that suffix — reading a bit past the end
+        // as absent — is the operator layer's job (see `Operator::transfer`).
         let mut pmap = PresenceMap::from_bits(vec![true]);
 
         assert!(!pmap.is_exhausted());

--- a/ironfix-fast/src/pmap.rs
+++ b/ironfix-fast/src/pmap.rs
@@ -14,6 +14,10 @@
 //! input: its encoded size is capped by [`MAX_PMAP_BYTES`], and running off
 //! the end of the map is an explicit [`FastError::PresenceMapExhausted`]
 //! rather than a fabricated "field absent" answer.
+//!
+//! On the way out, [`PresenceMap::encode`] emits the minimal form — no
+//! trailing all-absent bytes — because that is what a conformant FAST receiver
+//! expects and what a strict one insists on.
 
 use crate::decoder::{PAYLOAD_BITS, STOP_BIT, read_byte};
 use crate::error::FastError;
@@ -130,11 +134,14 @@ impl PresenceMap {
     /// seven-bit boundary.
     ///
     /// The mirror of that is over-rejection: a sender that omits trailing
-    /// all-absent bytes (legal in some implementations) produces a map shorter
-    /// than the template's field count, and the reads past its end error here
-    /// rather than yielding "absent". Resolving either direction requires the
-    /// expected field count, which belongs to the template layer — see the
-    /// template-driven decode work tracked in issue #13.
+    /// all-absent bytes — which is the minimal form, and what
+    /// [`PresenceMap::encode`] itself emits — produces a map shorter than the
+    /// template's field count, and reads past its end error here rather than
+    /// yielding "absent". A caller that knows how many fields to expect, and
+    /// therefore knows a short map is legal rather than truncated, reads with
+    /// [`PresenceMap::bit`] and treats `None` as absent. Resolving it inside
+    /// `next_bit` would need that field count, which belongs to the template
+    /// layer this crate does not yet implement — see the crate-level docs.
     #[inline]
     pub fn next_bit(&mut self) -> Result<bool, FastError> {
         let bit = *self
@@ -191,6 +198,20 @@ impl PresenceMap {
 
     /// Encodes the presence map to bytes.
     ///
+    /// The encoding is **minimal**: trailing bytes in which every bit is clear
+    /// are dropped, so a map of fourteen absent fields is the single byte
+    /// `0x80` rather than `0x00 0x80`. FAST allows a receiver to treat bits
+    /// past the end of the map as clear, and strict counterparties reject the
+    /// over-long form.
+    ///
+    /// The consequence is that `encode` followed by
+    /// [`PresenceMap::decode`] does not round-trip bit count: the decoded map
+    /// is as short as the last set bit allows, and every bit past its end is
+    /// absent. A reader that knows how many fields to expect uses
+    /// [`PresenceMap::bit`], which answers `None` past the end, rather than
+    /// [`PresenceMap::next_bit`], which treats running off the end as the
+    /// protocol error it is for a reader that does not.
+    ///
     /// # Returns
     /// The encoded bytes with stop-bit encoding.
     ///
@@ -199,10 +220,6 @@ impl PresenceMap {
     /// than [`MAX_PMAP_BYTES`] can carry — the encoder must never emit a map
     /// its own decoder would reject.
     pub fn encode(&self) -> Result<Vec<u8>, FastError> {
-        if self.bits.is_empty() {
-            return Ok(vec![STOP_BIT]); // Empty pmap with stop bit
-        }
-
         let byte_len = self.bits.len().div_ceil(PAYLOAD_BITS);
         if byte_len > MAX_PMAP_BYTES {
             return Err(FastError::PresenceMapTooLarge {
@@ -225,6 +242,18 @@ impl PresenceMap {
             result.push(byte);
         }
 
+        // Drop trailing all-absent bytes: they carry no information and the
+        // over-long form is not minimal. At least one byte must survive, since
+        // a presence map is never zero bytes on the wire.
+        while result.len() > 1 && result.last() == Some(&0) {
+            result.pop();
+        }
+
+        // An empty map still needs its lone stop byte.
+        if result.is_empty() {
+            result.push(0);
+        }
+
         // Set the stop bit on the last byte.
         if let Some(last) = result.last_mut() {
             *last |= STOP_BIT;
@@ -241,9 +270,12 @@ impl Default for PresenceMap {
 }
 
 /// Builder for constructing presence maps.
+///
+/// Bits accumulate inline, so a map covering every realistic template is built
+/// without touching the heap.
 #[derive(Debug, Default)]
 pub struct PresenceMapBuilder {
-    bits: Vec<bool>,
+    bits: PmapBits,
 }
 
 impl PresenceMapBuilder {
@@ -263,7 +295,10 @@ impl PresenceMapBuilder {
     /// Builds the presence map.
     #[must_use]
     pub fn build(self) -> PresenceMap {
-        PresenceMap::from_bits(self.bits)
+        PresenceMap {
+            bits: self.bits,
+            position: 0,
+        }
     }
 }
 
@@ -423,13 +458,50 @@ mod tests {
 
             if let Ok(decoded) = decoded {
                 assert_eq!(offset, encoded.len());
-                // The wire form is padded to whole bytes, so the decoded map is
-                // at least as long as the original and agrees on every bit.
-                assert!(decoded.len() >= bits.len());
+                // Every bit survives, either explicitly or as a bit past the
+                // end of the minimal map, which reads as absent.
                 for (index, &expected) in bits.iter().enumerate() {
-                    assert_eq!(decoded.bit(index), Some(expected), "bit {index}");
+                    assert_eq!(decoded.bit(index).unwrap_or(false), expected, "bit {index}");
                 }
             }
+        }
+    }
+
+    #[test]
+    fn test_presence_map_encode_drops_trailing_absent_bytes() {
+        // Fourteen absent fields fit in one byte, not two: the second byte
+        // would carry no information and is not the minimal form.
+        let pmap = PresenceMap::from_bits(vec![false; 14]);
+        assert_eq!(pmap.encode(), Ok(vec![STOP_BIT]));
+    }
+
+    #[test]
+    fn test_presence_map_encode_keeps_bytes_up_to_the_last_present_field() {
+        // One present field followed by thirteen absent ones: the first byte
+        // carries the set bit and the second is dropped.
+        let mut bits = vec![false; 14];
+        if let Some(first) = bits.first_mut() {
+            *first = true;
+        }
+        let pmap = PresenceMap::from_bits(bits);
+        assert_eq!(pmap.encode(), Ok(vec![0b1100_0000]));
+
+        // A set bit in the second byte keeps that byte alive.
+        let mut bits = vec![false; 14];
+        if let Some(last) = bits.last_mut() {
+            *last = true;
+        }
+        let pmap = PresenceMap::from_bits(bits);
+        assert_eq!(pmap.encode(), Ok(vec![0x00, 0b1000_0001]));
+    }
+
+    #[test]
+    fn test_presence_map_encode_all_absent_is_a_lone_stop_byte() {
+        // However many absent fields the template has, the minimal map is one
+        // byte -- and it must still decode as a presence map.
+        for count in [1_usize, 7, 8, 63, 64] {
+            let pmap = PresenceMap::from_bits(vec![false; count]);
+            assert_eq!(pmap.encode(), Ok(vec![STOP_BIT]), "{count} absent fields");
         }
     }
 


### PR DESCRIPTION
## Summary

Corrects presence-map semantics per FAST operator. A misaligned presence map does not fail — it silently reads the wrong fields as present — so this is a correctness fix, not a tidying one.

Closes #13.

## Stack

- **Base branch:** `stack/12-tagvalue-encoder` (PR #36)

## What was wrong

**`requires_pmap` answered with a single boolean per operator, which cannot be right.** Under FAST 1.1 several operators take a presence-map bit *only when the field is optional*, so one boolean per operator was always a half-truth. The signature now takes the field's optionality and answers per case.

**Four of the seven operators were wrong.** The worst was `None`: it claimed a bit, but a mandatory field with no operator is always present in the stream and takes none. Every presence map built from that answer was misaligned by one bit for the remainder of the message — and a misaligned map does not error, it reads the wrong fields as present. That is silent corruption of decoded market data.

**Encoded presence maps were non-minimal**, carrying trailing all-absent bytes the specification says to omit.

**The operator path allocated per value.**

**`DictionaryValue`'s accessors were variant-strict**, so `Int(42).as_u64()` and `UInt(42).as_i64()` both answered `None`. A `Copy` or `Increment` operator that stored a value under one variant could not read it back under the other — an interoperability trap for whoever wires the template layer.

## Scope

Template-driven decode — a template-XML parser and the field-sequence driver — is deliberately **not** in this PR. It is a feature in its own right rather than a fix, and folding it in here would have made this diff unreviewable. The crate docs do not claim it exists.

That leaves one consequence worth naming: `PresenceMap::decode` still yields a multiple of seven bits, so the padding inside the final byte is indistinguishable from genuinely absent fields at the primitive layer. Closing that needs the template's field count, which is precisely what the unbuilt template layer would supply. The behaviour is documented where a reader meets it.

## Performance

No measurement is claimed anywhere. There is no benchmark harness on this branch — one arrives with #35 — so the allocation removal is described structurally and no number appears in any doc or comment.

## Tests

Workspace goes to **434 passing**, including a per-operator assertion against the specification for both the mandatory and optional cases.

## Verification

```
cargo test --workspace                                    # 434 passed
cargo test --workspace --release                          # 434 passed
cargo clippy --all-targets --all-features -- -D warnings  # clean
cargo fmt --all --check                                   # clean
make doc                                                  # clean
```
