### PR TITLE
fix(session): validate session configuration instead of panicking on it

### DIFF
--- a/doc/fix_operations.md
+++ b/doc/fix_operations.md
@@ -178,6 +178,15 @@ reactor polls it on a 100 ms tick.
   zero-length interval. Note the consequence the FIX spec implies: with
   `108=0` there is no heartbeat-driven liveness check at all, so a dead peer is
   only noticed when TCP notices.
+- **The configured interval is whole seconds.** Tag 108 carries whole seconds,
+  so a fractional `SessionConfig::heartbeat_interval` is refused at
+  configuration time (`SessionConfigError::FractionalHeartbeatInterval`) rather
+  than truncated: flooring 500 ms to `108=0` would negotiate *no heartbeating*
+  while the local timers ran sub-second. The accepted range is 1 s to
+  `MAX_HEARTBEAT_INTERVAL_SECS` (3600 s), plus the `108=0` case, which
+  `SessionConfigBuilder::disable_heartbeats` asks for by name. `Initiator`
+  re-checks the whole configuration before it dials, so a configuration
+  assembled through the public fields cannot bypass this either.
 - **Heartbeat due.** One interval with nothing sent. Any outbound message
   resets the timer, so a busy session emits no Heartbeats.
 - **TestRequest due.** One interval plus a transmission grace with nothing

--- a/ironfix-engine/src/error.rs
+++ b/ironfix-engine/src/error.rs
@@ -8,7 +8,7 @@
 
 use ironfix_core::error::{DecodeError, EncodeError};
 use ironfix_session::config::SessionConfigError;
-use ironfix_session::sequence::SequenceExhausted;
+use ironfix_session::sequence::{SequenceCounter, SequenceExhausted};
 use ironfix_transport::CodecError;
 use std::time::Duration;
 
@@ -93,6 +93,18 @@ pub enum EngineError {
     /// numbered until the session performs a sequence reset.
     #[error(transparent)]
     SequenceExhausted(#[from] SequenceExhausted),
+
+    /// A seeded initial sequence number was zero.
+    ///
+    /// FIX numbers messages from 1; a seeded `MsgSeqNum` (34) of 0 would be
+    /// rejected by every conforming counterparty. Checked before the socket is
+    /// dialled. Set through
+    /// [`Initiator::with_initial_sequences`](crate::Initiator::with_initial_sequences).
+    #[error("initial {counter} sequence number must be at least 1, was 0")]
+    InvalidInitialSequence {
+        /// Which seeded counter was zero.
+        counter: SequenceCounter,
+    },
 
     /// The counterparty's identity fields (49/56, and 50/57 when
     /// configured) did not match the session configuration.

--- a/ironfix-engine/src/error.rs
+++ b/ironfix-engine/src/error.rs
@@ -7,6 +7,7 @@
 //! Engine error types.
 
 use ironfix_core::error::{DecodeError, EncodeError};
+use ironfix_session::config::SessionConfigError;
 use ironfix_session::sequence::SequenceExhausted;
 use ironfix_transport::CodecError;
 use std::time::Duration;
@@ -35,6 +36,16 @@ pub enum EngineError {
     /// for corrupted bytes.
     #[error("encode error: {0}")]
     Encode(#[from] EncodeError),
+
+    /// The session configuration is not usable.
+    ///
+    /// Checked before the socket is dialled: an out-of-range knob — a
+    /// fractional `HeartBtInt`, an identity string carrying SOH or `=`, a zero
+    /// timeout — would otherwise corrupt the session's own messages.
+    /// [`ironfix_session::SessionConfigBuilder`] reports the same errors at
+    /// configuration time.
+    #[error("invalid session configuration: {0}")]
+    Config(#[from] SessionConfigError),
 
     /// TCP connect did not complete within the configured timeout.
     #[error("connect timed out after {0:?}")]

--- a/ironfix-engine/src/initiator.rs
+++ b/ironfix-engine/src/initiator.rs
@@ -94,12 +94,13 @@ use ironfix_core::message::{MsgType, RawMessage};
 use ironfix_core::version::FixVersion;
 use ironfix_session::config::SessionConfigError;
 use ironfix_session::heartbeat::{generate_test_req_id, negotiate_interval};
-use ironfix_session::sequence::{SequenceExhausted, SequenceResult};
+use ironfix_session::sequence::{SequenceCounter, SequenceExhausted, SequenceResult};
 use ironfix_session::{
     Active, Disconnected, HeartbeatManager, LogoutPending, SequenceManager, Session, SessionConfig,
     TestRequestOutcome,
 };
 use ironfix_transport::FixCodec;
+use std::num::NonZeroU64;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::net::{TcpStream, ToSocketAddrs};
@@ -194,9 +195,15 @@ impl<A: Application + 'static> Initiator<A> {
     /// a previous session (e.g. after a reconnect supervised by the
     /// consumer). Ignored when `reset_on_logon` is set.
     ///
+    /// Both values must be at least 1: FIX numbers messages from 1, and a
+    /// seeded `MsgSeqNum` (34) of 0 would be rejected by every conforming
+    /// counterparty. A zero seed that would actually be used is refused by
+    /// [`Initiator::connect`] with [`EngineError::InvalidInitialSequence`],
+    /// before the socket is dialled.
+    ///
     /// # Arguments
-    /// * `sender_seq` - Next outgoing sequence number
-    /// * `target_seq` - Next expected incoming sequence number
+    /// * `sender_seq` - Next outgoing sequence number, `>= 1`
+    /// * `target_seq` - Next expected incoming sequence number, `>= 1`
     #[must_use]
     pub fn with_initial_sequences(mut self, sender_seq: u64, target_seq: u64) -> Self {
         self.initial_sequences = Some((sender_seq, target_seq));
@@ -241,8 +248,10 @@ impl<A: Application + 'static> Initiator<A> {
     /// sequence counter has reached `u64::MAX` and the session must be reset
     /// before it can number another message. A `BeginString` this engine
     /// cannot frame conformantly is refused up front with
-    /// [`EngineError::UnsupportedVersion`], and an unusable configuration with
-    /// [`EngineError::Config`], both before the socket is dialled.
+    /// [`EngineError::UnsupportedVersion`], an unusable configuration with
+    /// [`EngineError::Config`], and a zero initial sequence seed with
+    /// [`EngineError::InvalidInitialSequence`], all before the socket is
+    /// dialled.
     pub async fn connect(&self, addr: impl ToSocketAddrs) -> Result<Connection, EngineError> {
         // Refuse before dialling: a knob outside its documented range corrupts
         // the session's own messages — an identity string carrying SOH breaks
@@ -263,6 +272,25 @@ impl<A: Application + 'static> Initiator<A> {
                     detail: err.detail.clone(),
                 });
             }
+        };
+
+        // Refuse before dialling: a seeded sequence number of zero would put
+        // MsgSeqNum (34) = 0 on the wire, which every conforming counterparty
+        // rejects. The seed is ignored entirely when reset_on_logon is set, so
+        // a zero is only refused when it would actually be used.
+        let initial_sequences = match self.initial_sequences {
+            Some((sender, target)) if !self.config.reset_on_logon => {
+                let sender =
+                    NonZeroU64::new(sender).ok_or(EngineError::InvalidInitialSequence {
+                        counter: SequenceCounter::Sender,
+                    })?;
+                let target =
+                    NonZeroU64::new(target).ok_or(EngineError::InvalidInitialSequence {
+                        counter: SequenceCounter::Target,
+                    })?;
+                Some((sender, target))
+            }
+            _ => None,
         };
 
         let session_id = self.session_id.clone();
@@ -289,11 +317,9 @@ impl<A: Application + 'static> Initiator<A> {
             .with_checksum_validation(self.config.validate_checksum);
         let mut framed = Framed::new(stream, codec);
 
-        let sequences = match self.initial_sequences {
-            Some((sender, target)) if !self.config.reset_on_logon => {
-                SequenceManager::with_initial(sender, target)
-            }
-            _ => SequenceManager::new(),
+        let sequences = match initial_sequences {
+            Some((sender, target)) => SequenceManager::with_initial(sender, target),
+            None => SequenceManager::new(),
         };
         let runtime = Arc::new(SessionRuntime {
             sequences,

--- a/ironfix-engine/src/initiator.rs
+++ b/ironfix-engine/src/initiator.rs
@@ -92,6 +92,7 @@ use futures_util::{SinkExt, StreamExt};
 use ironfix_core::error::{DecodeError, EncodeError};
 use ironfix_core::message::{MsgType, RawMessage};
 use ironfix_core::version::FixVersion;
+use ironfix_session::config::SessionConfigError;
 use ironfix_session::heartbeat::{generate_test_req_id, negotiate_interval};
 use ironfix_session::sequence::{SequenceExhausted, SequenceResult};
 use ironfix_session::{
@@ -100,7 +101,7 @@ use ironfix_session::{
 };
 use ironfix_transport::FixCodec;
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use tokio::net::{TcpStream, ToSocketAddrs};
 use tokio::sync::{mpsc, watch};
 use tokio::time::{MissedTickBehavior, interval, timeout};
@@ -131,6 +132,10 @@ pub struct Initiator<A: Application = NoOpApplication> {
     /// The configured FIX version, or why it cannot be framed. Resolved once
     /// at construction and reported by [`Initiator::connect`] before dialling.
     version: Result<FixVersion, UnsupportedVersion>,
+    /// Whether the configuration is usable. Resolved once at construction and
+    /// reported by [`Initiator::connect`] before dialling, so a knob that
+    /// would corrupt the session's own messages never reaches a socket.
+    config_check: Result<(), SessionConfigError>,
     /// TCP connect timeout.
     connect_timeout: Duration,
     /// Initial (sender, target) sequence numbers for session continuity.
@@ -141,6 +146,11 @@ pub struct Initiator<A: Application = NoOpApplication> {
 
 impl<A: Application + 'static> Initiator<A> {
     /// Creates a new initiator.
+    ///
+    /// The configuration is validated here and the verdict is reported by
+    /// [`Initiator::connect`], which refuses to dial with an unusable one.
+    /// Building it through [`ironfix_session::SessionConfigBuilder`] surfaces
+    /// the same errors earlier.
     ///
     /// # Arguments
     /// * `config` - The session configuration
@@ -159,12 +169,14 @@ impl<A: Application + 'static> Initiator<A> {
             session_id = session_id.with_target_sub_id(sub.clone());
         }
         let version = wire::wire_version(&config.begin_string);
+        let config_check = config.validate();
 
         Self {
             config,
             application,
             session_id,
             version,
+            config_check,
             connect_timeout: Duration::from_secs(30),
             initial_sequences: None,
             outbound_capacity: DEFAULT_OUTBOUND_CAPACITY,
@@ -229,8 +241,17 @@ impl<A: Application + 'static> Initiator<A> {
     /// sequence counter has reached `u64::MAX` and the session must be reset
     /// before it can number another message. A `BeginString` this engine
     /// cannot frame conformantly is refused up front with
-    /// [`EngineError::UnsupportedVersion`], before the socket is dialled.
+    /// [`EngineError::UnsupportedVersion`], and an unusable configuration with
+    /// [`EngineError::Config`], both before the socket is dialled.
     pub async fn connect(&self, addr: impl ToSocketAddrs) -> Result<Connection, EngineError> {
+        // Refuse before dialling: a knob outside its documented range corrupts
+        // the session's own messages — an identity string carrying SOH breaks
+        // every header, and a fractional HeartBtInt negotiates one interval
+        // while the local timers run another.
+        if let Err(err) = &self.config_check {
+            return Err(EngineError::Config(err.clone()));
+        }
+
         // Refuse before dialling: an unsupported version cannot produce a
         // conforming Logon, and guessing one would put a fabricated version on
         // the wire.
@@ -569,7 +590,6 @@ impl<A: Application + 'static> Initiator<A> {
             application: Arc::clone(&self.application),
             session_id: session_id.clone(),
             pending_resend,
-            logout_deadline: None,
         };
         tokio::spawn(run_reactor(framed, command_rx, closed_tx, reactor, session));
 
@@ -658,9 +678,11 @@ struct Reactor<A: Application> {
     /// Session identifier.
     session_id: SessionId,
     /// Expected sequence number a pending ResendRequest was issued for.
+    ///
+    /// The logout deadline is *not* tracked here: `Session<LogoutPending>`
+    /// carries the instant the Logout went out, so the phase itself is the
+    /// deadline.
     pending_resend: Option<u64>,
-    /// Deadline for a locally initiated logout.
-    logout_deadline: Option<Instant>,
 }
 
 /// The session reactor: owns the socket, multiplexes inbound frames,
@@ -818,8 +840,8 @@ impl<A: Application> Reactor<A> {
                         let _ = session.disconnect();
                         return Err(closed(format!("send failed: {err}"), false));
                     }
-                    self.logout_deadline = Some(Instant::now() + self.config.logout_timeout);
-                    // Typestate: Active -> LogoutPending.
+                    // Typestate: Active -> LogoutPending. The new state records
+                    // when the Logout went out, which is what on_tick times.
                     Ok(Phase::LogoutPending(session.initiate_logout()))
                 }
             },
@@ -832,8 +854,11 @@ impl<A: Application> Reactor<A> {
         framed: &mut FixFramed,
         phase: Phase,
     ) -> Result<Phase, SessionClosed> {
-        if let Some(deadline) = self.logout_deadline
-            && Instant::now() >= deadline
+        // The logout deadline lives in the typestate: LogoutPending is defined
+        // by the instant its Logout was sent, so there is no second copy of it
+        // to drift.
+        if let Phase::LogoutPending(session) = &phase
+            && session.sent_at().elapsed() >= self.config.logout_timeout
         {
             teardown(phase);
             return Err(closed("logout ack timeout", true));

--- a/ironfix-engine/src/wire.rs
+++ b/ironfix-engine/src/wire.rs
@@ -215,6 +215,8 @@ pub(crate) struct MessageFactory {
     target_comp_id: String,
     sender_sub_id: Option<String>,
     target_sub_id: Option<String>,
+    sender_location_id: Option<String>,
+    target_location_id: Option<String>,
 }
 
 impl MessageFactory {
@@ -227,11 +229,18 @@ impl MessageFactory {
             target_comp_id: config.target_comp_id.as_str().to_string(),
             sender_sub_id: config.sender_sub_id.clone(),
             target_sub_id: config.target_sub_id.clone(),
+            sender_location_id: config.sender_location_id.clone(),
+            target_location_id: config.target_location_id.clone(),
         }
     }
 
     /// Starts an encoder with the standard header:
-    /// 35, [1128], 49, 56, [50], [57], 34, [43], 52, [122].
+    /// 35, [1128], 49, 56, [50], [142], [57], [143], 34, [43], 52, [122].
+    ///
+    /// `SenderLocationID` (142) follows `SenderSubID` (50) and
+    /// `TargetLocationID` (143) follows `TargetSubID` (57), the standard-header
+    /// pairing of the routing fields. Both are stamped only when configured;
+    /// an unset LocationID places nothing on the wire.
     ///
     /// `poss_dup` stamps both `PossDupFlag` (43) and `OrigSendingTime` (122):
     /// FIX requires 122 on every message carrying 43=Y, and
@@ -263,8 +272,14 @@ impl MessageFactory {
         if let Some(sub) = &self.sender_sub_id {
             encoder.put_str(50, sub);
         }
+        if let Some(location) = &self.sender_location_id {
+            encoder.put_str(142, location);
+        }
         if let Some(sub) = &self.target_sub_id {
             encoder.put_str(57, sub);
+        }
+        if let Some(location) = &self.target_location_id {
+            encoder.put_str(143, location);
         }
         encoder.put_uint(34, seq);
         if poss_dup {
@@ -521,6 +536,34 @@ mod tests {
         assert_eq!(raw.get_field_str(11), Some("ORDER-1"));
         assert_eq!(raw.get_field(95).map(|f| f.value), Some(b"5".as_slice()));
         assert_eq!(raw.get_field(96).map(|f| f.value), Some(payload));
+    }
+
+    #[test]
+    fn test_header_stamps_configured_location_ids() {
+        let mut config = config_for("FIX.4.4");
+        config.sender_location_id = Some("LON".to_string());
+        config.target_location_id = Some("NYC".to_string());
+        let version = match wire_version(&config.begin_string) {
+            Ok(version) => version,
+            Err(err) => panic!("test fixture uses an unsupported version: {err}"),
+        };
+        let factory = MessageFactory::new(&config, version);
+
+        let frame = framed(factory.logon(1, 30, false));
+        let raw = decode(&frame);
+        // SenderLocationID (142) and TargetLocationID (143) are routing fields
+        // of the standard header, so a configured value is stamped onto every
+        // outbound message.
+        assert_eq!(raw.get_field_str(142), Some("LON"));
+        assert_eq!(raw.get_field_str(143), Some("NYC"));
+    }
+
+    #[test]
+    fn test_header_omits_unset_location_ids() {
+        let frame = framed(factory().logon(1, 30, false));
+        let raw = decode(&frame);
+        assert_eq!(raw.get_field_str(142), None);
+        assert_eq!(raw.get_field_str(143), None);
     }
 
     #[test]

--- a/ironfix-engine/tests/initiator_tests.rs
+++ b/ironfix-engine/tests/initiator_tests.rs
@@ -2348,6 +2348,59 @@ async fn test_logon_ack_wrong_begin_string_fails_handshake() {
     ok(acceptor.await, "acceptor task");
 }
 
+/// A zero initial sequence seed is refused before the socket is dialled: a
+/// seeded MsgSeqNum (34) of 0 would be rejected by every conforming
+/// counterparty, since FIX numbers messages from 1.
+#[tokio::test]
+async fn test_connect_with_zero_initial_sender_seq_is_rejected() {
+    let (listener, addr) = bind_listener().await;
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app))
+        .with_initial_sequences(0, 9);
+
+    match initiator.connect(addr).await {
+        Err(EngineError::InvalidInitialSequence { counter }) => {
+            assert_eq!(counter, SequenceCounter::Sender);
+        }
+        Err(other) => panic!("expected an invalid-sequence error, got {other:?}"),
+        Ok(_) => panic!("a zero MsgSeqNum seed must not establish a session"),
+    }
+
+    assert!(
+        timeout(Duration::from_millis(200), listener.accept())
+            .await
+            .is_err(),
+        "the socket must never be dialled"
+    );
+}
+
+/// The target side of the zero-seed guard: a zero incoming seed is refused the
+/// same way, before the socket is dialled.
+#[tokio::test]
+async fn test_connect_with_zero_initial_target_seq_is_rejected() {
+    let (listener, addr) = bind_listener().await;
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app))
+        .with_initial_sequences(7, 0);
+
+    match initiator.connect(addr).await {
+        Err(EngineError::InvalidInitialSequence { counter }) => {
+            assert_eq!(counter, SequenceCounter::Target);
+        }
+        Err(other) => panic!("expected an invalid-sequence error, got {other:?}"),
+        Ok(_) => panic!("a zero MsgSeqNum seed must not establish a session"),
+    }
+
+    assert!(
+        timeout(Duration::from_millis(200), listener.accept())
+            .await
+            .is_err(),
+        "the socket must never be dialled"
+    );
+}
+
 /// A configuration knob that would corrupt the session's own messages is
 /// refused before the socket is dialled: an identity string carrying SOH would
 /// terminate tag 50 early in every outbound header.

--- a/ironfix-engine/tests/initiator_tests.rs
+++ b/ironfix-engine/tests/initiator_tests.rs
@@ -16,8 +16,8 @@ use ironfix_core::message::RawMessage;
 use ironfix_core::types::{CompId, Timestamp};
 use ironfix_engine::application::{Application, RejectReason, SessionId};
 use ironfix_engine::{EngineError, Initiator, OutboundMessage};
-use ironfix_session::SessionConfig;
 use ironfix_session::sequence::SequenceCounter;
+use ironfix_session::{SessionConfig, SessionConfigError};
 use ironfix_tagvalue::{Decoder, Encoder};
 use ironfix_transport::FixCodec;
 use std::sync::{Arc, Mutex};
@@ -2346,4 +2346,63 @@ async fn test_logon_ack_wrong_begin_string_fails_handshake() {
     }
 
     ok(acceptor.await, "acceptor task");
+}
+
+/// A configuration knob that would corrupt the session's own messages is
+/// refused before the socket is dialled: an identity string carrying SOH would
+/// terminate tag 50 early in every outbound header.
+#[tokio::test]
+async fn test_connect_refuses_an_invalid_configuration_without_dialling() {
+    let (listener, addr) = bind_listener().await;
+
+    let (app, _app_rx) = RecordingApp::new();
+    let config = client_config(Duration::from_secs(30)).with_sender_sub_id("DE\x01SK");
+    let initiator = Initiator::new(config, Arc::clone(&app));
+
+    match initiator.connect(addr).await {
+        Err(EngineError::Config(SessionConfigError::IllegalByte {
+            field,
+            byte,
+            position,
+        })) => {
+            assert_eq!(field, "sender_sub_id");
+            assert_eq!(byte, 0x01);
+            assert_eq!(position, 2);
+        }
+        Err(other) => panic!("expected a configuration error, got {other:?}"),
+        Ok(_) => panic!("an unencodable SenderSubID must not establish a session"),
+    }
+
+    assert!(
+        timeout(Duration::from_millis(200), listener.accept())
+            .await
+            .is_err(),
+        "the socket must never be dialled"
+    );
+}
+
+/// A fractional heartbeat interval never reaches the wire: HeartBtInt (108) is
+/// whole seconds, and truncating 500ms to 108=0 would negotiate no
+/// heartbeating at all.
+#[tokio::test]
+async fn test_connect_refuses_a_fractional_heartbeat_interval() {
+    let (listener, addr) = bind_listener().await;
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_millis(500)), Arc::clone(&app));
+
+    match initiator.connect(addr).await {
+        Err(EngineError::Config(SessionConfigError::FractionalHeartbeatInterval { interval })) => {
+            assert_eq!(interval, Duration::from_millis(500));
+        }
+        Err(other) => panic!("expected a configuration error, got {other:?}"),
+        Ok(_) => panic!("a sub-second HeartBtInt must not establish a session"),
+    }
+
+    assert!(
+        timeout(Duration::from_millis(200), listener.accept())
+            .await
+            .is_err(),
+        "the socket must never be dialled"
+    );
 }

--- a/ironfix-example/examples/fix44_engine_client.rs
+++ b/ironfix-example/examples/fix44_engine_client.rs
@@ -15,7 +15,7 @@ use ironfix_core::message::RawMessage;
 use ironfix_core::types::CompId;
 use ironfix_engine::application::{Application, NoOpApplication, RejectReason, SessionId};
 use ironfix_engine::{Initiator, OutboundMessage};
-use ironfix_session::SessionConfig;
+use ironfix_session::SessionConfigBuilder;
 
 mod common;
 use common::{ExampleConfig, init_logging};
@@ -83,12 +83,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cfg = ExampleConfig::client();
     info!("{FIX_VERSION} engine client connecting to {}", cfg.addr());
 
-    let config = SessionConfig::new(
-        CompId::new(&cfg.sender_comp_id).expect("valid sender"),
-        CompId::new(&cfg.target_comp_id).expect("valid target"),
-        FIX_VERSION,
-    )
-    .with_heartbeat_interval(Duration::from_secs(cfg.heartbeat_interval));
+    // The builder validates every knob, so a bad CompID or an out-of-range
+    // heartbeat is reported here rather than on the wire.
+    let config = SessionConfigBuilder::new()
+        .sender_comp_id(CompId::new(&cfg.sender_comp_id)?)
+        .target_comp_id(CompId::new(&cfg.target_comp_id)?)
+        .begin_string(FIX_VERSION)
+        .heartbeat_interval(Duration::from_secs(cfg.heartbeat_interval))
+        .build()?;
 
     let initiator = Initiator::new(config, Arc::new(LoggingApp::default()))
         .with_connect_timeout(Duration::from_secs(5));

--- a/ironfix-example/src/lib.rs
+++ b/ironfix-example/src/lib.rs
@@ -177,7 +177,8 @@ pub mod prelude {
     // Session
     pub use ironfix_session::{
         Active, Connecting, Disconnected, HeartbeatIntervalError, HeartbeatManager, LogonSent,
-        LogoutPending, Resending, SequenceManager, SessionConfig, SessionState, TestRequestOutcome,
+        LogoutPending, Resending, SequenceManager, SequenceResult, SessionConfig,
+        SessionConfigBuilder, SessionConfigError, SessionState, TestRequestOutcome,
     };
 
     // Store

--- a/ironfix-session/src/config.rs
+++ b/ironfix-session/src/config.rs
@@ -310,8 +310,6 @@ pub struct SessionConfig {
     pub logout_timeout: Duration,
     /// Whether to validate the `CheckSum` (10) of inbound messages.
     pub validate_checksum: bool,
-    /// Whether to validate the `BodyLength` (9) of inbound messages.
-    pub validate_length: bool,
     /// Optional sender sub ID (tag 50), 1..=[`MAX_ID_LEN`] bytes when set.
     pub sender_sub_id: Option<String>,
     /// Optional target sub ID (tag 57), 1..=[`MAX_ID_LEN`] bytes when set.
@@ -354,7 +352,6 @@ impl SessionConfig {
             logon_timeout: DEFAULT_TIMEOUT,
             logout_timeout: DEFAULT_TIMEOUT,
             validate_checksum: true,
-            validate_length: true,
             sender_sub_id: None,
             target_sub_id: None,
             sender_location_id: None,
@@ -538,8 +535,6 @@ pub struct SessionConfigBuilder {
     logout_timeout: Duration,
     /// Validate inbound `CheckSum` (10).
     validate_checksum: bool,
-    /// Validate inbound `BodyLength` (9).
-    validate_length: bool,
     /// Sender sub ID (tag 50).
     sender_sub_id: Option<String>,
     /// Target sub ID (tag 57).
@@ -564,7 +559,6 @@ impl Default for SessionConfigBuilder {
             logon_timeout: DEFAULT_TIMEOUT,
             logout_timeout: DEFAULT_TIMEOUT,
             validate_checksum: true,
-            validate_length: true,
             sender_sub_id: None,
             target_sub_id: None,
             sender_location_id: None,
@@ -684,13 +678,6 @@ impl SessionConfigBuilder {
         self
     }
 
-    /// Sets whether inbound `BodyLength` (9) is validated.
-    #[must_use = "builders do nothing unless .build() is called"]
-    pub const fn validate_length(mut self, validate: bool) -> Self {
-        self.validate_length = validate;
-        self
-    }
-
     /// Sets the sender sub ID (tag 50).
     ///
     /// 1..=[`MAX_ID_LEN`] bytes of printable ASCII except `=`.
@@ -768,7 +755,6 @@ impl SessionConfigBuilder {
             logon_timeout: self.logon_timeout,
             logout_timeout: self.logout_timeout,
             validate_checksum: self.validate_checksum,
-            validate_length: self.validate_length,
             sender_sub_id: self.sender_sub_id,
             target_sub_id: self.target_sub_id,
             sender_location_id: self.sender_location_id,
@@ -831,7 +817,6 @@ mod tests {
         assert_eq!(config.logout_timeout, Duration::from_secs(10));
         assert_eq!(config.max_message_size, 1024 * 1024);
         assert!(config.validate_checksum);
-        assert!(config.validate_length);
         assert!(!config.reset_on_logon);
         assert_eq!(config.validate(), Ok(()));
     }
@@ -847,7 +832,6 @@ mod tests {
         assert_eq!(built_config.logout_timeout, direct.logout_timeout);
         assert_eq!(built_config.max_message_size, direct.max_message_size);
         assert_eq!(built_config.validate_checksum, direct.validate_checksum);
-        assert_eq!(built_config.validate_length, direct.validate_length);
     }
 
     // --- Required fields -----------------------------------------------------
@@ -889,7 +873,6 @@ mod tests {
                 .logon_timeout(Duration::from_secs(5))
                 .logout_timeout(Duration::from_secs(7))
                 .validate_checksum(false)
-                .validate_length(false)
                 .sender_sub_id("SDESK")
                 .target_sub_id("TDESK")
                 .sender_location_id("LON")
@@ -907,7 +890,6 @@ mod tests {
         assert_eq!(config.logon_timeout, Duration::from_secs(5));
         assert_eq!(config.logout_timeout, Duration::from_secs(7));
         assert!(!config.validate_checksum);
-        assert!(!config.validate_length);
         assert_eq!(config.sender_sub_id.as_deref(), Some("SDESK"));
         assert_eq!(config.target_sub_id.as_deref(), Some("TDESK"));
         assert_eq!(config.sender_location_id.as_deref(), Some("LON"));

--- a/ironfix-session/src/config.rs
+++ b/ironfix-session/src/config.rs
@@ -6,55 +6,336 @@
 
 //! Session configuration.
 //!
-//! This module provides configuration options for FIX sessions.
+//! [`SessionConfig`] is the typed configuration surface of a FIX session.
+//! There is no environment-variable or file-based configuration anywhere in
+//! this workspace, by design: a session knob is a typed field with a default,
+//! a documented unit and range, and validation.
+//!
+//! # Where validity is decided
+//!
+//! [`SessionConfig::validate`] is the single definition of "valid". Two
+//! callers use it:
+//!
+//! - [`SessionConfigBuilder::build`], the canonical constructor — it exposes a
+//!   setter for every knob and reports the first violation as a typed
+//!   [`SessionConfigError`] instead of panicking.
+//! - `ironfix-engine`, before it dials, so an out-of-range knob assembled by
+//!   hand through the public fields still cannot reach the wire.
+//!
+//! # Ranges
+//!
+//! | Knob | Unit | Range | Default |
+//! |---|---|---|---|
+//! | `sender_comp_id` / `target_comp_id` | — | validated by [`CompId`] | required |
+//! | `begin_string` | ASCII | 1..=[`MAX_ID_LEN`] bytes, printable ASCII except `=` | `FIX.4.4` |
+//! | `heartbeat_interval` | whole seconds | 0 (disabled) or [`MIN_HEARTBEAT_INTERVAL_SECS`]..=[`MAX_HEARTBEAT_INTERVAL_SECS`] | 30 s |
+//! | `logon_timeout` / `logout_timeout` | duration | non-zero, at most [`MAX_TIMEOUT`] | 10 s |
+//! | `max_message_size` | bytes | [`MIN_MESSAGE_SIZE_LIMIT`]..=[`MAX_MESSAGE_SIZE_LIMIT`] | 1 MiB |
+//! | `sender_sub_id` / `target_sub_id` | ASCII | unset, or 1..=[`MAX_ID_LEN`] bytes, printable ASCII except `=` | unset |
+//! | `sender_location_id` / `target_location_id` | ASCII | as above | unset |
+//! | `reset_on_*`, `validate_*` | flag | any | see [`SessionConfig::new`] |
+//!
+//! # `HeartBtInt` (108) is whole seconds
+//!
+//! Tag 108 carries whole seconds, and `HeartBtInt = 0` means *do not
+//! heartbeat* (see the [`crate::heartbeat`] module). A fractional
+//! `heartbeat_interval` therefore has no honest wire form: truncating 500 ms
+//! to `108=0` would negotiate no heartbeating at all while local timers ran
+//! sub-second. Fractional intervals are rejected rather than truncated, and
+//! `HeartBtInt = 0` must be asked for explicitly through
+//! [`SessionConfigBuilder::disable_heartbeats`].
 
-use ironfix_core::types::CompId;
+use crate::heartbeat::MAX_HEARTBEAT_INTERVAL_SECS;
+use ironfix_core::types::{COMP_ID_MAX_LEN, CompId};
 use std::time::Duration;
 
+/// Smallest `HeartBtInt` (108) this engine will configure, in seconds.
+///
+/// One second is the smallest interval tag 108 can express. Anything shorter
+/// has no wire representation; see the module documentation. Zero is not in
+/// this range — it is the separate "heartbeating disabled" case.
+pub const MIN_HEARTBEAT_INTERVAL_SECS: u64 = 1;
+
+/// Largest handshake timeout this engine will configure.
+///
+/// Both `logon_timeout` and `logout_timeout` bound one round trip with the
+/// counterparty. Five minutes is far beyond any real venue's response time; a
+/// larger value would leave a dead handshake hanging rather than failing it.
+pub const MAX_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Smallest `max_message_size` this engine will configure, in bytes.
+///
+/// The limit must at least admit the session's own Logon: the standard header
+/// with maximum-length CompIDs, SubIDs and LocationIDs plus a Logon body runs
+/// to a few hundred bytes. Below this floor the session could not complete its
+/// own handshake.
+pub const MIN_MESSAGE_SIZE_LIMIT: usize = 512;
+
+/// Largest `max_message_size` this engine will configure, in bytes (64 MiB).
+///
+/// The codec buffers up to this much per connection before it can reject a
+/// frame, so the knob is also a per-connection memory ceiling. 64 MiB is well
+/// above the largest realistic FIX message (a mass quote or security list)
+/// and far below anything that would let one connection exhaust a host.
+pub const MAX_MESSAGE_SIZE_LIMIT: usize = 64 * 1024 * 1024;
+
+/// Maximum length, in bytes, of a configured identity string.
+///
+/// Applies to `begin_string`, the sub IDs and the location IDs. It is
+/// [`COMP_ID_MAX_LEN`], the same bound [`CompId`] applies to tags 49 and 56:
+/// these values sit in the same standard header and are written verbatim
+/// alongside it.
+pub const MAX_ID_LEN: usize = COMP_ID_MAX_LEN;
+
+/// `BeginString` (tag 8) used when the builder is not told otherwise.
+const DEFAULT_BEGIN_STRING: &str = "FIX.4.4";
+
+/// `HeartBtInt` (108) used when the builder is not told otherwise.
+const DEFAULT_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Handshake timeout used when the builder is not told otherwise.
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// `max_message_size` used when the builder is not told otherwise (1 MiB).
+const DEFAULT_MESSAGE_SIZE_LIMIT: usize = 1024 * 1024;
+
+/// Reason a session configuration cannot be used.
+///
+/// Every variant names the offending knob, so the message is actionable
+/// without the caller having to guess which setter produced it.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum SessionConfigError {
+    /// A field with no default was never set on the builder.
+    #[error("{field} is required")]
+    MissingField {
+        /// Name of the field that was never set.
+        field: &'static str,
+    },
+
+    /// A string knob was set to the empty string.
+    ///
+    /// An empty value has no wire form: the encoder refuses it, so it would
+    /// fail at the first outbound message rather than at configuration time.
+    #[error("{field} must not be empty")]
+    EmptyField {
+        /// Name of the empty field.
+        field: &'static str,
+    },
+
+    /// A string knob is longer than [`MAX_ID_LEN`] bytes.
+    #[error("{field} is {len} bytes, over the {max}-byte maximum")]
+    FieldTooLong {
+        /// Name of the oversized field.
+        field: &'static str,
+        /// Length of the configured value, in bytes.
+        len: usize,
+        /// The maximum accepted, in bytes.
+        max: usize,
+    },
+
+    /// A string knob carries a byte with no on-the-wire form.
+    ///
+    /// These values are written verbatim into the standard header, so SOH
+    /// would terminate the field early and `=` would open a new tag/value
+    /// pair: either byte structurally corrupts every outbound message.
+    #[error("{field} contains illegal byte 0x{byte:02x} at position {position}")]
+    IllegalByte {
+        /// Name of the offending field.
+        field: &'static str,
+        /// The byte that was refused.
+        byte: u8,
+        /// Its zero-based position in the value.
+        position: usize,
+    },
+
+    /// The heartbeat interval is not a whole number of seconds.
+    #[error(
+        "heartbeat interval {interval:?} is not a whole number of seconds; HeartBtInt (108) is expressed in whole seconds"
+    )]
+    FractionalHeartbeatInterval {
+        /// The configured interval.
+        interval: Duration,
+    },
+
+    /// The heartbeat interval is outside the supported range.
+    #[error("heartbeat interval of {secs}s is outside the supported range {min}s..={max}s")]
+    HeartbeatIntervalOutOfRange {
+        /// The configured interval, in seconds.
+        secs: u64,
+        /// The smallest interval accepted, in seconds.
+        min: u64,
+        /// The largest interval accepted, in seconds.
+        max: u64,
+    },
+
+    /// A zero heartbeat interval reached the builder without the explicit
+    /// opt-in.
+    ///
+    /// `HeartBtInt = 0` is legal and means "do not heartbeat", which switches
+    /// dead-peer detection off for the whole session. That is a decision, not
+    /// a default, so it has to be asked for by name.
+    #[error(
+        "a zero heartbeat interval disables heartbeating entirely (HeartBtInt = 0); call SessionConfigBuilder::disable_heartbeats to ask for that explicitly"
+    )]
+    HeartbeatDisabledWithoutOptIn,
+
+    /// A handshake timeout is zero or above [`MAX_TIMEOUT`].
+    #[error("{field} of {timeout:?} is outside the supported range (non-zero, at most {max:?})")]
+    TimeoutOutOfRange {
+        /// Name of the offending timeout.
+        field: &'static str,
+        /// The configured timeout.
+        timeout: Duration,
+        /// The largest timeout accepted.
+        max: Duration,
+    },
+
+    /// `max_message_size` is outside its supported range.
+    #[error("max_message_size of {size} bytes is outside the supported range {min}..={max}")]
+    MessageSizeLimitOutOfRange {
+        /// The configured limit, in bytes.
+        size: usize,
+        /// The smallest limit accepted, in bytes.
+        min: usize,
+        /// The largest limit accepted, in bytes.
+        max: usize,
+    },
+}
+
+/// Validates one identity string written verbatim into the standard header.
+///
+/// Charset and length match [`CompId`]: printable ASCII (`0x20..=0x7e`)
+/// except `=`, at most [`MAX_ID_LEN`] bytes, never empty.
+fn validate_id(field: &'static str, value: &str) -> Result<(), SessionConfigError> {
+    if value.is_empty() {
+        return Err(SessionConfigError::EmptyField { field });
+    }
+    if value.len() > MAX_ID_LEN {
+        return Err(SessionConfigError::FieldTooLong {
+            field,
+            len: value.len(),
+            max: MAX_ID_LEN,
+        });
+    }
+    for (position, &byte) in value.as_bytes().iter().enumerate() {
+        let printable = byte.is_ascii_graphic() || byte == b' ';
+        if !printable || byte == b'=' {
+            return Err(SessionConfigError::IllegalByte {
+                field,
+                byte,
+                position,
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Validates a handshake timeout: non-zero and at most [`MAX_TIMEOUT`].
+fn validate_timeout(field: &'static str, timeout: Duration) -> Result<(), SessionConfigError> {
+    if timeout.is_zero() || timeout > MAX_TIMEOUT {
+        return Err(SessionConfigError::TimeoutOutOfRange {
+            field,
+            timeout,
+            max: MAX_TIMEOUT,
+        });
+    }
+    Ok(())
+}
+
+/// Validates the heartbeat interval against what tag 108 can carry.
+///
+/// [`Duration::ZERO`] is accepted here: it is the legal `HeartBtInt = 0`
+/// case. The builder is what insists that zero be asked for explicitly.
+fn validate_heartbeat_interval(interval: Duration) -> Result<(), SessionConfigError> {
+    if interval.is_zero() {
+        return Ok(());
+    }
+    if interval.subsec_nanos() != 0 {
+        return Err(SessionConfigError::FractionalHeartbeatInterval { interval });
+    }
+    let secs = interval.as_secs();
+    if !(MIN_HEARTBEAT_INTERVAL_SECS..=MAX_HEARTBEAT_INTERVAL_SECS).contains(&secs) {
+        return Err(SessionConfigError::HeartbeatIntervalOutOfRange {
+            secs,
+            min: MIN_HEARTBEAT_INTERVAL_SECS,
+            max: MAX_HEARTBEAT_INTERVAL_SECS,
+        });
+    }
+    Ok(())
+}
+
 /// Configuration for a FIX session.
+///
+/// Construct one with [`SessionConfigBuilder`], which validates every knob.
+/// The fields are public so a configuration can also be assembled or adjusted
+/// directly; [`SessionConfig::validate`] then says whether the result is
+/// usable, and `ironfix-engine` calls it before dialling.
 #[derive(Debug, Clone)]
 pub struct SessionConfig {
     /// Sender CompID (tag 49).
     pub sender_comp_id: CompId,
     /// Target CompID (tag 56).
     pub target_comp_id: CompId,
-    /// FIX version BeginString (e.g., "FIX.4.4").
+    /// FIX version BeginString, tag 8 (e.g. `FIX.4.4`).
+    ///
+    /// 1..=[`MAX_ID_LEN`] bytes of printable ASCII except `=`. Whether the
+    /// version can actually be framed is a separate question, answered by
+    /// `ironfix-engine`.
     pub begin_string: String,
-    /// Heartbeat interval in seconds.
+    /// Heartbeat interval, `HeartBtInt` (108).
+    ///
+    /// Whole seconds, from [`MIN_HEARTBEAT_INTERVAL_SECS`] to
+    /// [`MAX_HEARTBEAT_INTERVAL_SECS`]. [`Duration::ZERO`] is the legal
+    /// `HeartBtInt = 0` case and disables heartbeating entirely.
     pub heartbeat_interval: Duration,
-    /// Whether to reset sequence numbers on logon.
+    /// Whether to set `ResetSeqNumFlag` (141) on the outbound Logon.
     pub reset_on_logon: bool,
-    /// Whether to reset sequence numbers on logout.
+    /// Whether to reset sequence numbers after a graceful Logout.
     pub reset_on_logout: bool,
-    /// Whether to reset sequence numbers on disconnect.
+    /// Whether to reset sequence numbers when the session disconnects.
     pub reset_on_disconnect: bool,
-    /// Maximum message size in bytes.
+    /// Maximum accepted message size, in bytes.
+    ///
+    /// From [`MIN_MESSAGE_SIZE_LIMIT`] to [`MAX_MESSAGE_SIZE_LIMIT`]. Also the
+    /// per-connection buffering ceiling of the codec.
     pub max_message_size: usize,
-    /// Logon timeout duration.
+    /// How long to wait for the Logon acknowledgement.
+    ///
+    /// Non-zero, at most [`MAX_TIMEOUT`].
     pub logon_timeout: Duration,
-    /// Logout timeout duration.
+    /// How long to wait for the Logout acknowledgement.
+    ///
+    /// Non-zero, at most [`MAX_TIMEOUT`].
     pub logout_timeout: Duration,
-    /// Whether to validate incoming message checksums.
+    /// Whether to validate the `CheckSum` (10) of inbound messages.
     pub validate_checksum: bool,
-    /// Whether to validate incoming message length.
+    /// Whether to validate the `BodyLength` (9) of inbound messages.
     pub validate_length: bool,
-    /// Optional sender sub ID (tag 50).
+    /// Optional sender sub ID (tag 50), 1..=[`MAX_ID_LEN`] bytes when set.
     pub sender_sub_id: Option<String>,
-    /// Optional target sub ID (tag 57).
+    /// Optional target sub ID (tag 57), 1..=[`MAX_ID_LEN`] bytes when set.
     pub target_sub_id: Option<String>,
-    /// Optional sender location ID (tag 142).
+    /// Optional sender location ID (tag 142), 1..=[`MAX_ID_LEN`] bytes when set.
     pub sender_location_id: Option<String>,
-    /// Optional target location ID (tag 143).
+    /// Optional target location ID (tag 143), 1..=[`MAX_ID_LEN`] bytes when set.
     pub target_location_id: Option<String>,
 }
 
 impl SessionConfig {
-    /// Creates a new session configuration with required fields.
+    /// Creates a session configuration with the documented defaults: a 30 s
+    /// heartbeat, 10 s handshake timeouts, a 1 MiB message limit, checksum and
+    /// length validation on, and no sequence resets.
+    ///
+    /// This applies defaults; it does not validate. `begin_string` is the one
+    /// argument that can be malformed — call [`SessionConfig::validate`], or
+    /// build through [`SessionConfigBuilder`], to find out before the session
+    /// dials.
     ///
     /// # Arguments
-    /// * `sender_comp_id` - The sender CompID
-    /// * `target_comp_id` - The target CompID
-    /// * `begin_string` - The FIX version string
+    /// * `sender_comp_id` - The sender CompID (tag 49)
+    /// * `target_comp_id` - The target CompID (tag 56)
+    /// * `begin_string` - The `BeginString` (tag 8), e.g. `FIX.4.4`
     #[must_use]
     pub fn new(
         sender_comp_id: CompId,
@@ -65,13 +346,13 @@ impl SessionConfig {
             sender_comp_id,
             target_comp_id,
             begin_string: begin_string.into(),
-            heartbeat_interval: Duration::from_secs(30),
+            heartbeat_interval: DEFAULT_HEARTBEAT_INTERVAL,
             reset_on_logon: false,
             reset_on_logout: false,
             reset_on_disconnect: false,
-            max_message_size: 1024 * 1024, // 1MB
-            logon_timeout: Duration::from_secs(10),
-            logout_timeout: Duration::from_secs(10),
+            max_message_size: DEFAULT_MESSAGE_SIZE_LIMIT,
+            logon_timeout: DEFAULT_TIMEOUT,
+            logout_timeout: DEFAULT_TIMEOUT,
             validate_checksum: true,
             validate_length: true,
             sender_sub_id: None,
@@ -81,129 +362,420 @@ impl SessionConfig {
         }
     }
 
-    /// Sets the heartbeat interval.
+    /// Checks every knob against the ranges documented on the module.
+    ///
+    /// The CompIDs are not re-checked: [`CompId`] validates its charset and
+    /// length at construction, so an illegal one is unrepresentable.
+    ///
+    /// [`Duration::ZERO`] passes as a heartbeat interval — it is the legal
+    /// `HeartBtInt = 0`. Only [`SessionConfigBuilder`] requires that case to
+    /// be opted into by name.
+    ///
+    /// # Errors
+    /// Returns the first [`SessionConfigError`] found: an empty, oversized or
+    /// non-encodable identity string, a fractional or out-of-range heartbeat
+    /// interval, a zero or excessive handshake timeout, or a message-size
+    /// limit outside [`MIN_MESSAGE_SIZE_LIMIT`]..=[`MAX_MESSAGE_SIZE_LIMIT`].
+    pub fn validate(&self) -> Result<(), SessionConfigError> {
+        validate_id("begin_string", &self.begin_string)?;
+        validate_heartbeat_interval(self.heartbeat_interval)?;
+        validate_timeout("logon_timeout", self.logon_timeout)?;
+        validate_timeout("logout_timeout", self.logout_timeout)?;
+
+        if !(MIN_MESSAGE_SIZE_LIMIT..=MAX_MESSAGE_SIZE_LIMIT).contains(&self.max_message_size) {
+            return Err(SessionConfigError::MessageSizeLimitOutOfRange {
+                size: self.max_message_size,
+                min: MIN_MESSAGE_SIZE_LIMIT,
+                max: MAX_MESSAGE_SIZE_LIMIT,
+            });
+        }
+
+        let optional = [
+            ("sender_sub_id", self.sender_sub_id.as_deref()),
+            ("target_sub_id", self.target_sub_id.as_deref()),
+            ("sender_location_id", self.sender_location_id.as_deref()),
+            ("target_location_id", self.target_location_id.as_deref()),
+        ];
+        for (field, value) in optional {
+            if let Some(value) = value {
+                validate_id(field, value)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Sets the heartbeat interval, `HeartBtInt` (108).
+    ///
+    /// Whole seconds, [`MIN_HEARTBEAT_INTERVAL_SECS`]..=[`MAX_HEARTBEAT_INTERVAL_SECS`],
+    /// or [`Duration::ZERO`] to disable heartbeating. Checked by
+    /// [`SessionConfig::validate`], not here.
     #[must_use]
-    pub fn with_heartbeat_interval(mut self, interval: Duration) -> Self {
+    pub const fn with_heartbeat_interval(mut self, interval: Duration) -> Self {
         self.heartbeat_interval = interval;
         self
     }
 
-    /// Sets whether to reset sequence numbers on logon.
+    /// Sets whether the outbound Logon carries `ResetSeqNumFlag` (141) = Y.
     #[must_use]
     pub const fn with_reset_on_logon(mut self, reset: bool) -> Self {
         self.reset_on_logon = reset;
         self
     }
 
-    /// Sets the maximum message size.
+    /// Sets the maximum accepted message size, in bytes.
+    ///
+    /// [`MIN_MESSAGE_SIZE_LIMIT`]..=[`MAX_MESSAGE_SIZE_LIMIT`]. Checked by
+    /// [`SessionConfig::validate`], not here.
     #[must_use]
     pub const fn with_max_message_size(mut self, size: usize) -> Self {
         self.max_message_size = size;
         self
     }
 
-    /// Sets the logon timeout.
+    /// Sets how long to wait for the Logon acknowledgement.
+    ///
+    /// Non-zero, at most [`MAX_TIMEOUT`]. Checked by
+    /// [`SessionConfig::validate`], not here.
     #[must_use]
-    pub fn with_logon_timeout(mut self, timeout: Duration) -> Self {
+    pub const fn with_logon_timeout(mut self, timeout: Duration) -> Self {
         self.logon_timeout = timeout;
         self
     }
 
-    /// Sets the sender sub ID.
+    /// Sets the sender sub ID (tag 50).
+    ///
+    /// 1..=[`MAX_ID_LEN`] bytes of printable ASCII except `=`. Checked by
+    /// [`SessionConfig::validate`], not here.
     #[must_use]
     pub fn with_sender_sub_id(mut self, sub_id: impl Into<String>) -> Self {
         self.sender_sub_id = Some(sub_id.into());
         self
     }
 
-    /// Sets the target sub ID.
+    /// Sets the target sub ID (tag 57).
+    ///
+    /// 1..=[`MAX_ID_LEN`] bytes of printable ASCII except `=`. Checked by
+    /// [`SessionConfig::validate`], not here.
     #[must_use]
     pub fn with_target_sub_id(mut self, sub_id: impl Into<String>) -> Self {
         self.target_sub_id = Some(sub_id.into());
         self
     }
 
-    /// Returns the heartbeat interval in seconds.
+    /// Returns the heartbeat interval as the whole seconds that go into
+    /// `HeartBtInt` (108).
+    ///
+    /// Exact for any configuration that passed [`SessionConfig::validate`],
+    /// which is what rules out a fractional interval; on an unvalidated
+    /// configuration a sub-second interval would floor to 0, which on the wire
+    /// means "do not heartbeat".
     #[must_use]
-    pub fn heartbeat_interval_secs(&self) -> u64 {
+    pub const fn heartbeat_interval_secs(&self) -> u64 {
         self.heartbeat_interval.as_secs()
     }
 }
 
-/// Builder for session configuration.
-#[derive(Debug, Default)]
+/// How the builder was told to configure heartbeating.
+///
+/// Keeps "no heartbeats, deliberately" distinguishable from "an interval that
+/// happens to be zero", which the plain [`Duration`] field cannot express.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HeartbeatSetting {
+    /// Heartbeat at this interval.
+    Interval(Duration),
+    /// `HeartBtInt = 0`: do not heartbeat at all.
+    Disabled,
+}
+
+/// Builder for [`SessionConfig`] — the canonical way to configure a session.
+///
+/// Every knob has a setter here, and [`SessionConfigBuilder::build`] validates
+/// all of them together. The sender and target CompIDs have no default and
+/// must be set; everything else falls back to the defaults documented on
+/// [`SessionConfig::new`].
+///
+/// # Example
+///
+/// ```
+/// use ironfix_core::types::CompId;
+/// use ironfix_session::config::SessionConfigBuilder;
+/// use std::time::Duration;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let config = SessionConfigBuilder::new()
+///     .sender_comp_id(CompId::new("CLIENT")?)
+///     .target_comp_id(CompId::new("VENUE")?)
+///     .begin_string("FIX.4.4")
+///     .heartbeat_interval(Duration::from_secs(30))
+///     .sender_sub_id("DESK")
+///     .build()?;
+///
+/// assert_eq!(config.heartbeat_interval_secs(), 30);
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone)]
 pub struct SessionConfigBuilder {
+    /// Sender CompID (tag 49); required.
     sender_comp_id: Option<CompId>,
+    /// Target CompID (tag 56); required.
     target_comp_id: Option<CompId>,
-    begin_string: Option<String>,
-    heartbeat_interval: Option<Duration>,
+    /// `BeginString` (tag 8).
+    begin_string: String,
+    /// Heartbeat configuration, including the explicit "disabled" case.
+    heartbeat: HeartbeatSetting,
+    /// `ResetSeqNumFlag` (141) on the outbound Logon.
     reset_on_logon: bool,
-    max_message_size: Option<usize>,
+    /// Reset sequence numbers after a graceful Logout.
+    reset_on_logout: bool,
+    /// Reset sequence numbers on disconnect.
+    reset_on_disconnect: bool,
+    /// Maximum accepted message size, in bytes.
+    max_message_size: usize,
+    /// Logon acknowledgement timeout.
+    logon_timeout: Duration,
+    /// Logout acknowledgement timeout.
+    logout_timeout: Duration,
+    /// Validate inbound `CheckSum` (10).
+    validate_checksum: bool,
+    /// Validate inbound `BodyLength` (9).
+    validate_length: bool,
+    /// Sender sub ID (tag 50).
+    sender_sub_id: Option<String>,
+    /// Target sub ID (tag 57).
+    target_sub_id: Option<String>,
+    /// Sender location ID (tag 142).
+    sender_location_id: Option<String>,
+    /// Target location ID (tag 143).
+    target_location_id: Option<String>,
+}
+
+impl Default for SessionConfigBuilder {
+    fn default() -> Self {
+        Self {
+            sender_comp_id: None,
+            target_comp_id: None,
+            begin_string: DEFAULT_BEGIN_STRING.to_string(),
+            heartbeat: HeartbeatSetting::Interval(DEFAULT_HEARTBEAT_INTERVAL),
+            reset_on_logon: false,
+            reset_on_logout: false,
+            reset_on_disconnect: false,
+            max_message_size: DEFAULT_MESSAGE_SIZE_LIMIT,
+            logon_timeout: DEFAULT_TIMEOUT,
+            logout_timeout: DEFAULT_TIMEOUT,
+            validate_checksum: true,
+            validate_length: true,
+            sender_sub_id: None,
+            target_sub_id: None,
+            sender_location_id: None,
+            target_location_id: None,
+        }
+    }
 }
 
 impl SessionConfigBuilder {
-    /// Creates a new builder.
-    #[must_use]
+    /// Creates a builder holding the defaults documented on
+    /// [`SessionConfig::new`].
+    #[must_use = "builders do nothing unless .build() is called"]
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Sets the sender CompID.
-    #[must_use]
+    /// Sets the sender CompID (tag 49). Required.
+    #[must_use = "builders do nothing unless .build() is called"]
     pub fn sender_comp_id(mut self, id: CompId) -> Self {
         self.sender_comp_id = Some(id);
         self
     }
 
-    /// Sets the target CompID.
-    #[must_use]
+    /// Sets the target CompID (tag 56). Required.
+    #[must_use = "builders do nothing unless .build() is called"]
     pub fn target_comp_id(mut self, id: CompId) -> Self {
         self.target_comp_id = Some(id);
         self
     }
 
-    /// Sets the FIX version.
-    #[must_use]
+    /// Sets the `BeginString` (tag 8), e.g. `FIX.4.4`.
+    ///
+    /// 1..=[`MAX_ID_LEN`] bytes of printable ASCII except `=`.
+    #[must_use = "builders do nothing unless .build() is called"]
     pub fn begin_string(mut self, version: impl Into<String>) -> Self {
-        self.begin_string = Some(version.into());
+        self.begin_string = version.into();
         self
     }
 
-    /// Sets the heartbeat interval.
-    #[must_use]
-    pub fn heartbeat_interval(mut self, interval: Duration) -> Self {
-        self.heartbeat_interval = Some(interval);
+    /// Sets the heartbeat interval, `HeartBtInt` (108).
+    ///
+    /// Whole seconds, from [`MIN_HEARTBEAT_INTERVAL_SECS`] to
+    /// [`MAX_HEARTBEAT_INTERVAL_SECS`]. A fractional or out-of-range value is
+    /// refused by [`SessionConfigBuilder::build`]; [`Duration::ZERO`] is
+    /// refused there too, because disabling heartbeats is
+    /// [`SessionConfigBuilder::disable_heartbeats`].
+    #[must_use = "builders do nothing unless .build() is called"]
+    pub const fn heartbeat_interval(mut self, interval: Duration) -> Self {
+        self.heartbeat = HeartbeatSetting::Interval(interval);
         self
     }
 
-    /// Sets whether to reset on logon.
-    #[must_use]
+    /// Configures `HeartBtInt` (108) = 0: no Heartbeats, no TestRequests, and
+    /// no heartbeat-driven liveness check for the life of the session.
+    ///
+    /// This is legal FIX and sometimes what a venue asks for, but it means a
+    /// dead peer is only noticed when TCP notices. See the
+    /// [`crate::heartbeat`] module.
+    #[must_use = "builders do nothing unless .build() is called"]
+    pub const fn disable_heartbeats(mut self) -> Self {
+        self.heartbeat = HeartbeatSetting::Disabled;
+        self
+    }
+
+    /// Sets whether the outbound Logon carries `ResetSeqNumFlag` (141) = Y.
+    #[must_use = "builders do nothing unless .build() is called"]
     pub const fn reset_on_logon(mut self, reset: bool) -> Self {
         self.reset_on_logon = reset;
         self
     }
 
-    /// Builds the configuration.
+    /// Sets whether sequence numbers reset after a graceful Logout.
+    #[must_use = "builders do nothing unless .build() is called"]
+    pub const fn reset_on_logout(mut self, reset: bool) -> Self {
+        self.reset_on_logout = reset;
+        self
+    }
+
+    /// Sets whether sequence numbers reset when the session disconnects.
+    #[must_use = "builders do nothing unless .build() is called"]
+    pub const fn reset_on_disconnect(mut self, reset: bool) -> Self {
+        self.reset_on_disconnect = reset;
+        self
+    }
+
+    /// Sets the maximum accepted message size, in bytes.
     ///
-    /// # Panics
-    /// Panics if required fields are not set.
-    #[must_use]
-    pub fn build(self) -> SessionConfig {
-        let sender = self.sender_comp_id.expect("sender_comp_id is required");
-        let target = self.target_comp_id.expect("target_comp_id is required");
-        let begin_string = self.begin_string.unwrap_or_else(|| "FIX.4.4".to_string());
+    /// [`MIN_MESSAGE_SIZE_LIMIT`]..=[`MAX_MESSAGE_SIZE_LIMIT`].
+    #[must_use = "builders do nothing unless .build() is called"]
+    pub const fn max_message_size(mut self, size: usize) -> Self {
+        self.max_message_size = size;
+        self
+    }
 
-        let mut config = SessionConfig::new(sender, target, begin_string);
+    /// Sets how long to wait for the Logon acknowledgement.
+    ///
+    /// Non-zero, at most [`MAX_TIMEOUT`].
+    #[must_use = "builders do nothing unless .build() is called"]
+    pub const fn logon_timeout(mut self, timeout: Duration) -> Self {
+        self.logon_timeout = timeout;
+        self
+    }
 
-        if let Some(interval) = self.heartbeat_interval {
-            config.heartbeat_interval = interval;
-        }
-        config.reset_on_logon = self.reset_on_logon;
-        if let Some(size) = self.max_message_size {
-            config.max_message_size = size;
-        }
+    /// Sets how long to wait for the Logout acknowledgement.
+    ///
+    /// Non-zero, at most [`MAX_TIMEOUT`].
+    #[must_use = "builders do nothing unless .build() is called"]
+    pub const fn logout_timeout(mut self, timeout: Duration) -> Self {
+        self.logout_timeout = timeout;
+        self
+    }
 
-        config
+    /// Sets whether inbound `CheckSum` (10) is validated.
+    #[must_use = "builders do nothing unless .build() is called"]
+    pub const fn validate_checksum(mut self, validate: bool) -> Self {
+        self.validate_checksum = validate;
+        self
+    }
+
+    /// Sets whether inbound `BodyLength` (9) is validated.
+    #[must_use = "builders do nothing unless .build() is called"]
+    pub const fn validate_length(mut self, validate: bool) -> Self {
+        self.validate_length = validate;
+        self
+    }
+
+    /// Sets the sender sub ID (tag 50).
+    ///
+    /// 1..=[`MAX_ID_LEN`] bytes of printable ASCII except `=`.
+    #[must_use = "builders do nothing unless .build() is called"]
+    pub fn sender_sub_id(mut self, sub_id: impl Into<String>) -> Self {
+        self.sender_sub_id = Some(sub_id.into());
+        self
+    }
+
+    /// Sets the target sub ID (tag 57).
+    ///
+    /// 1..=[`MAX_ID_LEN`] bytes of printable ASCII except `=`.
+    #[must_use = "builders do nothing unless .build() is called"]
+    pub fn target_sub_id(mut self, sub_id: impl Into<String>) -> Self {
+        self.target_sub_id = Some(sub_id.into());
+        self
+    }
+
+    /// Sets the sender location ID (tag 142).
+    ///
+    /// 1..=[`MAX_ID_LEN`] bytes of printable ASCII except `=`.
+    #[must_use = "builders do nothing unless .build() is called"]
+    pub fn sender_location_id(mut self, location_id: impl Into<String>) -> Self {
+        self.sender_location_id = Some(location_id.into());
+        self
+    }
+
+    /// Sets the target location ID (tag 143).
+    ///
+    /// 1..=[`MAX_ID_LEN`] bytes of printable ASCII except `=`.
+    #[must_use = "builders do nothing unless .build() is called"]
+    pub fn target_location_id(mut self, location_id: impl Into<String>) -> Self {
+        self.target_location_id = Some(location_id.into());
+        self
+    }
+
+    /// Builds the configuration, validating every knob.
+    ///
+    /// # Errors
+    /// Returns [`SessionConfigError::MissingField`] if either CompID was never
+    /// set, and [`SessionConfigError::HeartbeatDisabledWithoutOptIn`] if
+    /// [`SessionConfigBuilder::heartbeat_interval`] was given
+    /// [`Duration::ZERO`] instead of calling
+    /// [`SessionConfigBuilder::disable_heartbeats`]. Everything else is the
+    /// first violation reported by [`SessionConfig::validate`].
+    pub fn build(self) -> Result<SessionConfig, SessionConfigError> {
+        let sender_comp_id = self
+            .sender_comp_id
+            .ok_or(SessionConfigError::MissingField {
+                field: "sender_comp_id",
+            })?;
+        let target_comp_id = self
+            .target_comp_id
+            .ok_or(SessionConfigError::MissingField {
+                field: "target_comp_id",
+            })?;
+
+        let heartbeat_interval = match self.heartbeat {
+            HeartbeatSetting::Disabled => Duration::ZERO,
+            HeartbeatSetting::Interval(interval) if interval.is_zero() => {
+                return Err(SessionConfigError::HeartbeatDisabledWithoutOptIn);
+            }
+            HeartbeatSetting::Interval(interval) => interval,
+        };
+
+        let config = SessionConfig {
+            sender_comp_id,
+            target_comp_id,
+            begin_string: self.begin_string,
+            heartbeat_interval,
+            reset_on_logon: self.reset_on_logon,
+            reset_on_logout: self.reset_on_logout,
+            reset_on_disconnect: self.reset_on_disconnect,
+            max_message_size: self.max_message_size,
+            logon_timeout: self.logon_timeout,
+            logout_timeout: self.logout_timeout,
+            validate_checksum: self.validate_checksum,
+            validate_length: self.validate_length,
+            sender_sub_id: self.sender_sub_id,
+            target_sub_id: self.target_sub_id,
+            sender_location_id: self.sender_location_id,
+            target_location_id: self.target_location_id,
+        };
+        config.validate()?;
+        Ok(config)
     }
 }
 
@@ -211,30 +783,457 @@ impl SessionConfigBuilder {
 mod tests {
     use super::*;
 
+    /// Builds a CompID, failing the test rather than the session.
+    #[track_caller]
+    fn comp_id(value: &str) -> CompId {
+        match CompId::new(value) {
+            Ok(id) => id,
+            Err(err) => panic!("test CompID '{value}' must be valid: {err}"),
+        }
+    }
+
+    /// A builder with only the required knobs set.
+    fn required() -> SessionConfigBuilder {
+        SessionConfigBuilder::new()
+            .sender_comp_id(comp_id("SENDER"))
+            .target_comp_id(comp_id("TARGET"))
+    }
+
+    /// Unwraps a build that the test expects to succeed.
+    #[track_caller]
+    fn built(builder: SessionConfigBuilder) -> SessionConfig {
+        match builder.build() {
+            Ok(config) => config,
+            Err(err) => panic!("configuration must build: {err}"),
+        }
+    }
+
+    /// Returns the error from a build the test expects to fail.
+    #[track_caller]
+    fn build_error(builder: SessionConfigBuilder) -> SessionConfigError {
+        match builder.build() {
+            Ok(_) => panic!("configuration must not build"),
+            Err(err) => err,
+        }
+    }
+
+    // --- Defaults ------------------------------------------------------------
+
     #[test]
-    fn test_session_config_new() {
-        let sender = CompId::new("SENDER").unwrap();
-        let target = CompId::new("TARGET").unwrap();
-        let config = SessionConfig::new(sender, target, "FIX.4.4");
+    fn test_session_config_new_applies_documented_defaults() {
+        let config = SessionConfig::new(comp_id("SENDER"), comp_id("TARGET"), "FIX.4.4");
 
         assert_eq!(config.sender_comp_id.as_str(), "SENDER");
         assert_eq!(config.target_comp_id.as_str(), "TARGET");
         assert_eq!(config.begin_string, "FIX.4.4");
         assert_eq!(config.heartbeat_interval, Duration::from_secs(30));
+        assert_eq!(config.logon_timeout, Duration::from_secs(10));
+        assert_eq!(config.logout_timeout, Duration::from_secs(10));
+        assert_eq!(config.max_message_size, 1024 * 1024);
+        assert!(config.validate_checksum);
+        assert!(config.validate_length);
+        assert!(!config.reset_on_logon);
+        assert_eq!(config.validate(), Ok(()));
     }
 
     #[test]
-    fn test_session_config_builder() {
-        let config = SessionConfigBuilder::new()
-            .sender_comp_id(CompId::new("SENDER").unwrap())
-            .target_comp_id(CompId::new("TARGET").unwrap())
-            .begin_string("FIX.4.2")
-            .heartbeat_interval(Duration::from_secs(60))
-            .reset_on_logon(true)
-            .build();
+    fn test_builder_defaults_match_session_config_new() {
+        let built_config = built(required());
+        let direct = SessionConfig::new(comp_id("SENDER"), comp_id("TARGET"), "FIX.4.4");
 
+        assert_eq!(built_config.begin_string, direct.begin_string);
+        assert_eq!(built_config.heartbeat_interval, direct.heartbeat_interval);
+        assert_eq!(built_config.logon_timeout, direct.logon_timeout);
+        assert_eq!(built_config.logout_timeout, direct.logout_timeout);
+        assert_eq!(built_config.max_message_size, direct.max_message_size);
+        assert_eq!(built_config.validate_checksum, direct.validate_checksum);
+        assert_eq!(built_config.validate_length, direct.validate_length);
+    }
+
+    // --- Required fields -----------------------------------------------------
+
+    #[test]
+    fn test_build_without_sender_comp_id_reports_missing_field() {
+        let builder = SessionConfigBuilder::new().target_comp_id(comp_id("TARGET"));
+        assert_eq!(
+            build_error(builder),
+            SessionConfigError::MissingField {
+                field: "sender_comp_id"
+            }
+        );
+    }
+
+    #[test]
+    fn test_build_without_target_comp_id_reports_missing_field() {
+        let builder = SessionConfigBuilder::new().sender_comp_id(comp_id("SENDER"));
+        assert_eq!(
+            build_error(builder),
+            SessionConfigError::MissingField {
+                field: "target_comp_id"
+            }
+        );
+    }
+
+    // --- Every setter lands in the built configuration -----------------------
+
+    #[test]
+    fn test_builder_setters_land_in_the_built_config() {
+        let config = built(
+            required()
+                .begin_string("FIX.4.2")
+                .heartbeat_interval(Duration::from_secs(60))
+                .reset_on_logon(true)
+                .reset_on_logout(true)
+                .reset_on_disconnect(true)
+                .max_message_size(4096)
+                .logon_timeout(Duration::from_secs(5))
+                .logout_timeout(Duration::from_secs(7))
+                .validate_checksum(false)
+                .validate_length(false)
+                .sender_sub_id("SDESK")
+                .target_sub_id("TDESK")
+                .sender_location_id("LON")
+                .target_location_id("NYC"),
+        );
+
+        assert_eq!(config.sender_comp_id.as_str(), "SENDER");
+        assert_eq!(config.target_comp_id.as_str(), "TARGET");
         assert_eq!(config.begin_string, "FIX.4.2");
         assert_eq!(config.heartbeat_interval, Duration::from_secs(60));
         assert!(config.reset_on_logon);
+        assert!(config.reset_on_logout);
+        assert!(config.reset_on_disconnect);
+        assert_eq!(config.max_message_size, 4096);
+        assert_eq!(config.logon_timeout, Duration::from_secs(5));
+        assert_eq!(config.logout_timeout, Duration::from_secs(7));
+        assert!(!config.validate_checksum);
+        assert!(!config.validate_length);
+        assert_eq!(config.sender_sub_id.as_deref(), Some("SDESK"));
+        assert_eq!(config.target_sub_id.as_deref(), Some("TDESK"));
+        assert_eq!(config.sender_location_id.as_deref(), Some("LON"));
+        assert_eq!(config.target_location_id.as_deref(), Some("NYC"));
+    }
+
+    // --- Heartbeat interval --------------------------------------------------
+
+    #[test]
+    fn test_build_with_fractional_heartbeat_interval_is_rejected() {
+        let interval = Duration::from_millis(500);
+        assert_eq!(
+            build_error(required().heartbeat_interval(interval)),
+            SessionConfigError::FractionalHeartbeatInterval { interval }
+        );
+    }
+
+    #[test]
+    fn test_build_with_sub_second_heartbeat_never_truncates_to_zero() {
+        // The defect this replaces: 500ms floored to HeartBtInt=0, which now
+        // means "no heartbeating at all" on the wire.
+        assert!(
+            required()
+                .heartbeat_interval(Duration::from_millis(500))
+                .build()
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_build_with_zero_heartbeat_interval_requires_the_explicit_opt_in() {
+        assert_eq!(
+            build_error(required().heartbeat_interval(Duration::ZERO)),
+            SessionConfigError::HeartbeatDisabledWithoutOptIn
+        );
+    }
+
+    #[test]
+    fn test_disable_heartbeats_builds_a_zero_interval() {
+        let config = built(required().disable_heartbeats());
+        assert_eq!(config.heartbeat_interval, Duration::ZERO);
+        assert_eq!(config.heartbeat_interval_secs(), 0);
+    }
+
+    #[test]
+    fn test_build_with_heartbeat_interval_above_the_ceiling_is_rejected() {
+        let secs = MAX_HEARTBEAT_INTERVAL_SECS + 1;
+        assert_eq!(
+            build_error(required().heartbeat_interval(Duration::from_secs(secs))),
+            SessionConfigError::HeartbeatIntervalOutOfRange {
+                secs,
+                min: MIN_HEARTBEAT_INTERVAL_SECS,
+                max: MAX_HEARTBEAT_INTERVAL_SECS,
+            }
+        );
+    }
+
+    #[test]
+    fn test_build_accepts_the_heartbeat_interval_bounds() {
+        let min =
+            built(required().heartbeat_interval(Duration::from_secs(MIN_HEARTBEAT_INTERVAL_SECS)));
+        assert_eq!(min.heartbeat_interval_secs(), MIN_HEARTBEAT_INTERVAL_SECS);
+
+        let max =
+            built(required().heartbeat_interval(Duration::from_secs(MAX_HEARTBEAT_INTERVAL_SECS)));
+        assert_eq!(max.heartbeat_interval_secs(), MAX_HEARTBEAT_INTERVAL_SECS);
+    }
+
+    #[test]
+    fn test_heartbeat_interval_secs_equals_the_configured_whole_seconds() {
+        let config = built(required().heartbeat_interval(Duration::from_secs(45)));
+        assert_eq!(
+            config.heartbeat_interval_secs(),
+            config.heartbeat_interval.as_secs()
+        );
+        assert_eq!(config.heartbeat_interval_secs(), 45);
+    }
+
+    // --- BeginString ---------------------------------------------------------
+
+    #[test]
+    fn test_build_with_empty_begin_string_is_rejected() {
+        assert_eq!(
+            build_error(required().begin_string("")),
+            SessionConfigError::EmptyField {
+                field: "begin_string"
+            }
+        );
+    }
+
+    #[test]
+    fn test_build_with_soh_in_begin_string_is_rejected() {
+        assert_eq!(
+            build_error(required().begin_string("FIX\x014.4")),
+            SessionConfigError::IllegalByte {
+                field: "begin_string",
+                byte: 0x01,
+                position: 3,
+            }
+        );
+    }
+
+    #[test]
+    fn test_build_with_overlong_begin_string_is_rejected() {
+        let long = "F".repeat(MAX_ID_LEN + 1);
+        assert_eq!(
+            build_error(required().begin_string(long)),
+            SessionConfigError::FieldTooLong {
+                field: "begin_string",
+                len: MAX_ID_LEN + 1,
+                max: MAX_ID_LEN,
+            }
+        );
+    }
+
+    // --- Timeouts ------------------------------------------------------------
+
+    #[test]
+    fn test_build_with_zero_logon_timeout_is_rejected() {
+        assert_eq!(
+            build_error(required().logon_timeout(Duration::ZERO)),
+            SessionConfigError::TimeoutOutOfRange {
+                field: "logon_timeout",
+                timeout: Duration::ZERO,
+                max: MAX_TIMEOUT,
+            }
+        );
+    }
+
+    #[test]
+    fn test_build_with_zero_logout_timeout_is_rejected() {
+        assert_eq!(
+            build_error(required().logout_timeout(Duration::ZERO)),
+            SessionConfigError::TimeoutOutOfRange {
+                field: "logout_timeout",
+                timeout: Duration::ZERO,
+                max: MAX_TIMEOUT,
+            }
+        );
+    }
+
+    #[test]
+    fn test_build_with_excessive_logon_timeout_is_rejected() {
+        let timeout = MAX_TIMEOUT + Duration::from_secs(1);
+        assert_eq!(
+            build_error(required().logon_timeout(timeout)),
+            SessionConfigError::TimeoutOutOfRange {
+                field: "logon_timeout",
+                timeout,
+                max: MAX_TIMEOUT,
+            }
+        );
+    }
+
+    #[test]
+    fn test_build_accepts_a_sub_second_timeout() {
+        // Timeouts are not wire values: unlike HeartBtInt they may be
+        // fractional, and short ones are how a test drives the handshake.
+        let config = built(required().logon_timeout(Duration::from_millis(300)));
+        assert_eq!(config.logon_timeout, Duration::from_millis(300));
+    }
+
+    // --- Message size limit --------------------------------------------------
+
+    #[test]
+    fn test_build_with_zero_max_message_size_is_rejected() {
+        assert_eq!(
+            build_error(required().max_message_size(0)),
+            SessionConfigError::MessageSizeLimitOutOfRange {
+                size: 0,
+                min: MIN_MESSAGE_SIZE_LIMIT,
+                max: MAX_MESSAGE_SIZE_LIMIT,
+            }
+        );
+    }
+
+    #[test]
+    fn test_build_with_max_message_size_below_the_floor_is_rejected() {
+        let size = MIN_MESSAGE_SIZE_LIMIT - 1;
+        assert_eq!(
+            build_error(required().max_message_size(size)),
+            SessionConfigError::MessageSizeLimitOutOfRange {
+                size,
+                min: MIN_MESSAGE_SIZE_LIMIT,
+                max: MAX_MESSAGE_SIZE_LIMIT,
+            }
+        );
+    }
+
+    #[test]
+    fn test_build_with_max_message_size_above_the_ceiling_is_rejected() {
+        let size = MAX_MESSAGE_SIZE_LIMIT + 1;
+        assert_eq!(
+            build_error(required().max_message_size(size)),
+            SessionConfigError::MessageSizeLimitOutOfRange {
+                size,
+                min: MIN_MESSAGE_SIZE_LIMIT,
+                max: MAX_MESSAGE_SIZE_LIMIT,
+            }
+        );
+    }
+
+    #[test]
+    fn test_build_accepts_the_message_size_bounds() {
+        assert_eq!(
+            built(required().max_message_size(MIN_MESSAGE_SIZE_LIMIT)).max_message_size,
+            MIN_MESSAGE_SIZE_LIMIT
+        );
+        assert_eq!(
+            built(required().max_message_size(MAX_MESSAGE_SIZE_LIMIT)).max_message_size,
+            MAX_MESSAGE_SIZE_LIMIT
+        );
+    }
+
+    // --- Sub IDs and location IDs --------------------------------------------
+
+    #[test]
+    fn test_build_with_empty_sender_sub_id_is_rejected() {
+        assert_eq!(
+            build_error(required().sender_sub_id("")),
+            SessionConfigError::EmptyField {
+                field: "sender_sub_id"
+            }
+        );
+    }
+
+    #[test]
+    fn test_build_with_soh_in_target_sub_id_is_rejected() {
+        assert_eq!(
+            build_error(required().target_sub_id("DE\x01SK")),
+            SessionConfigError::IllegalByte {
+                field: "target_sub_id",
+                byte: 0x01,
+                position: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn test_build_with_equals_in_sender_location_id_is_rejected() {
+        assert_eq!(
+            build_error(required().sender_location_id("LON=1")),
+            SessionConfigError::IllegalByte {
+                field: "sender_location_id",
+                byte: b'=',
+                position: 3,
+            }
+        );
+    }
+
+    #[test]
+    fn test_build_with_overlong_target_location_id_is_rejected() {
+        let long = "N".repeat(MAX_ID_LEN + 1);
+        assert_eq!(
+            build_error(required().target_location_id(long)),
+            SessionConfigError::FieldTooLong {
+                field: "target_location_id",
+                len: MAX_ID_LEN + 1,
+                max: MAX_ID_LEN,
+            }
+        );
+    }
+
+    #[test]
+    fn test_build_with_non_ascii_sub_id_is_rejected() {
+        // 'é' is two UTF-8 bytes, neither of them printable ASCII.
+        assert!(matches!(
+            build_error(required().sender_sub_id("DESKé")),
+            SessionConfigError::IllegalByte {
+                field: "sender_sub_id",
+                ..
+            }
+        ));
+    }
+
+    // --- validate() on a hand-assembled configuration ------------------------
+
+    #[test]
+    fn test_validate_rejects_a_hand_assembled_fractional_heartbeat() {
+        let config = SessionConfig::new(comp_id("SENDER"), comp_id("TARGET"), "FIX.4.4")
+            .with_heartbeat_interval(Duration::from_millis(1500));
+
+        assert_eq!(
+            config.validate(),
+            Err(SessionConfigError::FractionalHeartbeatInterval {
+                interval: Duration::from_millis(1500)
+            })
+        );
+    }
+
+    #[test]
+    fn test_validate_accepts_a_zero_heartbeat_interval() {
+        // HeartBtInt = 0 is legal FIX; only the builder insists it be asked
+        // for by name.
+        let config = SessionConfig::new(comp_id("SENDER"), comp_id("TARGET"), "FIX.4.4")
+            .with_heartbeat_interval(Duration::ZERO);
+        assert_eq!(config.validate(), Ok(()));
+    }
+
+    #[test]
+    fn test_validate_rejects_a_hand_assembled_sub_id_with_soh() {
+        let config = SessionConfig::new(comp_id("SENDER"), comp_id("TARGET"), "FIX.4.4")
+            .with_sender_sub_id("DESK\x01");
+
+        assert_eq!(
+            config.validate(),
+            Err(SessionConfigError::IllegalByte {
+                field: "sender_sub_id",
+                byte: 0x01,
+                position: 4,
+            })
+        );
+    }
+
+    #[test]
+    fn test_validate_rejects_a_hand_assembled_message_size_of_zero() {
+        let mut config = SessionConfig::new(comp_id("SENDER"), comp_id("TARGET"), "FIX.4.4");
+        config.max_message_size = 0;
+
+        assert_eq!(
+            config.validate(),
+            Err(SessionConfigError::MessageSizeLimitOutOfRange {
+                size: 0,
+                min: MIN_MESSAGE_SIZE_LIMIT,
+                max: MAX_MESSAGE_SIZE_LIMIT,
+            })
+        );
     }
 }

--- a/ironfix-session/src/lib.rs
+++ b/ironfix-session/src/lib.rs
@@ -16,10 +16,14 @@
 //!   (`Disconnected` → `Connecting` → `LogonSent`/`LogonReceived` → `Active` →
 //!   `Resending`/`LogoutPending`), so illegal transitions do not compile
 //! - **Sequence management**: [`SequenceManager`] with checked arithmetic —
-//!   exhaustion is a typed error, never a silent wrap
+//!   exhaustion is a typed error, never a silent wrap. Gap *detection*
+//!   ([`SequenceResult::Gap`]) lives here; the recovery that follows
+//!   (ResendRequest, SequenceReset, gap fill) is orchestrated by
+//!   `ironfix-engine`, which owns the socket
 //! - **Heartbeat handling**: [`HeartbeatManager`], `Instant`-based timing for
-//!   heartbeat and TestRequest deadlines
-//! - **Configuration**: [`SessionConfig`] and [`config::SessionConfigBuilder`]
+//!   heartbeat and TestRequest deadlines and `HeartBtInt` negotiation
+//! - **Configuration**: [`SessionConfig`] and its validating
+//!   [`config::SessionConfigBuilder`]
 //!
 //! Note that the `Resending` state is only the FSM marker for "a resend is in
 //! progress". The actual `ResendRequest` / `SequenceReset` / gap-fill message
@@ -30,9 +34,12 @@ pub mod heartbeat;
 pub mod sequence;
 pub mod state;
 
-pub use config::SessionConfig;
-pub use heartbeat::{HeartbeatIntervalError, HeartbeatManager, TestRequestOutcome};
-pub use sequence::{SequenceCounter, SequenceExhausted, SequenceManager};
+pub use config::{SessionConfig, SessionConfigBuilder, SessionConfigError};
+pub use heartbeat::{
+    HeartbeatIntervalError, HeartbeatManager, MAX_HEARTBEAT_INTERVAL_SECS, TestRequestOutcome,
+    generate_test_req_id, negotiate_interval,
+};
+pub use sequence::{SequenceCounter, SequenceExhausted, SequenceManager, SequenceResult};
 pub use state::{
     Active, Connecting, Disconnected, LogonReceived, LogonSent, LogoutPending, Resending, Session,
     SessionState,

--- a/ironfix-session/src/sequence.rs
+++ b/ironfix-session/src/sequence.rs
@@ -9,6 +9,7 @@
 //! This module provides atomic sequence number management for FIX sessions.
 
 use ironfix_core::types::SeqNum;
+use std::num::NonZeroU64;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Error returned when a sequence counter has reached its maximum value.
@@ -67,21 +68,22 @@ impl SequenceManager {
         }
     }
 
-    /// Creates a new sequence manager with specified starting values.
+    /// Creates a new sequence manager seeded with the given starting values.
     ///
-    /// Both counters must be **at least 1**: FIX numbers messages from 1, and
-    /// a `MsgSeqNum` (34) of 0 is rejected by every conforming counterparty.
-    /// That contract is not enforced here yet — seeding 0 is accepted and
-    /// would put `34=0` on the wire.
+    /// Both counters are [`NonZeroU64`]: FIX numbers messages from 1, and a
+    /// `MsgSeqNum` (34) of 0 is rejected by every conforming counterparty.
+    /// Taking [`NonZeroU64`] makes a zero seed unrepresentable at the type
+    /// level, so a `34=0` can never be seeded onto the wire — the invalid
+    /// state is refused at the call site rather than caught at runtime.
     ///
     /// # Arguments
     /// * `sender_seq` - Next outgoing sequence number, `>= 1`
     /// * `target_seq` - Next expected incoming sequence number, `>= 1`
     #[must_use]
-    pub fn with_initial(sender_seq: u64, target_seq: u64) -> Self {
+    pub const fn with_initial(sender_seq: NonZeroU64, target_seq: NonZeroU64) -> Self {
         Self {
-            next_sender_seq: AtomicU64::new(sender_seq),
-            next_target_seq: AtomicU64::new(target_seq),
+            next_sender_seq: AtomicU64::new(sender_seq.get()),
+            next_target_seq: AtomicU64::new(target_seq.get()),
         }
     }
 
@@ -283,11 +285,30 @@ impl SequenceResult {
 mod tests {
     use super::*;
 
+    /// Builds a `NonZeroU64` for seeding, failing the test rather than the
+    /// session if the literal is zero.
+    #[track_caller]
+    fn nz(value: u64) -> NonZeroU64 {
+        match NonZeroU64::new(value) {
+            Some(value) => value,
+            None => panic!("test seed {value} must be non-zero"),
+        }
+    }
+
     #[test]
     fn test_sequence_manager_new() {
         let mgr = SequenceManager::new();
         assert_eq!(mgr.next_sender_seq().value(), 1);
         assert_eq!(mgr.next_target_seq().value(), 1);
+    }
+
+    #[test]
+    fn test_with_initial_seeds_the_given_nonzero_values() {
+        // A zero seed is unrepresentable: `with_initial` takes NonZeroU64, so
+        // `34=0` can never be seeded onto the wire.
+        let mgr = SequenceManager::with_initial(nz(7), nz(9));
+        assert_eq!(mgr.next_sender_seq().value(), 7);
+        assert_eq!(mgr.next_target_seq().value(), 9);
     }
 
     #[test]
@@ -339,7 +360,7 @@ mod tests {
 
     #[test]
     fn test_try_allocate_sender_seq_exhausted() {
-        let mgr = SequenceManager::with_initial(u64::MAX, 1);
+        let mgr = SequenceManager::with_initial(NonZeroU64::MAX, NonZeroU64::MIN);
 
         assert_eq!(
             mgr.try_allocate_sender_seq(),
@@ -367,7 +388,7 @@ mod tests {
 
     #[test]
     fn test_try_increment_target_seq_exhausted() {
-        let mgr = SequenceManager::with_initial(1, u64::MAX);
+        let mgr = SequenceManager::with_initial(NonZeroU64::MIN, NonZeroU64::MAX);
 
         assert_eq!(
             mgr.try_increment_target_seq(),
@@ -381,7 +402,7 @@ mod tests {
 
     #[test]
     fn test_reset() {
-        let mgr = SequenceManager::with_initial(100, 200);
+        let mgr = SequenceManager::with_initial(nz(100), nz(200));
         assert_eq!(mgr.next_sender_seq().value(), 100);
         assert_eq!(mgr.next_target_seq().value(), 200);
 

--- a/ironfix-session/src/sequence.rs
+++ b/ironfix-session/src/sequence.rs
@@ -69,9 +69,14 @@ impl SequenceManager {
 
     /// Creates a new sequence manager with specified starting values.
     ///
+    /// Both counters must be **at least 1**: FIX numbers messages from 1, and
+    /// a `MsgSeqNum` (34) of 0 is rejected by every conforming counterparty.
+    /// That contract is not enforced here yet — seeding 0 is accepted and
+    /// would put `34=0` on the wire.
+    ///
     /// # Arguments
-    /// * `sender_seq` - Initial sender sequence number
-    /// * `target_seq` - Initial target sequence number
+    /// * `sender_seq` - Next outgoing sequence number, `>= 1`
+    /// * `target_seq` - Next expected incoming sequence number, `>= 1`
     #[must_use]
     pub fn with_initial(sender_seq: u64, target_seq: u64) -> Self {
         Self {
@@ -103,6 +108,7 @@ impl SequenceManager {
     /// [`try_allocate_sender_seq`](Self::try_allocate_sender_seq) for
     /// venue-grade sessions where exhaustion must be an explicit error.
     #[inline]
+    #[must_use = "dropping the allocated sequence number leaves a gap in the outbound stream"]
     #[deprecated(
         since = "0.4.0",
         note = "wraps silently on overflow, which corrupts a live session; use try_allocate_sender_seq. Removed in the next breaking release."
@@ -174,7 +180,8 @@ impl SequenceManager {
     /// Sets the next sender sequence number.
     ///
     /// # Arguments
-    /// * `seq` - The new sequence number
+    /// * `seq` - The new sequence number, `>= 1` (see
+    ///   [`SequenceManager::with_initial`] for the contract)
     #[inline]
     pub fn set_sender_seq(&self, seq: u64) {
         self.next_sender_seq.store(seq, Ordering::SeqCst);
@@ -183,7 +190,8 @@ impl SequenceManager {
     /// Sets the next target sequence number.
     ///
     /// # Arguments
-    /// * `seq` - The new sequence number
+    /// * `seq` - The new sequence number, `>= 1` (see
+    ///   [`SequenceManager::with_initial`] for the contract)
     #[inline]
     pub fn set_target_seq(&self, seq: u64) {
         self.next_target_seq.store(seq, Ordering::SeqCst);
@@ -196,15 +204,20 @@ impl SequenceManager {
         self.next_target_seq.store(1, Ordering::SeqCst);
     }
 
-    /// Validates an incoming sequence number.
+    /// Validates an incoming `MsgSeqNum` (34) against the next expected
+    /// target sequence number.
+    ///
+    /// This only classifies; it moves no counter. Acting on the answer —
+    /// a ResendRequest for a gap, a `PossDupFlag` check for a duplicate — is
+    /// the engine's job.
     ///
     /// # Arguments
     /// * `received` - The received sequence number
     ///
     /// # Returns
-    /// - `Ok(())` if the sequence number matches expected
-    /// - `Err(SequenceResult::TooLow)` if it's a possible duplicate
-    /// - `Err(SequenceResult::Gap)` if there's a gap
+    /// - [`SequenceResult::Ok`] when it is exactly the expected number
+    /// - [`SequenceResult::TooLow`] when it is lower (a possible duplicate)
+    /// - [`SequenceResult::Gap`] when it is higher (messages were missed)
     #[must_use]
     pub fn validate_incoming(&self, received: u64) -> SequenceResult {
         let expected = self.next_target_seq.load(Ordering::SeqCst);

--- a/ironfix-session/src/state.rs
+++ b/ironfix-session/src/state.rs
@@ -8,8 +8,19 @@
 //!
 //! This module implements a compile-time checked state machine for FIX sessions.
 //! State transitions are enforced by the type system, preventing invalid operations.
+//!
+//! # States carry their data
+//!
+//! [`Session`] stores its state value, not a `PhantomData<S>`, so the data a
+//! state is defined by is reachable: when the session is in [`LogonSent`] it
+//! *has* the instant the Logon went out, and only then. That is what lets a
+//! caller enforce the logon and logout timeouts from the state machine rather
+//! than tracking deadlines beside it — `ironfix-engine`'s reactor times its
+//! Logout out through `Session<LogoutPending>::sent_at`.
+//!
+//! The states with no data ([`Disconnected`], [`Connecting`], [`Active`]) stay
+//! zero-sized, so the typestate still costs nothing for them.
 
-use std::marker::PhantomData;
 use std::time::Instant;
 
 /// Marker trait for session states.
@@ -34,9 +45,9 @@ impl private::Sealed for Connecting {}
 impl SessionState for Connecting {}
 
 /// LogonSent state - Logon message sent, awaiting response.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct LogonSent {
-    /// Time when Logon was sent.
+    /// Time when Logon was sent, for the `logon_timeout`.
     pub sent_at: Instant,
 }
 
@@ -45,9 +56,9 @@ impl SessionState for LogonSent {}
 
 /// LogonReceived state - Logon received from counterparty (acceptor side),
 /// pending authentication.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct LogonReceived {
-    /// Time when the Logon was received.
+    /// Time when the Logon was received, for the authentication deadline.
     pub received_at: Instant,
 }
 
@@ -62,11 +73,14 @@ impl private::Sealed for Active {}
 impl SessionState for Active {}
 
 /// Resending state - processing a resend request.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct Resending {
-    /// Begin sequence number of the gap.
+    /// Begin sequence number of the gap, `BeginSeqNo` (7).
     pub begin_seq: u64,
-    /// End sequence number of the gap.
+    /// End sequence number of the gap, `EndSeqNo` (16).
+    ///
+    /// `0` carries the FIX convention "through the last message sent"
+    /// (`doc/fix_operations.md`, "Resend Request"), not an empty range.
     pub end_seq: u64,
 }
 
@@ -74,9 +88,9 @@ impl private::Sealed for Resending {}
 impl SessionState for Resending {}
 
 /// LogoutPending state - Logout sent, awaiting confirmation.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct LogoutPending {
-    /// Time when Logout was sent.
+    /// Time when Logout was sent, for the `logout_timeout`.
     pub sent_at: Instant,
 }
 
@@ -85,13 +99,14 @@ impl SessionState for LogoutPending {}
 
 /// Session wrapper with typestate for compile-time state checking.
 ///
-/// The type parameter `S` represents the current session state.
+/// The type parameter `S` represents the current session state, and the value
+/// of that state is stored: see the module documentation.
 #[derive(Debug)]
 pub struct Session<S: SessionState> {
     /// Session identifier.
     pub session_id: String,
-    /// Phantom data for the state type.
-    _state: PhantomData<S>,
+    /// The current state and its data.
+    state: S,
 }
 
 impl<S: SessionState> Session<S> {
@@ -99,6 +114,23 @@ impl<S: SessionState> Session<S> {
     #[must_use]
     pub fn session_id(&self) -> &str {
         &self.session_id
+    }
+
+    /// Returns the current state and its data.
+    #[must_use]
+    pub const fn state(&self) -> &S {
+        &self.state
+    }
+
+    /// Moves to `next`, carrying the session identity across.
+    ///
+    /// Private: the only way to reach a state is through the transition that
+    /// names it, which is what keeps an illegal transition uncompilable.
+    fn transition<N: SessionState>(self, next: N) -> Session<N> {
+        Session {
+            session_id: self.session_id,
+            state: next,
+        }
     }
 }
 
@@ -111,182 +143,173 @@ impl Session<Disconnected> {
     pub fn new(session_id: impl Into<String>) -> Self {
         Self {
             session_id: session_id.into(),
-            _state: PhantomData,
+            state: Disconnected,
         }
     }
 
     /// Transitions to the Connecting state (initiator side).
     #[must_use]
     pub fn connect(self) -> Session<Connecting> {
-        Session {
-            session_id: self.session_id,
-            _state: PhantomData,
-        }
+        self.transition(Connecting)
     }
 
     /// Transitions to the Connecting state after accepting an inbound
     /// TCP connection (acceptor side).
     #[must_use]
     pub fn accept(self) -> Session<Connecting> {
-        Session {
-            session_id: self.session_id,
-            _state: PhantomData,
-        }
+        self.transition(Connecting)
     }
 }
 
 impl Session<Connecting> {
-    /// Transitions to the LogonSent state after sending Logon (initiator side).
+    /// Transitions to the LogonSent state after sending Logon (initiator
+    /// side), recording the send instant for the logon timeout.
     #[must_use]
     pub fn send_logon(self) -> Session<LogonSent> {
-        Session {
-            session_id: self.session_id,
-            _state: PhantomData,
-        }
+        self.transition(LogonSent {
+            sent_at: Instant::now(),
+        })
     }
 
     /// Transitions to the LogonReceived state when a Logon arrives from
-    /// the counterparty (acceptor side).
+    /// the counterparty (acceptor side), recording the arrival instant.
     #[must_use]
     pub fn on_logon_received(self) -> Session<LogonReceived> {
-        Session {
-            session_id: self.session_id,
-            _state: PhantomData,
-        }
+        self.transition(LogonReceived {
+            received_at: Instant::now(),
+        })
     }
 
     /// Transitions back to Disconnected on connection failure.
     #[must_use]
     pub fn disconnect(self) -> Session<Disconnected> {
-        Session {
-            session_id: self.session_id,
-            _state: PhantomData,
-        }
+        self.transition(Disconnected)
     }
 }
 
 impl Session<LogonSent> {
+    /// Returns when the Logon was sent, for the `logon_timeout`.
+    #[must_use]
+    pub const fn sent_at(&self) -> Instant {
+        self.state.sent_at
+    }
+
     /// Transitions to Active state on successful Logon acknowledgement.
     #[must_use]
     pub fn on_logon_ack(self) -> Session<Active> {
-        Session {
-            session_id: self.session_id,
-            _state: PhantomData,
-        }
+        self.transition(Active)
     }
 
     /// Transitions to Disconnected on Logon rejection or timeout.
     #[must_use]
     pub fn on_logon_reject(self) -> Session<Disconnected> {
-        Session {
-            session_id: self.session_id,
-            _state: PhantomData,
-        }
+        self.transition(Disconnected)
     }
 }
 
 impl Session<LogonReceived> {
+    /// Returns when the counterparty's Logon arrived, for the authentication
+    /// deadline.
+    #[must_use]
+    pub const fn received_at(&self) -> Instant {
+        self.state.received_at
+    }
+
     /// Transitions to Active after successful authentication, once the
     /// Logon acknowledgement has been sent back to the counterparty.
     #[must_use]
     pub fn accept_logon(self) -> Session<Active> {
-        Session {
-            session_id: self.session_id,
-            _state: PhantomData,
-        }
+        self.transition(Active)
     }
 
     /// Transitions to Disconnected when authentication fails and the
     /// Logon is rejected (Logout/Reject sent, connection dropped).
     #[must_use]
     pub fn reject_logon(self) -> Session<Disconnected> {
-        Session {
-            session_id: self.session_id,
-            _state: PhantomData,
-        }
+        self.transition(Disconnected)
     }
 
     /// Transitions to Disconnected when authentication does not complete
     /// within the allowed time.
     #[must_use]
     pub fn on_timeout(self) -> Session<Disconnected> {
-        Session {
-            session_id: self.session_id,
-            _state: PhantomData,
-        }
+        self.transition(Disconnected)
     }
 }
 
 impl Session<Active> {
-    /// Transitions to Resending state when a gap is detected.
+    /// Transitions to Resending state when a gap is detected, carrying the
+    /// range the resend covers.
     ///
     /// # Arguments
-    /// * `begin_seq` - Begin sequence number of the gap
-    /// * `end_seq` - End sequence number of the gap
+    /// * `begin_seq` - `BeginSeqNo` (7) of the gap
+    /// * `end_seq` - `EndSeqNo` (16) of the gap; `0` means "through the last
+    ///   message sent", the FIX convention
     #[must_use]
-    pub fn start_resend(self, _begin_seq: u64, _end_seq: u64) -> Session<Resending> {
-        Session {
-            session_id: self.session_id,
-            _state: PhantomData,
-        }
+    pub fn start_resend(self, begin_seq: u64, end_seq: u64) -> Session<Resending> {
+        self.transition(Resending { begin_seq, end_seq })
     }
 
-    /// Transitions to LogoutPending state.
+    /// Transitions to LogoutPending state, recording the send instant for the
+    /// logout timeout.
     #[must_use]
     pub fn initiate_logout(self) -> Session<LogoutPending> {
-        Session {
-            session_id: self.session_id,
-            _state: PhantomData,
-        }
+        self.transition(LogoutPending {
+            sent_at: Instant::now(),
+        })
     }
 
     /// Transitions to Disconnected on unexpected disconnect.
     #[must_use]
     pub fn disconnect(self) -> Session<Disconnected> {
-        Session {
-            session_id: self.session_id,
-            _state: PhantomData,
-        }
+        self.transition(Disconnected)
     }
 }
 
 impl Session<Resending> {
+    /// Returns `BeginSeqNo` (7) of the range being resent.
+    #[must_use]
+    pub const fn begin_seq(&self) -> u64 {
+        self.state.begin_seq
+    }
+
+    /// Returns `EndSeqNo` (16) of the range being resent; `0` means "through
+    /// the last message sent".
+    #[must_use]
+    pub const fn end_seq(&self) -> u64 {
+        self.state.end_seq
+    }
+
     /// Transitions back to Active when resend is complete.
     #[must_use]
     pub fn resend_complete(self) -> Session<Active> {
-        Session {
-            session_id: self.session_id,
-            _state: PhantomData,
-        }
+        self.transition(Active)
     }
 
     /// Transitions to Disconnected on error.
     #[must_use]
     pub fn disconnect(self) -> Session<Disconnected> {
-        Session {
-            session_id: self.session_id,
-            _state: PhantomData,
-        }
+        self.transition(Disconnected)
     }
 }
 
 impl Session<LogoutPending> {
+    /// Returns when the Logout was sent, for the `logout_timeout`.
+    #[must_use]
+    pub const fn sent_at(&self) -> Instant {
+        self.state.sent_at
+    }
+
     /// Transitions to Disconnected on Logout acknowledgement or timeout.
     #[must_use]
     pub fn on_logout_ack(self) -> Session<Disconnected> {
-        Session {
-            session_id: self.session_id,
-            _state: PhantomData,
-        }
+        self.transition(Disconnected)
     }
 
     /// Transitions to Disconnected on timeout.
     #[must_use]
     pub fn on_timeout(self) -> Session<Disconnected> {
-        Session {
-            session_id: self.session_id,
-            _state: PhantomData,
-        }
+        self.transition(Disconnected)
     }
 }
 
@@ -345,5 +368,99 @@ mod tests {
 
         let session = session.start_resend(1, 5);
         let _session = session.resend_complete();
+    }
+
+    // --- States carry their data --------------------------------------------
+
+    #[test]
+    fn test_send_logon_records_the_send_instant() {
+        let before = Instant::now();
+        let session = Session::<Disconnected>::new("TEST").connect().send_logon();
+        let after = Instant::now();
+
+        assert!(session.sent_at() >= before);
+        assert!(session.sent_at() <= after);
+        assert_eq!(session.state().sent_at, session.sent_at());
+    }
+
+    #[test]
+    fn test_on_logon_received_records_the_arrival_instant() {
+        let before = Instant::now();
+        let session = Session::<Disconnected>::new("ACCEPTOR")
+            .accept()
+            .on_logon_received();
+        let after = Instant::now();
+
+        assert!(session.received_at() >= before);
+        assert!(session.received_at() <= after);
+    }
+
+    #[test]
+    fn test_initiate_logout_records_the_send_instant() {
+        let before = Instant::now();
+        let session = Session::<Disconnected>::new("TEST")
+            .connect()
+            .send_logon()
+            .on_logon_ack()
+            .initiate_logout();
+        let after = Instant::now();
+
+        assert!(session.sent_at() >= before);
+        assert!(session.sent_at() <= after);
+    }
+
+    #[test]
+    fn test_start_resend_keeps_the_requested_range() {
+        let session = Session::<Disconnected>::new("TEST")
+            .connect()
+            .send_logon()
+            .on_logon_ack()
+            .start_resend(7, 16);
+
+        assert_eq!(session.begin_seq(), 7);
+        assert_eq!(session.end_seq(), 16);
+        assert_eq!(session.state().begin_seq, 7);
+    }
+
+    #[test]
+    fn test_start_resend_keeps_the_open_ended_range() {
+        // EndSeqNo (16) = 0 is the FIX "through the last message" convention
+        // and must survive the transition unchanged.
+        let session = Session::<Disconnected>::new("TEST")
+            .connect()
+            .send_logon()
+            .on_logon_ack()
+            .start_resend(42, 0);
+
+        assert_eq!(session.begin_seq(), 42);
+        assert_eq!(session.end_seq(), 0);
+    }
+
+    #[test]
+    fn test_session_id_survives_every_transition() {
+        let session = Session::<Disconnected>::new("PERSISTENT")
+            .connect()
+            .send_logon()
+            .on_logon_ack();
+        assert_eq!(session.session_id(), "PERSISTENT");
+
+        let session = session.start_resend(1, 2).resend_complete();
+        assert_eq!(session.session_id(), "PERSISTENT");
+
+        let session = session.initiate_logout();
+        assert_eq!(session.session_id(), "PERSISTENT");
+
+        let session = session.on_logout_ack();
+        assert_eq!(session.session_id(), "PERSISTENT");
+    }
+
+    #[test]
+    fn test_stateless_states_stay_zero_sized() {
+        use std::mem::size_of;
+
+        assert_eq!(size_of::<Disconnected>(), 0);
+        assert_eq!(size_of::<Connecting>(), 0);
+        assert_eq!(size_of::<Active>(), 0);
+        assert_eq!(size_of::<Session<Active>>(), size_of::<String>());
     }
 }


### PR DESCRIPTION
## Summary

Makes session configuration validate rather than panic, and stops a sub-second heartbeat from silently meaning "no heartbeat".

Closes #17.

## Stack

- **Base branch:** `stack/10-heartbeat` (PR #37)

## What was wrong

**`SessionConfigBuilder` panicked via `expect()` and validated nothing.** A library that panics on bad configuration is a hard rule violation here, and under `panic = "abort"` it takes the caller's process with it. Every knob now has a typed field with a default, a documented unit and range, validation at `build()`, and a test for its invalid path — the convention this repository states for adding a knob, applied to the knobs that were already there.

**A sub-second heartbeat interval truncated to zero.** Tag 108 is whole seconds and the conversion floored, so configuring 500 ms negotiated `HeartBtInt = 0`.

That was already wrong. It became **worse** during this stack: PR #37 makes `HeartBtInt = 0` mean "heartbeating disabled", as FIX intends — so the truncation turned a request for a fast heartbeat into a request for no heartbeat at all, silently. It is explicit now rather than truncating.

**The typestate carried dead data** — fields no state read — and the setter surface had drifted from its own documentation.

## Public API changes (semver)

`build()` is fallible, which ripples mechanically into `ironfix-engine` and one example. Workspace is at 0.4.0, which covers it.

## Tests

Workspace goes to **475 passing**, with a test per invalid path rather than only per valid one.

## Verification

```
cargo test --workspace                                    # 475 passed
cargo clippy --all-targets --all-features -- -D warnings  # clean
cargo fmt --all --check                                   # clean
make doc                                                  # clean
```
No `.unwrap()` or `.expect()` remains in the crate's production code.
