### PR TITLE
feat(store): replay messages from the store instead of gap-filling everything

### DIFF
--- a/doc/fix_operations.md
+++ b/doc/fix_operations.md
@@ -278,12 +278,14 @@ sent and **nothing at all** arrived in the interval that followed.
 
 **What IronFix implements today**
 
-`ironfix-engine` **does not use a message store for replay**: although it
-declares `ironfix-store` in its `Cargo.toml`, no store is wired into the session
-path, so mandate items 1, 2 and 4 above are **not implemented** and the engine
-cannot replay a single stored message. What it does is answer the whole
-requested range with one SequenceReset-GapFill (item 3, generalized to every
-message type):
+All four mandate items are implemented, **provided a message store is attached**
+with `Initiator::with_store(Arc<dyn MessageStore>)`. Every sequenced outbound
+frame is then filed in the store under its `MsgSeqNum`, before it goes on the
+wire, and is available to be replayed. Without a store there is nothing to
+replay and the engine falls back to answering the whole range with one gap fill
+(see "Without a store" below).
+
+*Validation, identical in both modes:*
 
 - `BeginSeqNo` (7) absent or unparseable → session Reject, reason 1 (required
   tag missing), `RefTagID` = 7. There is deliberately **no** default value;
@@ -296,21 +298,60 @@ message type):
   have not sent.
 - `EndSeqNo` below `BeginSeqNo` (and not 0) → session Reject, reason 5,
   `RefTagID` = 16.
-- Otherwise the reply is `SequenceReset`-GapFill with `MsgSeqNum` = BeginSeqNo
-  and `NewSeqNo` = min(EndSeqNo + 1, next outbound sequence), or the next
-  outbound sequence when `EndSeqNo` = 0 (infinity). A bounded request therefore
-  never advances the counterparty past what it asked for.
 
-The GapFill carries `PossDupFlag` (43) = Y and `OrigSendingTime` (122). Absent
-a store there is no recorded original sending time, so 122 is stamped with the
-same value as `SendingTime` (52), which is the FIX handling for an unavailable
-OrigSendingTime. A GapFill's "original" messages are administrative filler
-rather than replayed traffic, so no information is lost by this.
+*The reply range.* The reply always covers exactly
+`BeginSeqNo .. NewSeqNo`, where `NewSeqNo` = min(EndSeqNo + 1, next outbound
+sequence), or the next outbound sequence when `EndSeqNo` = 0 (infinity). A
+bounded request therefore never advances the counterparty past what it asked
+for, and every sequence number inside the range is accounted for by either a
+replayed message or a gap fill — never skipped.
 
-Consequence for consumers: **application messages are never replayed.** A
-counterparty that requests a resend of business traffic receives a gap fill,
-not the traffic. Real replay requires wiring a `MessageStore` into the engine,
-which is separate, tracked work.
+*What is replayed.* An **application** message that is present in the store and
+can be rebuilt is resent with:
+
+- its **original `MsgSeqNum` (34)** — a resend re-occupies the number it was
+  first sent under, and allocates no new one;
+- its original body, field for field, in its original order;
+- `PossDupFlag` (43) = Y (mandate item 2);
+- `OrigSendingTime` (122) = the `SendingTime` (52) recorded on the original
+  frame, while 52 is restamped with the time of this retransmission (mandate
+  item 4);
+- `BodyLength` (9) and `CheckSum` (10) recomputed, since 43 and 122 change both.
+
+*What is gap-filled.* Everything else in the range is covered by
+`SequenceReset`-GapFill messages interleaved between the replayed messages,
+each carrying `MsgSeqNum` = the first number it covers, `GapFillFlag` (123) = Y,
+`NewSeqNo` (36) = the first number it does **not** cover, and `PossDupFlag`
+(43) = Y with `OrigSendingTime` (122). Specifically:
+
+- **administrative messages** in the range (mandate item 3) — a stale Heartbeat
+  or Logon says nothing true about the session now;
+- **sequence numbers the store never held or has evicted**;
+- **stored frames that cannot be rebuilt** — a frame that does not decode, or
+  that carries no `SendingTime` (52) to copy into `OrigSendingTime` and so
+  cannot be resent conformantly;
+- **the whole range**, if the store itself returns an error.
+
+A gap fill allocates no sender sequence number either: it occupies the range it
+replaces. So answering a resend never moves the session's own outbound
+numbering, whatever mix of replay and fill the reply turns out to be.
+
+A GapFill's "original" messages are administrative filler that was never sent,
+so there is no recorded original sending time for it and 122 is stamped with
+the same value as `SendingTime` (52) — the FIX handling for an unavailable
+OrigSendingTime. That substitution applies to gap fills only; a genuine replay
+always carries the real original time.
+
+**Without a store**, mandate items 1, 2 and 4 cannot be satisfied — the engine
+has nothing to replay from — and the whole requested range is answered with a
+single `SequenceReset`-GapFill with `MsgSeqNum` = BeginSeqNo and `NewSeqNo` as
+above. A counterparty asking for business traffic then receives a gap fill
+rather than the traffic.
+
+**Restart caveat.** `MemoryStore` is the only `MessageStore` implementation and
+is not persistent: it holds messages and sequence numbers in process memory
+only. Replay therefore works within a live process, but no message and no
+sequence number survives a restart. A durable store is separate, tracked work.
 
 **Outbound `EndSeqNo` sentinel — a version caveat.** When the engine detects an
 inbound gap it requests retransmission with `EndSeqNo` (16) = 0, the open-ended
@@ -941,9 +982,14 @@ Rationale for the two policies:
   `ironfix-engine`, so the server-side examples do their own heartbeating.
 - [x] Reject
 - [x] Sequence Reset
-- [ ] Resend Request — **partial**: inbound requests are validated and answered
-  with a correctly bounded SequenceReset-GapFill, but the engine has no message
-  store, so no message is ever actually replayed. See "Resend Request" above.
+- [x] Resend Request — inbound requests are validated, and with a
+  `MessageStore` attached (`Initiator::with_store`) the stored application
+  messages in the range are replayed with `PossDupFlag` (43) = Y and the
+  original `SendingTime` in `OrigSendingTime` (122), with administrative
+  messages and unavailable sequence numbers gap-filled. Two limits are worth
+  stating: the store is **opt-in**, and without one the whole range is still
+  answered with a single gap fill; and `MemoryStore` is not persistent, so
+  nothing is replayable after a restart. See "Resend Request" above.
 
 ### Phase 2: Order Entry (High Priority)
 - [ ] New Order Single

--- a/ironfix-core/src/error.rs
+++ b/ironfix-core/src/error.rs
@@ -9,7 +9,6 @@
 //! This module provides a unified error hierarchy using `thiserror` for typed,
 //! domain-specific errors across all IronFix operations.
 
-use std::ops::Range;
 use thiserror::Error;
 
 /// Result type alias using [`FixError`] as the error type.
@@ -293,11 +292,34 @@ pub enum StoreError {
         seq_num: u64,
     },
 
-    /// Range of messages not available.
-    #[error("messages not available for range: {range:?}")]
+    /// No message is available anywhere in the requested range.
+    ///
+    /// The bounds are **inclusive**, which is how a FIX `ResendRequest`
+    /// expresses them. A half-open `Range<u64>` cannot represent an upper
+    /// bound of `u64::MAX` — the "to infinity" case a `ResendRequest` with
+    /// `EndSeqNo` (16) = 0 asks for — without an `end + 1` that overflows, so
+    /// the bounds are carried as two numbers and no arithmetic is performed on
+    /// them.
+    #[error("messages not available for range: {begin}..={end}")]
     RangeNotAvailable {
-        /// The requested range of sequence numbers.
-        range: Range<u64>,
+        /// First requested sequence number, inclusive.
+        begin: u64,
+        /// Last requested sequence number, inclusive.
+        end: u64,
+    },
+
+    /// The requested range is inverted: `begin` is above `end`.
+    ///
+    /// This is a caller error, not an empty result. It is reported rather than
+    /// normalised because a store cannot tell an inverted range apart from a
+    /// range that happens to hold nothing, and silently answering "empty"
+    /// hides the bug that produced it.
+    #[error("invalid range: begin {begin} is above end {end}")]
+    InvalidRange {
+        /// First requested sequence number, inclusive.
+        begin: u64,
+        /// Last requested sequence number, inclusive.
+        end: u64,
     },
 
     /// Store is corrupted.

--- a/ironfix-engine/src/error.rs
+++ b/ironfix-engine/src/error.rs
@@ -6,7 +6,7 @@
 
 //! Engine error types.
 
-use ironfix_core::error::{DecodeError, EncodeError};
+use ironfix_core::error::{DecodeError, EncodeError, StoreError};
 use ironfix_session::config::SessionConfigError;
 use ironfix_session::sequence::{SequenceCounter, SequenceExhausted};
 use ironfix_transport::CodecError;
@@ -141,6 +141,17 @@ pub enum EngineError {
         /// Why it cannot be framed.
         detail: String,
     },
+
+    /// A message-store operation the session depends on failed during setup.
+    ///
+    /// Raised by [`Initiator::connect`](crate::Initiator::connect) when the
+    /// store cannot be reset for a `ResetSeqNumFlag` (141) Logon, or refreshed to
+    /// recover its counters, before the session starts. Continuing anyway would
+    /// either file a new stream on top of a previous one's numbers or reuse a
+    /// `MsgSeqNum` the counterparty has already seen, so the session is refused
+    /// rather than started from a counter the store could not vouch for.
+    #[error("store error: {0}")]
+    Store(#[from] StoreError),
 
     /// The connection is closed; no more messages can be sent.
     #[error("connection closed")]

--- a/ironfix-engine/src/initiator.rs
+++ b/ironfix-engine/src/initiator.rs
@@ -44,10 +44,21 @@
 //! Sequence recovery follows `doc/fix_operations.md`: a `SequenceReset` with
 //! `GapFillFlag` (123) = Y is an ordinary sequenced message and is validated
 //! against its own `MsgSeqNum`, while Reset mode alone may ignore it; an
-//! inbound `ResendRequest` is answered with a `SequenceReset`-GapFill bounded
-//! by `EndSeqNo`. **The engine does not use a message store for replay, so no
-//! message is ever actually replayed** — a resend request is always answered
-//! with a gap fill.
+//! inbound `ResendRequest` is answered within the bound set by `EndSeqNo`.
+//!
+//! # Resend and the message store
+//!
+//! [`Initiator::with_store`] attaches a [`MessageStore`]. Every sequenced
+//! outbound frame is then filed under its `MsgSeqNum` before it goes on the
+//! wire, and an inbound `ResendRequest` replays the stored application
+//! messages with `PossDupFlag` (43) = Y and their original `SendingTime` in
+//! `OrigSendingTime` (122). Administrative messages in the range, and any
+//! sequence number the store cannot produce, are covered by
+//! `SequenceReset`-GapFill, so the counterparty's expectation always lands
+//! exactly where the request asked it to.
+//!
+//! **Without a store nothing can be replayed** and the whole requested range
+//! is answered with one gap fill.
 //!
 //! All sequence arithmetic goes through the checked
 //! [`SequenceManager::try_allocate_sender_seq`] /
@@ -99,6 +110,7 @@ use ironfix_session::{
     Active, Disconnected, HeartbeatManager, LogoutPending, SequenceManager, Session, SessionConfig,
     TestRequestOutcome,
 };
+use ironfix_store::MessageStore;
 use ironfix_transport::FixCodec;
 use std::num::NonZeroU64;
 use std::sync::{Arc, Mutex};
@@ -117,12 +129,20 @@ const DEFAULT_OUTBOUND_CAPACITY: usize = 1024;
 /// Reactor tick granularity for heartbeat/timeout checks.
 const TICK_INTERVAL: Duration = Duration::from_millis(100);
 
+/// Number of stored messages a resend reads from the store per page.
+///
+/// A `ResendRequest` with `EndSeqNo` (16) = 0 asks for the whole session, so the
+/// replay reads in bounded batches and yields between them rather than
+/// allocating and locking over the entire history at once. The value trades the
+/// per-page allocation ceiling against how often the reactor yields; a few
+/// hundred frames keeps both modest.
+const RESEND_PAGE_LIMIT: usize = 256;
+
 /// Client-side FIX engine.
 ///
 /// Owns the session configuration and the [`Application`] callbacks. Each
 /// call to [`Initiator::connect`] establishes one live session and returns
 /// a [`Connection`] handle for it.
-#[derive(Debug)]
 pub struct Initiator<A: Application = NoOpApplication> {
     /// Session configuration.
     config: SessionConfig,
@@ -143,6 +163,25 @@ pub struct Initiator<A: Application = NoOpApplication> {
     initial_sequences: Option<(u64, u64)>,
     /// Capacity of the outbound command queue.
     outbound_capacity: usize,
+    /// Optional message store: outbound frames are filed here and replayed
+    /// from here when the counterparty asks for a resend.
+    store: Option<Arc<dyn MessageStore>>,
+}
+
+/// Written by hand rather than derived: `dyn MessageStore` is not `Debug`, and
+/// requiring it of every implementation to print one field is the wrong trade.
+impl<A: Application> std::fmt::Debug for Initiator<A> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Initiator")
+            .field("config", &self.config)
+            .field("session_id", &self.session_id)
+            .field("version", &self.version)
+            .field("connect_timeout", &self.connect_timeout)
+            .field("initial_sequences", &self.initial_sequences)
+            .field("outbound_capacity", &self.outbound_capacity)
+            .field("store", &self.store.is_some())
+            .finish_non_exhaustive()
+    }
 }
 
 impl<A: Application + 'static> Initiator<A> {
@@ -181,7 +220,34 @@ impl<A: Application + 'static> Initiator<A> {
             connect_timeout: Duration::from_secs(30),
             initial_sequences: None,
             outbound_capacity: DEFAULT_OUTBOUND_CAPACITY,
+            store: None,
         }
+    }
+
+    /// Attaches a message store to the session.
+    ///
+    /// With a store the engine files every sequenced outbound frame under its
+    /// `MsgSeqNum` and, on an inbound `ResendRequest` (35=2), replays the
+    /// stored **application** messages with `PossDupFlag` (43) = Y and the
+    /// original `SendingTime` in `OrigSendingTime` (122). Administrative
+    /// messages, and any sequence number the store cannot produce, are covered
+    /// by `SequenceReset`-GapFill instead — see
+    /// [`Initiator::connect`](Initiator::connect) and
+    /// `doc/fix_operations.md`, "Resend Request".
+    ///
+    /// Without a store the engine has nothing to replay and answers the whole
+    /// requested range with one gap fill.
+    ///
+    /// The store also carries sequence numbers: unless `reset_on_logon` is set
+    /// or [`Initiator::with_initial_sequences`] is called, the session starts
+    /// from the counters the store reports, and both counters are mirrored back
+    /// into it as the session runs. Note that
+    /// [`MemoryStore`](ironfix_store::MemoryStore) is the only implementation
+    /// today and is **not** persistent, so this does not yet survive a restart.
+    #[must_use]
+    pub fn with_store(mut self, store: Arc<dyn MessageStore>) -> Self {
+        self.store = Some(store);
+        self
     }
 
     /// Sets the TCP connect timeout (default 30s).
@@ -215,6 +281,71 @@ impl<A: Application + 'static> Initiator<A> {
     pub fn with_outbound_capacity(mut self, capacity: usize) -> Self {
         self.outbound_capacity = capacity.max(1);
         self
+    }
+
+    /// Decides the sequence numbers this session starts from.
+    ///
+    /// Priority, highest first:
+    ///
+    /// 1. `reset_on_logon` — the Logon declares `ResetSeqNumFlag` (141) = Y, so
+    ///    both counters start at 1 and the store is cleared. Keeping the old
+    ///    messages would leave two different streams filed under the same
+    ///    numbers, and a later `ResendRequest` could not tell them apart.
+    /// 2. [`Initiator::with_initial_sequences`] — an explicit instruction from
+    ///    the consumer outranks whatever the store remembers.
+    /// 3. The store's own counters, refreshed from its backing medium first.
+    /// 4. A fresh session at 1/1.
+    ///
+    /// # Errors
+    /// Returns [`EngineError::Store`] if the store cannot be reset (case 1) or
+    /// refreshed (case 3). Both are fatal for the handshake: starting at 1 with
+    /// the previous stream still filed would let a later `ResendRequest` replay
+    /// it, and starting against un-refreshed counters would reuse a `MsgSeqNum`
+    /// the counterparty has already seen. The session is refused rather than
+    /// silently started from a counter the store could not vouch for.
+    async fn seed_sequences(&self) -> Result<SequenceManager, EngineError> {
+        if self.config.reset_on_logon {
+            if let Some(store) = &self.store
+                && let Err(err) = store.reset().await
+            {
+                tracing::error!(
+                    session = %self.session_id,
+                    error = %err,
+                    "cannot reset the store for a ResetSeqNumFlag logon: refusing the session \
+                     rather than starting at 1 with the previous stream still filed"
+                );
+                return Err(EngineError::Store(err));
+            }
+            return Ok(SequenceManager::new());
+        }
+
+        if let Some((sender, target)) = self.initial_sequences {
+            // A zero seed is refused before dialling, so both are non-zero here;
+            // the floor keeps the conversion total.
+            return Ok(SequenceManager::with_initial(
+                NonZeroU64::new(sender).unwrap_or(NonZeroU64::MIN),
+                NonZeroU64::new(target).unwrap_or(NonZeroU64::MIN),
+            ));
+        }
+
+        let Some(store) = &self.store else {
+            return Ok(SequenceManager::new());
+        };
+        if let Err(err) = store.refresh().await {
+            tracing::error!(
+                session = %self.session_id,
+                error = %err,
+                "cannot refresh the store: refusing the session rather than starting against \
+                 unknown counters and risking a reused MsgSeqNum"
+            );
+            return Err(EngineError::Store(err));
+        }
+        // MsgSeqNum starts at 1, so a store reporting 0 is reporting a number
+        // that names no message. Floor it rather than number a message 0.
+        Ok(SequenceManager::with_initial(
+            NonZeroU64::new(store.next_sender_seq().max(1)).unwrap_or(NonZeroU64::MIN),
+            NonZeroU64::new(store.next_target_seq().max(1)).unwrap_or(NonZeroU64::MIN),
+        ))
     }
 
     /// Returns the session configuration.
@@ -277,21 +408,19 @@ impl<A: Application + 'static> Initiator<A> {
         // Refuse before dialling: a seeded sequence number of zero would put
         // MsgSeqNum (34) = 0 on the wire, which every conforming counterparty
         // rejects. The seed is ignored entirely when reset_on_logon is set, so
-        // a zero is only refused when it would actually be used.
-        let initial_sequences = match self.initial_sequences {
-            Some((sender, target)) if !self.config.reset_on_logon => {
-                let sender =
-                    NonZeroU64::new(sender).ok_or(EngineError::InvalidInitialSequence {
-                        counter: SequenceCounter::Sender,
-                    })?;
-                let target =
-                    NonZeroU64::new(target).ok_or(EngineError::InvalidInitialSequence {
-                        counter: SequenceCounter::Target,
-                    })?;
-                Some((sender, target))
-            }
-            _ => None,
-        };
+        // a zero is only refused when it would actually be used. The validated
+        // seed is applied by `seed_sequences`, which reads the same field; this
+        // is only the guard.
+        if let Some((sender, target)) = self.initial_sequences
+            && !self.config.reset_on_logon
+        {
+            NonZeroU64::new(sender).ok_or(EngineError::InvalidInitialSequence {
+                counter: SequenceCounter::Sender,
+            })?;
+            NonZeroU64::new(target).ok_or(EngineError::InvalidInitialSequence {
+                counter: SequenceCounter::Target,
+            })?;
+        }
 
         let session_id = self.session_id.clone();
         self.application.on_create(&session_id).await;
@@ -317,9 +446,16 @@ impl<A: Application + 'static> Initiator<A> {
             .with_checksum_validation(self.config.validate_checksum);
         let mut framed = Framed::new(stream, codec);
 
-        let sequences = match initial_sequences {
-            Some((sender, target)) => SequenceManager::with_initial(sender, target),
-            None => SequenceManager::new(),
+        // Seeding fails closed: a store that cannot be reset or refreshed leaves
+        // the session unable to vouch for its own counters, so it is refused
+        // here rather than started from a number that could collide with a
+        // stream still on file.
+        let sequences = match self.seed_sequences().await {
+            Ok(sequences) => sequences,
+            Err(err) => {
+                let _ = session.disconnect();
+                return Err(err);
+            }
         };
         let runtime = Arc::new(SessionRuntime {
             sequences,
@@ -336,6 +472,10 @@ impl<A: Application + 'static> Initiator<A> {
                 return Err(err.into());
             }
         };
+        // Mirror the advanced sender counter into the store before the Logon —
+        // the first numbered frame of the session — reaches the wire, so a store
+        // reused across a reconnect cannot report a number the peer has seen.
+        mirror_sender_seq(self.store.as_ref(), &runtime.sequences);
         let logon = factory.logon(
             seq,
             self.config.heartbeat_interval_secs(),
@@ -344,6 +484,14 @@ impl<A: Application + 'static> Initiator<A> {
         if let Ok(mut owned) = wire::owned_from_frame(&logon) {
             self.application.to_admin(&mut owned, &session_id).await;
         }
+        persist_outbound(
+            self.store.as_ref(),
+            &session_id,
+            seq,
+            &MsgType::Logon,
+            &logon,
+        )
+        .await;
         framed.send(logon).await?;
         lock_heartbeat(&runtime).on_message_sent();
         let session = session.send_logon();
@@ -425,11 +573,13 @@ impl<A: Application + 'static> Initiator<A> {
                         &reason,
                     )
                 {
+                    mirror_sender_seq(self.store.as_ref(), &runtime.sequences);
                     let _ = framed.send(reject).await;
                 }
                 if let Ok(out_seq) = runtime.sequences.try_allocate_sender_seq()
                     && let Ok(logout) = factory.logout(out_seq.value(), Some(&detail))
                 {
+                    mirror_sender_seq(self.store.as_ref(), &runtime.sequences);
                     let _ = framed.send(logout).await;
                 }
                 let _ = session.on_logon_reject();
@@ -440,6 +590,7 @@ impl<A: Application + 'static> Initiator<A> {
                 match runtime.sequences.try_allocate_sender_seq() {
                     Ok(seq) => match factory.logout(seq.value(), Some(&reason.text)) {
                         Ok(logout) => {
+                            mirror_sender_seq(self.store.as_ref(), &runtime.sequences);
                             let _ = framed.send(logout).await;
                         }
                         Err(err) => tracing::warn!(
@@ -597,10 +748,19 @@ impl<A: Application + 'static> Initiator<A> {
         // A gap in the Logon ack means we missed messages: request a resend.
         if let Some(expected) = pending_resend {
             let seq = runtime.sequences.try_allocate_sender_seq()?.value();
+            mirror_sender_seq(self.store.as_ref(), &runtime.sequences);
             let frame = factory.resend_request(seq, expected, 0)?;
             if let Ok(mut owned) = wire::owned_from_frame(&frame) {
                 self.application.to_admin(&mut owned, &session_id).await;
             }
+            persist_outbound(
+                self.store.as_ref(),
+                &session_id,
+                seq,
+                &MsgType::ResendRequest,
+                &frame,
+            )
+            .await;
             framed.send(frame).await?;
             lock_heartbeat(&runtime).on_message_sent();
         }
@@ -615,8 +775,10 @@ impl<A: Application + 'static> Initiator<A> {
             config: self.config.clone(),
             application: Arc::clone(&self.application),
             session_id: session_id.clone(),
+            store: self.store.clone(),
             pending_resend,
         };
+        reactor.sync_sequences();
         tokio::spawn(run_reactor(framed, command_rx, closed_tx, reactor, session));
 
         Ok(Connection {
@@ -625,6 +787,53 @@ impl<A: Application + 'static> Initiator<A> {
             closed: closed_rx,
             runtime,
         })
+    }
+}
+
+/// Mirrors the sender sequence counter into the store, if one is attached.
+///
+/// The reactor mirrors both counters after every event through
+/// [`Reactor::sync_sequences`], but the reactor does not exist yet during the
+/// Logon handshake. This closes the window: it is called after each handshake
+/// frame is numbered, before that frame reaches the wire, so a store reused
+/// across a reconnect never reports a sender counter behind a `MsgSeqNum` the
+/// counterparty has already seen — which would reuse that number on the next
+/// session. Only the sender counter is mirrored; the target counter advances
+/// only once an inbound message is accepted, which the reactor then mirrors.
+fn mirror_sender_seq(store: Option<&Arc<dyn MessageStore>>, sequences: &SequenceManager) {
+    if let Some(store) = store {
+        store.set_next_sender_seq(sequences.next_sender_seq().value());
+    }
+}
+
+/// Files one outbound frame under the sequence number it was sent with.
+///
+/// A store failure is logged and the session continues: a message that could
+/// not be filed simply cannot be replayed, and the resend path already covers
+/// an unavailable sequence number with a gap fill. Tearing a healthy session
+/// down over it would be a worse outcome than a gap fill.
+///
+/// The frame body is **never** logged. A Logon carries `Password` (554) and
+/// `NewPassword` (925), and any message may carry `RawData` (96); the log line
+/// names the sequence number and the message type only.
+async fn persist_outbound(
+    store: Option<&Arc<dyn MessageStore>>,
+    session_id: &SessionId,
+    seq: u64,
+    msg_type: &MsgType,
+    frame: &[u8],
+) {
+    let Some(store) = store else {
+        return;
+    };
+    if let Err(err) = store.store(seq, msg_type, frame).await {
+        tracing::warn!(
+            session = %session_id,
+            seq,
+            msg_type = msg_type.as_str(),
+            error = %err,
+            "cannot store outbound message: a resend of it will be gap-filled"
+        );
     }
 }
 
@@ -703,6 +912,8 @@ struct Reactor<A: Application> {
     application: Arc<A>,
     /// Session identifier.
     session_id: SessionId,
+    /// Optional message store for outbound frames and resend replay.
+    store: Option<Arc<dyn MessageStore>>,
     /// Expected sequence number a pending ResendRequest was issued for.
     ///
     /// The logout deadline is *not* tracked here: `Session<LogoutPending>`
@@ -758,11 +969,27 @@ async fn run_reactor<A: Application + 'static>(
             Ok(next) => phase = Some(next),
             Err(outcome) => break outcome,
         }
+        // One place, after every handled event, so no path can advance a
+        // counter without the store seeing it.
+        ctx.sync_sequences();
     };
 
     if ctx.config.reset_on_disconnect || (outcome.graceful && ctx.config.reset_on_logout) {
         ctx.runtime.sequences.reset();
+        // The stored messages go with the counters. Leaving them behind would
+        // file the next session's messages on top of this one's, and a resend
+        // request in that session could answer with traffic from this one.
+        if let Some(store) = &ctx.store
+            && let Err(err) = store.reset().await
+        {
+            tracing::warn!(
+                session = %ctx.session_id,
+                error = %err,
+                "cannot clear the store after a session-closing sequence reset"
+            );
+        }
     }
+    ctx.sync_sequences();
     ctx.application.on_logout(&ctx.session_id).await;
     let _ = closed_tx.send(true);
     if outcome.graceful {
@@ -773,21 +1000,75 @@ async fn run_reactor<A: Application + 'static>(
 }
 
 impl<A: Application> Reactor<A> {
+    /// Mirrors both sequence counters into the store.
+    ///
+    /// The counters are the store's other job: they are what lets a later
+    /// session pick up where this one stopped. Both trait methods are
+    /// synchronous, so this costs two atomic stores and holds no lock.
+    fn sync_sequences(&self) {
+        let Some(store) = &self.store else {
+            return;
+        };
+        store.set_next_sender_seq(self.runtime.sequences.next_sender_seq().value());
+        store.set_next_target_seq(self.runtime.sequences.next_target_seq().value());
+    }
+
     /// Sends an admin frame, running the `to_admin` callback and updating
     /// heartbeat bookkeeping.
+    ///
+    /// `seq` is the sender sequence number allocated for this frame, and the
+    /// key it is filed under. It is `None` only for a `SequenceReset`-GapFill,
+    /// which allocates no number of its own: it re-occupies the range it
+    /// replaces, and filing it would overwrite a message that is still
+    /// resendable.
+    ///
+    /// The message is filed **before** it is written to the socket. A frame
+    /// stored but never sent is harmless — the counterparty never saw it and so
+    /// never asks for it — whereas a frame sent but never stored is a message
+    /// this session can be asked to replay and cannot produce.
     async fn send_admin(
         &self,
         framed: &mut FixFramed,
+        seq: Option<u64>,
         frame: Result<BytesMut, EncodeError>,
     ) -> Result<(), EngineError> {
         // The frame arrives as the encoder's result so every caller reports an
         // unencodable message through the path it already uses for a failed
         // send, rather than each deciding for itself.
         let frame = frame?;
+        let mut msg_type = None;
         if let Ok(mut owned) = wire::owned_from_frame(&frame) {
+            msg_type = Some(owned.msg_type().clone());
             self.application
                 .to_admin(&mut owned, &self.session_id)
                 .await;
+        }
+        if let (Some(seq), Some(msg_type)) = (seq, msg_type.as_ref()) {
+            self.persist(seq, msg_type, &frame).await;
+        }
+        framed.send(frame).await?;
+        lock_heartbeat(&self.runtime).on_message_sent();
+        Ok(())
+    }
+
+    /// Files one outbound frame in the store, if there is one.
+    async fn persist(&self, seq: u64, msg_type: &MsgType, frame: &[u8]) {
+        persist_outbound(self.store.as_ref(), &self.session_id, seq, msg_type, frame).await;
+    }
+
+    /// Writes an already-built replay frame to the socket.
+    ///
+    /// A replayed message keeps the sequence number and the body it was first
+    /// sent with, so nothing is allocated and nothing is re-filed. `to_app`
+    /// still runs, because from the application's point of view this is another
+    /// transmission of one of its messages.
+    async fn send_replay(
+        &self,
+        framed: &mut FixFramed,
+        frame: BytesMut,
+    ) -> Result<(), EngineError> {
+        if let Ok(mut owned) = wire::owned_from_frame(&frame) {
+            self.application.to_app(&mut owned, &self.session_id).await;
         }
         framed.send(frame).await?;
         lock_heartbeat(&self.runtime).on_message_sent();
@@ -844,6 +1125,10 @@ impl<A: Application> Reactor<A> {
                 if let Ok(mut owned) = wire::owned_from_frame(&frame) {
                     self.application.to_app(&mut owned, &self.session_id).await;
                 }
+                // Filed before it is sent: this is the traffic a ResendRequest
+                // actually asks for, and a message on the wire that was never
+                // stored is one this session can be asked to replay and cannot.
+                self.persist(seq, message.msg_type(), &frame).await;
                 if let Err(err) = framed.send(frame).await {
                     teardown(phase);
                     return Err(closed(format!("send failed: {err}"), false));
@@ -862,7 +1147,7 @@ impl<A: Application> Reactor<A> {
                         }
                     };
                     let frame = self.factory.logout(seq, None);
-                    if let Err(err) = self.send_admin(framed, frame).await {
+                    if let Err(err) = self.send_admin(framed, Some(seq), frame).await {
                         let _ = session.disconnect();
                         return Err(closed(format!("send failed: {err}"), false));
                     }
@@ -913,7 +1198,7 @@ impl<A: Application> Reactor<A> {
                 Err(err) => return Err(exhausted(phase, err)),
             };
             let frame = self.factory.test_request(seq, &test_req_id);
-            if let Err(err) = self.send_admin(framed, frame).await {
+            if let Err(err) = self.send_admin(framed, Some(seq), frame).await {
                 teardown(phase);
                 return Err(closed(format!("send failed: {err}"), false));
             }
@@ -924,7 +1209,7 @@ impl<A: Application> Reactor<A> {
                 Err(err) => return Err(exhausted(phase, err)),
             };
             let frame = self.factory.heartbeat(seq, None);
-            if let Err(err) = self.send_admin(framed, frame).await {
+            if let Err(err) = self.send_admin(framed, Some(seq), frame).await {
                 teardown(phase);
                 return Err(closed(format!("send failed: {err}"), false));
             }
@@ -948,7 +1233,7 @@ impl<A: Application> Reactor<A> {
         let frame = self
             .factory
             .session_reject(out_seq, ref_seq, ref_msg_type, reason);
-        if let Err(err) = self.send_admin(framed, frame).await {
+        if let Err(err) = self.send_admin(framed, Some(out_seq), frame).await {
             teardown(phase);
             return Err(closed(format!("send failed: {err}"), false));
         }
@@ -971,7 +1256,7 @@ impl<A: Application> Reactor<A> {
             Err(err) => return Err(exhausted(phase, err)),
         };
         let frame = self.factory.resend_request(out_seq, expected, 0);
-        if let Err(err) = self.send_admin(framed, frame).await {
+        if let Err(err) = self.send_admin(framed, Some(out_seq), frame).await {
             teardown(phase);
             return Err(closed(format!("send failed: {err}"), false));
         }
@@ -992,7 +1277,7 @@ impl<A: Application> Reactor<A> {
         let reason = format!("MsgSeqNum too low: expected {expected}, received {received}");
         if let Ok(out_seq) = self.runtime.sequences.try_allocate_sender_seq() {
             let frame = self.factory.logout(out_seq.value(), Some(&reason));
-            let _ = self.send_admin(framed, frame).await;
+            let _ = self.send_admin(framed, Some(out_seq.value()), frame).await;
         }
         teardown(phase);
         closed(reason, false)
@@ -1020,11 +1305,11 @@ impl<A: Application> Reactor<A> {
             let frame =
                 self.factory
                     .session_reject(out_seq.value(), ref_seq, ref_msg_type, &reason);
-            let _ = self.send_admin(framed, frame).await;
+            let _ = self.send_admin(framed, Some(out_seq.value()), frame).await;
         }
         if let Ok(out_seq) = self.runtime.sequences.try_allocate_sender_seq() {
             let frame = self.factory.logout(out_seq.value(), Some(&detail));
-            let _ = self.send_admin(framed, frame).await;
+            let _ = self.send_admin(framed, Some(out_seq.value()), frame).await;
         }
         teardown(phase);
         closed(detail, false)
@@ -1215,11 +1500,23 @@ impl<A: Application> Reactor<A> {
 
     /// Answers an inbound ResendRequest (35=2).
     ///
-    /// The engine has no message store, so it cannot replay the requested
-    /// messages: it answers the whole requested range with a single
-    /// SequenceReset-GapFill. The reply is bounded by `EndSeqNo` (16) so the
-    /// counterparty is never advanced past what it asked for, and `16=0`
-    /// means "up to infinity" (`doc/fix_operations.md`, "Resend Request").
+    /// With a store attached (see [`Initiator::with_store`]) the reply is the
+    /// requested **application** messages, replayed from the store with
+    /// `PossDupFlag` (43) = Y and their original `SendingTime` in
+    /// `OrigSendingTime` (122), interleaved with `SequenceReset`-GapFill
+    /// messages covering everything that is not replayed: administrative
+    /// messages, sequence numbers the store never held or has evicted, and
+    /// stored frames that cannot be rebuilt. Without a store nothing can be
+    /// replayed and the whole range is one gap fill.
+    ///
+    /// Either way the reply is bounded by `EndSeqNo` (16) so the counterparty
+    /// is never advanced past what it asked for, and `16=0` means "up to
+    /// infinity" (`doc/fix_operations.md`, "Resend Request").
+    ///
+    /// Nothing here allocates a sender sequence number. A replayed message
+    /// re-occupies the number it was first sent under, and a gap fill occupies
+    /// the range it replaces, so the session's own outbound numbering is
+    /// unchanged by answering a resend.
     async fn on_resend_request(
         &mut self,
         framed: &mut FixFramed,
@@ -1266,7 +1563,7 @@ impl<A: Application> Reactor<A> {
                 .await;
         }
 
-        // The fill covers begin_seq..new_seq, never beyond EndSeqNo + 1 and
+        // The reply covers begin_seq..new_seq, never beyond EndSeqNo + 1 and
         // never beyond what we have actually sent.
         let new_seq = match end_seq {
             0 => next_sender,
@@ -1274,12 +1571,156 @@ impl<A: Application> Reactor<A> {
                 .checked_add(1)
                 .map_or(next_sender, |bound| bound.min(next_sender)),
         };
-        let frame = self.factory.sequence_reset_gap_fill(begin_seq, new_seq);
-        if let Err(err) = self.send_admin(framed, frame).await {
-            teardown(phase);
-            return Err(closed(format!("send failed: {err}"), false));
+
+        let cursor = match self.replay_range(framed, begin_seq, new_seq).await {
+            Ok(cursor) => cursor,
+            Err(err) => {
+                teardown(phase);
+                return Err(closed(format!("resend failed: {err}"), false));
+            }
+        };
+
+        // Whatever the replay did not cover — a trailing run of admin messages,
+        // holes, or the entire range when there is no store — is gap-filled, so
+        // the counterparty's expectation always lands exactly on `new_seq`.
+        if cursor < new_seq {
+            let frame = self.factory.sequence_reset_gap_fill(cursor, new_seq);
+            if let Err(err) = self.send_admin(framed, None, frame).await {
+                teardown(phase);
+                return Err(closed(format!("send failed: {err}"), false));
+            }
         }
         Ok(phase)
+    }
+
+    /// Replays the stored application messages in `begin_seq..new_seq`.
+    ///
+    /// Returns the first sequence number the reply has **not** yet covered, so
+    /// the caller can gap-fill from there to `new_seq`. With no store, or a
+    /// store that cannot answer, that is `begin_seq` and the whole range is
+    /// gap-filled — the degradation is always a gap fill, never a silent skip,
+    /// because a skipped number leaves the counterparty expecting a message
+    /// that will never arrive.
+    ///
+    /// The store is read in bounded pages of [`RESEND_PAGE_LIMIT`] rather than
+    /// all at once: a `ResendRequest` with `EndSeqNo` (16) = 0 asks for the whole
+    /// session, and materialising an arbitrarily long history in one read would
+    /// allocate it all up front and stall the reactor for the duration of a
+    /// single peer request. The reactor yields between pages so other sessions
+    /// and this session's own inbound traffic keep making progress.
+    ///
+    /// # Errors
+    /// Returns [`EngineError`] only if writing to the socket fails; the session
+    /// is then closed by the caller. Every other failure — an unreadable store,
+    /// an unrebuildable frame — degrades to a gap fill.
+    async fn replay_range(
+        &self,
+        framed: &mut FixFramed,
+        begin_seq: u64,
+        new_seq: u64,
+    ) -> Result<u64, EngineError> {
+        let Some(store) = &self.store else {
+            return Ok(begin_seq);
+        };
+        // `new_seq` is the exclusive upper bound of the reply, so the last
+        // replayable number is one below it. A `new_seq` of 0 is unreachable
+        // (it is at least `begin_seq` >= 1), and an empty range needs no read.
+        let Some(end_seq) = new_seq.checked_sub(1) else {
+            return Ok(begin_seq);
+        };
+        if end_seq < begin_seq {
+            return Ok(begin_seq);
+        }
+
+        // `reply_cursor` is the next number the reply still owes the peer; it
+        // advances only past messages actually replayed, so holes, admin
+        // messages and unrebuildable frames stay for the leading or trailing gap
+        // fill. `read_from` is the next store key to page from, and advances
+        // past everything a page yields so no message is read twice.
+        let mut reply_cursor = begin_seq;
+        let mut read_from = begin_seq;
+        loop {
+            let page = match store.get_page(read_from, end_seq, RESEND_PAGE_LIMIT).await {
+                Ok(page) => page,
+                Err(err) => {
+                    tracing::warn!(
+                        session = %self.session_id,
+                        read_from,
+                        end_seq,
+                        error = %err,
+                        "cannot read the resend range from the store: gap-filling the rest"
+                    );
+                    return Ok(reply_cursor);
+                }
+            };
+            let page_len = page.len();
+            // Ascending and bounded to `end_seq`: the last key is the furthest
+            // this page reached, so the next page pages from just past it.
+            let Some(furthest) = page.last().map(|message| message.seq_num()) else {
+                break;
+            };
+
+            for message in page {
+                let seq = message.seq_num();
+                // A store handing back something outside the asked-for range
+                // must not be allowed to move the reply.
+                if seq < reply_cursor || seq > end_seq {
+                    continue;
+                }
+                // Administrative messages are gap-filled, not replayed
+                // (`doc/fix_operations.md`, "Resend Request", item 3): resending
+                // a stale Heartbeat or Logon says nothing true about the session
+                // now.
+                if message.msg_type().is_admin() {
+                    continue;
+                }
+                let frame = match wire::resend_frame(message.payload()) {
+                    Ok(frame) => frame,
+                    Err(err) => {
+                        tracing::warn!(
+                            session = %self.session_id,
+                            seq,
+                            error = %err,
+                            "cannot rebuild a stored message as a resend: gap-filling it instead"
+                        );
+                        continue;
+                    }
+                };
+
+                // Everything between the cursor and this message — holes, admin
+                // messages, frames that would not rebuild — is one fill.
+                if seq > reply_cursor {
+                    let fill = self.factory.sequence_reset_gap_fill(reply_cursor, seq);
+                    self.send_admin(framed, None, fill).await?;
+                }
+                self.send_replay(framed, frame).await?;
+
+                // `seq <= end_seq < new_seq <= next_sender <= u64::MAX`, so this
+                // cannot overflow; it is checked rather than assumed because a
+                // wrapped sequence number would corrupt the session it is meant
+                // to repair.
+                let Some(next) = seq.checked_add(1) else {
+                    return Ok(new_seq);
+                };
+                reply_cursor = next;
+            }
+
+            // A short page means the range is exhausted; a full one means there
+            // may be more, so page again from past the furthest key and yield
+            // first so one resend cannot monopolise the reactor.
+            if page_len < RESEND_PAGE_LIMIT {
+                break;
+            }
+            let Some(next_read) = furthest.checked_add(1) else {
+                break;
+            };
+            read_from = next_read;
+            if read_from > end_seq {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        Ok(reply_cursor)
     }
 
     /// Handles one inbound frame: identity validation, sequence validation,
@@ -1411,7 +1852,7 @@ impl<A: Application> Reactor<A> {
                 // session being torn down over the peer's mistake.
                 let test_req_id = raw.get_field_str(112).filter(|id| !id.is_empty());
                 let frame = self.factory.heartbeat(out_seq, test_req_id);
-                if let Err(err) = self.send_admin(framed, frame).await {
+                if let Err(err) = self.send_admin(framed, Some(out_seq), frame).await {
                     teardown(phase);
                     return Err(closed(format!("send failed: {err}"), false));
                 }
@@ -1442,7 +1883,7 @@ impl<A: Application> Reactor<A> {
                 Phase::Active(session) => {
                     if let Ok(out_seq) = self.runtime.sequences.try_allocate_sender_seq() {
                         let frame = self.factory.logout(out_seq.value(), None);
-                        let _ = self.send_admin(framed, frame).await;
+                        let _ = self.send_admin(framed, Some(out_seq.value()), frame).await;
                     }
                     let _ = session.disconnect();
                     let text = raw

--- a/ironfix-engine/src/wire.rs
+++ b/ironfix-engine/src/wire.rs
@@ -15,6 +15,7 @@ use crate::application::RejectReason;
 use crate::outbound::{OutboundField, OutboundMessage};
 use bytes::BytesMut;
 use ironfix_core::error::{DecodeError, EncodeError};
+use ironfix_core::field::FieldRef;
 use ironfix_core::message::{OwnedMessage, RawMessage};
 use ironfix_core::types::Timestamp;
 use ironfix_core::version::FixVersion;
@@ -194,6 +195,119 @@ pub(crate) fn owned_from_frame(frame: &[u8]) -> Result<OwnedMessage, DecodeError
     Ok(decode_frame(frame)?.to_owned())
 }
 
+/// Why a stored message could not be rebuilt as a resend.
+///
+/// Every variant means the same thing to the reactor — this particular message
+/// cannot be replayed and its sequence number must be gap-filled instead — but
+/// they are kept apart so the log line says which defect was hit.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ResendError {
+    /// The stored frame does not decode.
+    #[error("stored frame does not decode: {0}")]
+    Decode(#[from] DecodeError),
+
+    /// The rebuilt frame has no legal wire form.
+    #[error("resend frame cannot be encoded: {0}")]
+    Encode(#[from] EncodeError),
+
+    /// The stored frame carries no `SendingTime` (52).
+    ///
+    /// FIX requires `OrigSendingTime` (122) on a message carrying
+    /// `PossDupFlag` (43) = Y. On the first resend that original time is the
+    /// frame's own 52 (a resend-of-a-resend keeps it in its own 122 instead —
+    /// see [`resend_frame`]). With no 52 recorded there is no header position to
+    /// re-stamp and nothing truthful to put in 122, and inventing one would
+    /// misreport when the message was first sent.
+    #[error("stored frame carries no SendingTime (52) to copy into OrigSendingTime (122)")]
+    MissingSendingTime,
+}
+
+/// Rebuilds a stored frame as a resend of itself.
+///
+/// The message keeps its original `MsgSeqNum` (34) — a resend re-occupies the
+/// number it was first sent under and allocates nothing — and gains
+/// `PossDupFlag` (43) = Y with `OrigSendingTime` (122) set to when the message
+/// was *first* sent, while 52 is restamped with the time of *this* transmission
+/// (`doc/fix_operations.md`, "Resend Request", items 2 and 4). Both are written
+/// in their standard-header positions: 43 immediately before 52, 122 immediately
+/// after it.
+///
+/// On a plain resend the first-sent time is the frame's own `SendingTime` (52).
+/// On a **resend of a resend** the frame already carries that original in its
+/// own 122 — its 52 by then is only the prior transmission's time — so an
+/// existing 122 is preferred and copied through unchanged. Overwriting it with
+/// 52 would silently move `OrigSendingTime` forward to the last replay.
+///
+/// Every other field is copied through verbatim in its original order, so the
+/// business content of the replayed message is byte-identical to what was
+/// sent. `BodyLength` (9) and `CheckSum` (10) are restamped by the encoder,
+/// because both change with the two inserted fields.
+///
+/// # Errors
+/// Returns [`ResendError`] if the stored frame does not decode, carries no
+/// `SendingTime` (52), or cannot be re-encoded. The caller must gap-fill the
+/// sequence number instead of skipping it.
+pub(crate) fn resend_frame(stored: &[u8]) -> Result<BytesMut, ResendError> {
+    let raw = decode_frame(stored)?;
+    let begin_string = raw.begin_string()?;
+    // 52 is both the emission trigger below and the fallback source for 122, so
+    // its absence is the terminal error: our own stored frames always carry it.
+    let sending_time_52 = raw
+        .get_field_str(52)
+        .ok_or(ResendError::MissingSendingTime)?;
+    // Prefer an existing OrigSendingTime (122): on a resend-of-a-resend it holds
+    // the *first* transmission's time, whereas 52 by then is the prior replay's.
+    // Falling back to 52 covers the first resend, where no 122 is present yet.
+    let orig_sending_time = raw.get_field_str(122).unwrap_or(sending_time_52);
+    let sending_time = Timestamp::now().format_millis();
+
+    // The rebuilt frame is the original plus 43 and 122; the extra headroom
+    // keeps the encoder from reallocating while it copies the body across.
+    let mut encoder = Encoder::with_capacity(begin_string, stored.len() + RESEND_HEADROOM);
+
+    // Collected so a LENGTH field can look ahead to its DATA field. This is
+    // the resend path, not the hot path: one allocation per replayed message
+    // is the right trade for handling every spec-defined field shape.
+    let fields: Vec<&FieldRef<'_>> = raw.fields().collect();
+    let mut index = 0;
+    while let Some(field) = fields.get(index) {
+        index += 1;
+        match field.tag {
+            // BeginString and BodyLength are stamped by `finish`.
+            8 | 9 => {}
+            // Re-emitted below, in their standard-header positions. A frame
+            // already carrying them is being replayed a second time.
+            43 | 122 => {}
+            52 => {
+                encoder.try_put_raw(43, b"Y")?;
+                encoder.try_put_raw(52, sending_time.as_str().as_bytes())?;
+                encoder.try_put_raw(122, orig_sending_time.as_bytes())?;
+            }
+            tag => {
+                if let Err(err) = encoder.try_put_raw(tag, field.value) {
+                    // The encoder refuses a LENGTH or DATA tag on its own,
+                    // because it derives the declared count from the payload
+                    // so the two cannot disagree. Pair it with the field that
+                    // follows and write both together.
+                    let paired = fields.get(index).is_some_and(|data| {
+                        encoder.try_put_data(tag, data.tag, data.value).is_ok()
+                    });
+                    if !paired {
+                        return Err(err.into());
+                    }
+                    index += 1;
+                }
+            }
+        }
+    }
+
+    Ok(into_frame(&mut encoder)?)
+}
+
+/// Extra bytes reserved for the `PossDupFlag` (43) and `OrigSendingTime` (122)
+/// a resend inserts, plus the framing fields the encoder restamps.
+const RESEND_HEADROOM: usize = 64;
+
 /// Stamps the frame and moves it into a buffer the transport owns.
 ///
 /// # Errors
@@ -242,14 +356,14 @@ impl MessageFactory {
     /// pairing of the routing fields. Both are stamped only when configured;
     /// an unset LocationID places nothing on the wire.
     ///
-    /// `poss_dup` stamps both `PossDupFlag` (43) and `OrigSendingTime` (122):
-    /// FIX requires 122 on every message carrying 43=Y, and
-    /// `doc/fix_operations.md` mandates it for resends. The engine has no
-    /// message store, so the original sending time of the replaced messages
-    /// is not recoverable; per the spec's handling of an unavailable
-    /// OrigSendingTime the current time is used, which is also what a
-    /// SequenceReset-GapFill (whose "original" messages are administrative
-    /// filler, not replayed traffic) needs.
+    /// `poss_dup` stamps both `PossDupFlag` (43) and `OrigSendingTime` (122),
+    /// because FIX requires 122 on every message carrying 43=Y. Its only user
+    /// is [`MessageFactory::sequence_reset_gap_fill`], which is not a replay of
+    /// anything: a gap fill's "original" is administrative filler that was
+    /// never sent, so there is no recorded sending time to copy and 122 takes
+    /// the same value as `SendingTime` (52) — the FIX handling for an
+    /// unavailable OrigSendingTime. A genuine replay of a stored message goes
+    /// through [`resend_frame`], which copies the real original 52 into 122.
     ///
     /// `appl_ver_id` stamps `ApplVerID` (1128) immediately after MsgType,
     /// its position in the FIXT.1.1 standard header. It is passed only for
@@ -468,6 +582,22 @@ mod tests {
         }
     }
 
+    /// Fails the test with context instead of `.unwrap()` / `.expect()`.
+    #[track_caller]
+    fn some<T>(value: Option<T>, what: &str) -> T {
+        match value {
+            Some(value) => value,
+            None => panic!("{what}"),
+        }
+    }
+
+    /// Reads a field out of a finished frame as an owned `String`.
+    fn field_of(frame: &[u8], tag: u32) -> Option<String> {
+        decode_frame(frame)
+            .ok()
+            .and_then(|raw| raw.get_field_str(tag).map(str::to_string))
+    }
+
     #[test]
     fn test_logon_frame_roundtrip() {
         let frame = framed(factory().logon(1, 30, true));
@@ -670,6 +800,133 @@ mod tests {
         let raw = decode(&frame);
         assert_eq!(raw.begin_string(), Ok("FIXT.1.1"));
         assert_eq!(raw.get_field_str(1128), Some("9"));
+    }
+
+    #[test]
+    fn test_resend_frame_preserves_body_and_stamps_poss_dup() {
+        let mut message = OutboundMessage::new(MsgType::NewOrderSingle);
+        message.push_str(11, "ORDER-1").push_char(54, '1');
+        let original = framed(factory().application_message(7, &message));
+        let original_sending_time = some(
+            field_of(&original, 52),
+            "the original must carry SendingTime",
+        );
+
+        let resent = match resend_frame(&original) {
+            Ok(frame) => frame,
+            Err(err) => panic!("a factory frame must rebuild as a resend: {err}"),
+        };
+        let raw = decode(&resent);
+
+        // Same message, same number: a resend re-occupies the sequence number
+        // it was first sent under.
+        assert_eq!(raw.msg_type(), &MsgType::NewOrderSingle);
+        assert_eq!(raw.get_field_str(34), Some("7"));
+        assert_eq!(raw.get_field_str(11), Some("ORDER-1"));
+        assert_eq!(raw.get_field_str(54), Some("1"));
+        assert_eq!(raw.get_field_str(49), Some("CLIENT"));
+        assert_eq!(raw.get_field_str(56), Some("VENUE"));
+
+        // The whole point: 122 is the *original* sending time, not a fresh one.
+        assert_eq!(raw.get_field_str(43), Some("Y"));
+        assert_eq!(raw.get_field_str(122), Some(original_sending_time.as_str()));
+    }
+
+    #[test]
+    fn test_resend_frame_of_a_resend_preserves_the_first_sending_time() {
+        // The intermediate frame is built by hand so its SendingTime (52, the
+        // *prior* replay) and OrigSendingTime (122, the *first* transmission)
+        // are deterministically different. Chaining two `resend_frame` calls
+        // would let both land in the same millisecond — SendingTime is
+        // millisecond-resolution — and hide a 122 overwritten with 52.
+        const FIRST_SENT: &str = "20260721-10:00:00.000";
+        const PRIOR_REPLAY: &str = "20260721-11:30:45.500";
+
+        let mut encoder = Encoder::new("FIX.4.4");
+        encoder.put_str(35, "D");
+        encoder.put_str(49, "CLIENT");
+        encoder.put_str(56, "VENUE");
+        encoder.put_uint(34, 3);
+        encoder.put_bool(43, true);
+        encoder.put_str(52, PRIOR_REPLAY);
+        encoder.put_str(122, FIRST_SENT);
+        encoder.put_str(11, "ORDER-1");
+        let once = framed(into_frame(&mut encoder));
+
+        let twice = match resend_frame(&once) {
+            Ok(frame) => frame,
+            Err(err) => panic!("second resend must build: {err}"),
+        };
+        let raw = decode(&twice);
+
+        // The prior 43/122 are re-emitted once in their header positions, never
+        // duplicated.
+        assert_eq!(raw.fields().filter(|field| field.tag == 43).count(), 1);
+        assert_eq!(raw.fields().filter(|field| field.tag == 122).count(), 1);
+        // The whole point: 122 still names the *first* transmission, not the
+        // prior replay's SendingTime.
+        assert_eq!(raw.get_field_str(122), Some(FIRST_SENT));
+        assert_ne!(raw.get_field_str(122), Some(PRIOR_REPLAY));
+        // 52 is this transmission's time, distinct from both, and the body and
+        // number survive.
+        assert_eq!(raw.get_field_str(34), Some("3"));
+        assert_eq!(raw.get_field_str(11), Some("ORDER-1"));
+        assert_eq!(raw.get_field_str(43), Some("Y"));
+    }
+
+    #[test]
+    fn test_resend_frame_without_sending_time_is_a_typed_error() {
+        // Built by hand: the factory always stamps 52.
+        let mut encoder = Encoder::new("FIX.4.4");
+        encoder.put_str(35, "D");
+        encoder.put_str(49, "CLIENT");
+        encoder.put_str(56, "VENUE");
+        encoder.put_uint(34, 4);
+        let frame = framed(into_frame(&mut encoder));
+
+        match resend_frame(&frame) {
+            Err(ResendError::MissingSendingTime) => {}
+            Err(err) => panic!("expected MissingSendingTime, got {err}"),
+            Ok(_) => panic!("a frame with no SendingTime must not be replayed"),
+        }
+    }
+
+    #[test]
+    fn test_resend_frame_of_undecodable_bytes_is_a_typed_error() {
+        match resend_frame(b"not a fix message") {
+            Err(ResendError::Decode(_)) => {}
+            Err(err) => panic!("expected a decode error, got {err}"),
+            Ok(_) => panic!("garbage must not rebuild into a frame"),
+        }
+    }
+
+    #[test]
+    fn test_resend_frame_preserves_a_length_data_pair() {
+        // RawData (96) is framed by the count in RawDataLength (95), so the two
+        // have to be rebuilt together or the frame is corrupt. The payload
+        // carries SOH deliberately: that is what the pair exists for.
+        let mut encoder = Encoder::new("FIX.4.4");
+        encoder.put_str(35, "D");
+        encoder.put_str(49, "CLIENT");
+        encoder.put_str(56, "VENUE");
+        encoder.put_uint(34, 9);
+        encoder.put_str(52, "20260721-10:00:00.000");
+        encoder.put_data(95, 96, b"opaque\x01payload");
+        let original = framed(into_frame(&mut encoder));
+
+        let resent = match resend_frame(&original) {
+            Ok(frame) => frame,
+            Err(err) => panic!("a frame with a LENGTH/DATA pair must rebuild: {err}"),
+        };
+        let raw = decode(&resent);
+
+        assert_eq!(raw.get_field_str(95), Some("14"));
+        assert_eq!(
+            some(raw.get_field(96), "RawData must survive the rebuild").value,
+            b"opaque\x01payload"
+        );
+        assert_eq!(raw.get_field_str(43), Some("Y"));
+        assert_eq!(raw.get_field_str(122), Some("20260721-10:00:00.000"));
     }
 
     #[test]

--- a/ironfix-engine/tests/initiator_tests.rs
+++ b/ironfix-engine/tests/initiator_tests.rs
@@ -11,6 +11,7 @@
 use async_trait::async_trait;
 use bytes::BytesMut;
 use futures_util::{SinkExt, StreamExt};
+use ironfix_core::error::StoreError;
 use ironfix_core::message::MsgType;
 use ironfix_core::message::RawMessage;
 use ironfix_core::types::{CompId, Timestamp};
@@ -18,6 +19,7 @@ use ironfix_engine::application::{Application, RejectReason, SessionId};
 use ironfix_engine::{EngineError, Initiator, OutboundMessage};
 use ironfix_session::sequence::SequenceCounter;
 use ironfix_session::{SessionConfig, SessionConfigError};
+use ironfix_store::{MemoryStore, MessageStore, StoredMessage};
 use ironfix_tagvalue::{Decoder, Encoder};
 use ironfix_transport::FixCodec;
 use std::sync::{Arc, Mutex};
@@ -2457,5 +2459,740 @@ async fn test_connect_refuses_a_fractional_heartbeat_interval() {
             .await
             .is_err(),
         "the socket must never be dialled"
+    );
+}
+// ---------------------------------------------------------------------------
+// Resend from a message store
+// ---------------------------------------------------------------------------
+
+/// Wraps a [`MemoryStore`] and silently forgets one sequence number, standing
+/// in for a store that has evicted a message the counterparty still asks for.
+///
+/// The engine must gap-fill the forgotten number rather than skip it: a skipped
+/// number leaves the counterparty expecting a message that will never arrive.
+#[derive(Debug)]
+struct ForgetfulStore {
+    inner: MemoryStore,
+    forget: u64,
+}
+
+impl ForgetfulStore {
+    fn new(forget: u64) -> Self {
+        Self {
+            inner: MemoryStore::new(),
+            forget,
+        }
+    }
+}
+
+#[async_trait]
+impl MessageStore for ForgetfulStore {
+    async fn store(
+        &self,
+        seq_num: u64,
+        msg_type: &MsgType,
+        message: &[u8],
+    ) -> Result<(), StoreError> {
+        if seq_num == self.forget {
+            return Ok(());
+        }
+        self.inner.store(seq_num, msg_type, message).await
+    }
+
+    async fn get_range(&self, begin: u64, end: u64) -> Result<Vec<StoredMessage>, StoreError> {
+        self.inner.get_range(begin, end).await
+    }
+
+    fn next_sender_seq(&self) -> u64 {
+        self.inner.next_sender_seq()
+    }
+
+    fn next_target_seq(&self) -> u64 {
+        self.inner.next_target_seq()
+    }
+
+    fn set_next_sender_seq(&self, seq: u64) {
+        self.inner.set_next_sender_seq(seq);
+    }
+
+    fn set_next_target_seq(&self, seq: u64) {
+        self.inner.set_next_target_seq(seq);
+    }
+
+    async fn reset(&self) -> Result<(), StoreError> {
+        self.inner.reset().await
+    }
+
+    fn creation_time(&self) -> std::time::SystemTime {
+        self.inner.creation_time()
+    }
+}
+
+/// One original send, as the stub acceptor observed it.
+struct SentOrder {
+    /// ClOrdID (11), so the replay can be matched to the original.
+    cl_ord_id: String,
+    /// SendingTime (52), which must reappear as OrigSendingTime (122).
+    sending_time: String,
+}
+
+/// Drains `count` orders starting at sequence `first`, recording what the
+/// acceptor saw so a later replay can be compared against it.
+async fn drain_orders(
+    framed: &mut Framed<TcpStream, FixCodec>,
+    first: u64,
+    count: u64,
+) -> Vec<SentOrder> {
+    let mut sent = Vec::new();
+    for offset in 0..count {
+        let frame = next_frame(framed).await;
+        assert_eq!(msg_type_of(&frame), "D");
+        assert_eq!(field(&frame, 34), Some((first + offset).to_string()));
+        assert_eq!(
+            field(&frame, 43),
+            None,
+            "an original send is not a possible duplicate"
+        );
+        sent.push(SentOrder {
+            cl_ord_id: some(field(&frame, 11), "order must carry ClOrdID (11)"),
+            sending_time: some(field(&frame, 52), "order must carry SendingTime (52)"),
+        });
+    }
+    sent
+}
+
+/// Asserts that `frame` is `original` replayed under sequence number `seq`.
+#[track_caller]
+fn assert_replay_of(frame: &[u8], seq: u64, original: &SentOrder) {
+    assert_eq!(msg_type_of(frame), "D");
+    assert_eq!(field(frame, 34), Some(seq.to_string()));
+    assert_eq!(
+        field(frame, 11).as_deref(),
+        Some(original.cl_ord_id.as_str()),
+        "the replayed body must be the original body"
+    );
+    assert_eq!(
+        field(frame, 43).as_deref(),
+        Some("Y"),
+        "a resend must carry PossDupFlag"
+    );
+    assert_eq!(
+        field(frame, 122).as_deref(),
+        Some(original.sending_time.as_str()),
+        "OrigSendingTime must be the original SendingTime, not a fresh one"
+    );
+}
+
+/// Asserts that `frame` is a SequenceReset-GapFill occupying `seq` and
+/// advancing the counterparty to `new_seq`.
+#[track_caller]
+fn assert_gap_fill(frame: &[u8], seq: u64, new_seq: u64) {
+    assert_eq!(msg_type_of(frame), "4");
+    assert_eq!(field(frame, 123).as_deref(), Some("Y"));
+    assert_eq!(field(frame, 34), Some(seq.to_string()));
+    assert_eq!(field(frame, 36), Some(new_seq.to_string()));
+    assert_eq!(field(frame, 43).as_deref(), Some("Y"));
+    assert!(field(frame, 122).is_some(), "PossDup requires 122");
+}
+
+/// Sends `count` orders on the connection.
+async fn send_orders(connection: &ironfix_engine::Connection, count: usize) {
+    for index in 0..count {
+        let mut order = OutboundMessage::new(MsgType::NewOrderSingle);
+        order.push_str(11, &format!("ORDER-{index}"));
+        ok(connection.send(order).await, "send order");
+    }
+}
+
+/// With a store attached, a bounded ResendRequest replays the real application
+/// messages — same bodies, same sequence numbers — carrying PossDupFlag (43)
+/// and the original SendingTime in OrigSendingTime (122).
+#[tokio::test]
+async fn test_resend_request_replays_stored_application_messages() {
+    let (listener, addr) = bind_listener().await;
+    let (replay_seen_tx, replay_seen_rx) = tokio::sync::oneshot::channel::<()>();
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+        let sent = drain_orders(&mut framed, 2, 3).await;
+
+        ok(
+            framed.send(venue_msg("2", 2, &[(7, "2"), (16, "4")])).await,
+            "send bounded resend request",
+        );
+
+        for (seq, original) in (2..).zip(sent.iter()) {
+            let replayed = next_frame(&mut framed).await;
+            assert_replay_of(&replayed, seq, original);
+        }
+
+        let _ = replay_seen_tx.send(());
+
+        // A replay re-occupies the numbers it replaces and allocates nothing,
+        // so the next real message still goes out at 5.
+        let next = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&next), "D");
+        assert_eq!(field(&next, 34).as_deref(), Some("5"));
+        assert_eq!(field(&next, 43), None);
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app))
+        .with_store(Arc::new(MemoryStore::new()));
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    send_orders(&connection, 3).await;
+
+    ok(
+        timeout(Duration::from_secs(5), replay_seen_rx).await,
+        "replay observed within 5s",
+    )
+    .ok();
+    let mut order = OutboundMessage::new(MsgType::NewOrderSingle);
+    order.push_str(11, "ORDER-AFTER-REPLAY");
+    ok(connection.send(order).await, "send order after replay");
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+}
+
+/// Administrative messages inside the requested range are gap-filled rather
+/// than replayed: sequence 1 is the Logon, so the reply opens with a gap fill
+/// advancing to the first application message.
+#[tokio::test]
+async fn test_resend_request_gap_fills_admin_messages_before_replaying_orders() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+        let sent = drain_orders(&mut framed, 2, 3).await;
+
+        ok(
+            framed.send(venue_msg("2", 2, &[(7, "1"), (16, "4")])).await,
+            "send resend request covering the Logon",
+        );
+
+        // Sequence 1 is our Logon: administrative, so it is filled, not resent.
+        let fill = next_frame(&mut framed).await;
+        assert_gap_fill(&fill, 1, 2);
+
+        for (seq, original) in (2..).zip(sent.iter()) {
+            let replayed = next_frame(&mut framed).await;
+            assert_replay_of(&replayed, seq, original);
+        }
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app))
+        .with_store(Arc::new(MemoryStore::new()));
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    send_orders(&connection, 3).await;
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+}
+
+/// A sequence number the store cannot produce is gap-filled in place, between
+/// the messages either side of it, so the counterparty is never desynchronised
+/// by a hole in the replay.
+#[tokio::test]
+async fn test_resend_request_gap_fills_a_message_the_store_lost() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+        let sent = drain_orders(&mut framed, 2, 3).await;
+
+        ok(
+            framed.send(venue_msg("2", 2, &[(7, "2"), (16, "4")])).await,
+            "send bounded resend request",
+        );
+
+        let first = next_frame(&mut framed).await;
+        let [second, _, fourth] = sent.as_slice() else {
+            panic!("three orders must have been recorded, got {}", sent.len());
+        };
+        assert_replay_of(&first, 2, second);
+
+        // 3 was never filed, so it is covered by a fill that stops at 4.
+        let fill = next_frame(&mut framed).await;
+        assert_gap_fill(&fill, 3, 4);
+
+        let last = next_frame(&mut framed).await;
+        assert_replay_of(&last, 4, fourth);
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app))
+        .with_store(Arc::new(ForgetfulStore::new(3)));
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    send_orders(&connection, 3).await;
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+}
+
+/// A hole at the end of the requested range is covered by a trailing gap fill,
+/// so the counterparty's expectation still lands exactly on EndSeqNo + 1.
+#[tokio::test]
+async fn test_resend_request_trailing_hole_is_gap_filled_to_the_bound() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+        let sent = drain_orders(&mut framed, 2, 3).await;
+
+        ok(
+            framed.send(venue_msg("2", 2, &[(7, "2"), (16, "4")])).await,
+            "send bounded resend request",
+        );
+
+        let [second, third, _] = sent.as_slice() else {
+            panic!("three orders must have been recorded, got {}", sent.len());
+        };
+        let first_replay = next_frame(&mut framed).await;
+        assert_replay_of(&first_replay, 2, second);
+        let second_replay = next_frame(&mut framed).await;
+        assert_replay_of(&second_replay, 3, third);
+
+        // 4 was never filed: the trailing fill still advances to EndSeqNo + 1.
+        let fill = next_frame(&mut framed).await;
+        assert_gap_fill(&fill, 4, 5);
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app))
+        .with_store(Arc::new(ForgetfulStore::new(4)));
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    send_orders(&connection, 3).await;
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+}
+
+/// EndSeqNo = 0 with a store replays everything from BeginSeqNo up to the
+/// last message actually sent.
+#[tokio::test]
+async fn test_resend_request_unbounded_replays_to_the_last_sent_message() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+        let sent = drain_orders(&mut framed, 2, 3).await;
+
+        ok(
+            framed.send(venue_msg("2", 2, &[(7, "2"), (16, "0")])).await,
+            "send unbounded resend request",
+        );
+
+        for (seq, original) in (2..).zip(sent.iter()) {
+            let replayed = next_frame(&mut framed).await;
+            assert_replay_of(&replayed, seq, original);
+        }
+
+        // Everything up to next-sender-1 was replayed, so there is nothing
+        // left to fill: the next frame is the client's Logout.
+        ok(
+            framed.send(venue_msg("5", 3, &[])).await,
+            "send logout to end the test deterministically",
+        );
+        let reply = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&reply), "5");
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app))
+        .with_store(Arc::new(MemoryStore::new()));
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    send_orders(&connection, 3).await;
+    connection.wait_closed().await;
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+}
+
+/// A store carries sequence numbers as well as messages: a session started
+/// against a store holding counters resumes from them, and mirrors its own
+/// counters back into it.
+#[tokio::test]
+async fn test_initiator_seeds_and_mirrors_sequence_numbers_through_the_store() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_framed(listener).await;
+
+        let logon = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&logon), "A");
+        // Seeded from the store, not from 1.
+        assert_eq!(field(&logon, 34).as_deref(), Some("7"));
+        ok(
+            framed
+                .send(venue_msg("A", 4, &[(98, "0"), (108, "30")]))
+                .await,
+            "send logon ack",
+        );
+
+        let order = next_frame(&mut framed).await;
+        assert_eq!(field(&order, 34).as_deref(), Some("8"));
+    });
+
+    let store = Arc::new(MemoryStore::new());
+    store.set_next_sender_seq(7);
+    store.set_next_target_seq(4);
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app))
+        .with_store(Arc::clone(&store) as Arc<dyn MessageStore>);
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    send_orders(&connection, 1).await;
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+
+    // The counters advanced in the session are visible in the store: 7 (Logon)
+    // and 8 (the order) were sent, and the Logon ack at 4 was consumed.
+    assert_eq!(connection.next_sender_seq(), 9);
+    assert_eq!(store.next_sender_seq(), 9);
+    assert_eq!(store.next_target_seq(), 5);
+
+    // And the frames themselves are filed under the numbers they went out with.
+    let stored = ok(store.get_range(7, 8).await, "the store must hold 7..=8");
+    assert_eq!(
+        stored
+            .iter()
+            .map(|message| (message.seq_num(), message.msg_type().as_str().to_string()))
+            .collect::<Vec<_>>(),
+        vec![(7, "A".to_string()), (8, "D".to_string())]
+    );
+}
+
+/// A session that resets its counters when it closes must clear the store with
+/// them: otherwise the next session, numbering from 1 again, would file its
+/// messages on top of this one's and could answer a resend with the wrong
+/// session's traffic.
+#[tokio::test]
+async fn test_reset_on_disconnect_clears_the_store() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+        let _ = drain_orders(&mut framed, 2, 1).await;
+        // Dropping the socket closes the session abnormally.
+        drop(framed);
+    });
+
+    let store = Arc::new(MemoryStore::new());
+    let mut config = client_config(Duration::from_secs(30));
+    config.reset_on_disconnect = true;
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(config, Arc::clone(&app))
+        .with_store(Arc::clone(&store) as Arc<dyn MessageStore>);
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    send_orders(&connection, 1).await;
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+    connection.wait_closed().await;
+
+    assert_eq!(store.message_count(), 0);
+    assert_eq!(store.next_sender_seq(), 1);
+    assert_eq!(store.next_target_seq(), 1);
+}
+
+/// A Logon declaring ResetSeqNumFlag starts both counters at 1 and clears the
+/// store, so the numbers the new session hands out cannot collide with
+/// messages an earlier one filed under them.
+#[tokio::test]
+async fn test_reset_on_logon_clears_a_populated_store() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_framed(listener).await;
+
+        let logon = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&logon), "A");
+        assert_eq!(field(&logon, 141).as_deref(), Some("Y"));
+        // Numbered from 1 despite the store reporting 42.
+        assert_eq!(field(&logon, 34).as_deref(), Some("1"));
+        ok(
+            framed
+                .send(venue_msg("A", 1, &[(98, "0"), (108, "30"), (141, "Y")]))
+                .await,
+            "send logon ack",
+        );
+
+        let order = next_frame(&mut framed).await;
+        assert_eq!(field(&order, 34).as_deref(), Some("2"));
+    });
+
+    let store = Arc::new(MemoryStore::new());
+    ok(
+        store.store(41, &MsgType::NewOrderSingle, b"stale").await,
+        "seed the store with a previous session's message",
+    );
+    store.set_next_sender_seq(42);
+    store.set_next_target_seq(17);
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(
+        client_config(Duration::from_secs(30)).with_reset_on_logon(true),
+        Arc::clone(&app),
+    )
+    .with_store(Arc::clone(&store) as Arc<dyn MessageStore>);
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    assert!(!store.contains(41), "the stale message must be gone");
+
+    send_orders(&connection, 1).await;
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+}
+
+/// A store whose `reset` and/or `refresh` fail, standing in for a persistent
+/// backend that cannot vouch for its counters when the session starts.
+#[derive(Debug)]
+struct FailingStore {
+    inner: MemoryStore,
+    fail_reset: bool,
+    fail_refresh: bool,
+}
+
+impl FailingStore {
+    fn failing_reset() -> Self {
+        Self {
+            inner: MemoryStore::new(),
+            fail_reset: true,
+            fail_refresh: false,
+        }
+    }
+
+    fn failing_refresh() -> Self {
+        Self {
+            inner: MemoryStore::new(),
+            fail_reset: false,
+            fail_refresh: true,
+        }
+    }
+}
+
+#[async_trait]
+impl MessageStore for FailingStore {
+    async fn store(
+        &self,
+        seq_num: u64,
+        msg_type: &MsgType,
+        message: &[u8],
+    ) -> Result<(), StoreError> {
+        self.inner.store(seq_num, msg_type, message).await
+    }
+
+    async fn get_range(&self, begin: u64, end: u64) -> Result<Vec<StoredMessage>, StoreError> {
+        self.inner.get_range(begin, end).await
+    }
+
+    fn next_sender_seq(&self) -> u64 {
+        self.inner.next_sender_seq()
+    }
+
+    fn next_target_seq(&self) -> u64 {
+        self.inner.next_target_seq()
+    }
+
+    fn set_next_sender_seq(&self, seq: u64) {
+        self.inner.set_next_sender_seq(seq);
+    }
+
+    fn set_next_target_seq(&self, seq: u64) {
+        self.inner.set_next_target_seq(seq);
+    }
+
+    async fn reset(&self) -> Result<(), StoreError> {
+        if self.fail_reset {
+            return Err(StoreError::Io("reset failed".to_string()));
+        }
+        self.inner.reset().await
+    }
+
+    fn creation_time(&self) -> std::time::SystemTime {
+        self.inner.creation_time()
+    }
+
+    async fn refresh(&self) -> Result<(), StoreError> {
+        if self.fail_refresh {
+            return Err(StoreError::Io("refresh failed".to_string()));
+        }
+        Ok(())
+    }
+}
+
+/// A ResetSeqNumFlag Logon whose store cannot be cleared must abort the
+/// handshake with a typed error, not start at 1 with the previous stream still
+/// filed — which a later ResendRequest could then replay as this session's.
+#[tokio::test]
+async fn test_reset_on_logon_aborts_when_the_store_cannot_be_reset() {
+    // The connection is dialled before the store is seeded, so a listener must
+    // be bound; the handshake never gets far enough to send a Logon.
+    let (_listener, addr) = bind_listener().await;
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(
+        client_config(Duration::from_secs(30)).with_reset_on_logon(true),
+        Arc::clone(&app),
+    )
+    .with_store(Arc::new(FailingStore::failing_reset()) as Arc<dyn MessageStore>);
+
+    match initiator.connect(addr).await {
+        Err(EngineError::Store(_)) => {}
+        Err(other) => panic!("expected a store error, got {other:?}"),
+        Ok(_) => panic!("connect must fail when the store cannot be reset"),
+    }
+}
+
+/// A session seeding its counters from the store must abort the handshake if the
+/// store cannot be refreshed, rather than start against unknown counters and
+/// risk reusing a MsgSeqNum the counterparty has already seen.
+#[tokio::test]
+async fn test_connect_aborts_when_the_store_cannot_be_refreshed() {
+    let (_listener, addr) = bind_listener().await;
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app))
+        .with_store(Arc::new(FailingStore::failing_refresh()) as Arc<dyn MessageStore>);
+
+    match initiator.connect(addr).await {
+        Err(EngineError::Store(_)) => {}
+        Err(other) => panic!("expected a store error, got {other:?}"),
+        Ok(_) => panic!("connect must fail when the store cannot be refreshed"),
+    }
+}
+
+/// The store's sender counter must advance to reflect the Logon before the
+/// handshake completes: if the ack never arrives, a reconnect reusing the store
+/// must still see the Logon's MsgSeqNum spent, never hand out 1 again.
+#[tokio::test]
+async fn test_handshake_mirrors_the_sender_counter_before_the_logon_is_acked() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_framed(listener).await;
+        let logon = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&logon), "A");
+        assert_eq!(field(&logon, 34).as_deref(), Some("1"));
+        // Drop without acking: the handshake fails after the Logon is on the
+        // wire but before any acknowledgement.
+        drop(framed);
+    });
+
+    let store = Arc::new(MemoryStore::new());
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app))
+        .with_store(Arc::clone(&store) as Arc<dyn MessageStore>);
+
+    assert!(
+        initiator.connect(addr).await.is_err(),
+        "the handshake must fail when the ack never arrives"
+    );
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+
+    // The Logon went out under MsgSeqNum 1, so the store must already read 2
+    // even though the handshake failed before any ack. Without the handshake
+    // mirroring the counter, the store would still report 1 and a reconnect
+    // would reuse the number the counterparty has already seen.
+    assert_eq!(store.next_sender_seq(), 2);
+}
+
+/// A ResendRequest spanning more messages than one store page replays every one
+/// of them, in order, across page boundaries — the paged read must not truncate
+/// the reply at the first page.
+#[tokio::test]
+async fn test_resend_request_replays_across_store_pages() {
+    // 260 exceeds the 256-message page size, so the replay must page at least
+    // twice; every order still comes back exactly once, in sequence order.
+    const ORDERS: u64 = 260;
+
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+        let sent = drain_orders(&mut framed, 2, ORDERS).await;
+
+        ok(
+            framed.send(venue_msg("2", 2, &[(7, "2"), (16, "0")])).await,
+            "send unbounded resend request",
+        );
+
+        for (seq, original) in (2..).zip(sent.iter()) {
+            let replayed = next_frame(&mut framed).await;
+            assert_replay_of(&replayed, seq, original);
+        }
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app))
+        .with_store(Arc::new(MemoryStore::new()));
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    send_orders(&connection, ORDERS as usize).await;
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(10), acceptor).await,
+            "acceptor done within 10s",
+        ),
+        "acceptor task",
     );
 }

--- a/ironfix-store/src/lib.rs
+++ b/ironfix-store/src/lib.rs
@@ -6,27 +6,33 @@
 
 //! # IronFix Store
 //!
-//! Message persistence and storage for the IronFix FIX protocol engine.
+//! Message storage for the IronFix FIX protocol engine.
+//!
+//! A store exists to answer one question the FIX session layer cannot answer
+//! on its own: *what did we send under sequence number N?* `ironfix-engine`
+//! files every sequenced outbound frame here, and replays from here when a
+//! counterparty sends a `ResendRequest` (35=2).
 //!
 //! This crate provides:
 //! - **[`MessageStore`] trait**: the abstract interface for storing outbound
 //!   messages so a `ResendRequest` can be answered, and for persisting sequence
 //!   numbers across restarts
+//! - **[`StoredMessage`]**: one message as it was filed — verbatim frame bytes,
+//!   its sequence number, and its recorded `MsgType`
 //! - **[`MemoryStore`]**: an in-memory implementation, backed by a
 //!   `parking_lot::RwLock<BTreeMap<..>>` and two atomics
 //!
-//! ## Current limitations
+//! ## Not persistent
 //!
 //! [`MemoryStore`] is the **only** implementation — there is no file-based or
-//! memory-mapped store, so nothing here survives a process restart.
-//!
-//! Furthermore, `ironfix-engine` does not currently use this crate at all: no
-//! outbound message is stored and no sequence number is persisted, so
-//! resend-from-store is not implemented. An inbound `ResendRequest` is answered
-//! with a `SequenceReset`/gap fill rather than with the original messages.
+//! memory-mapped store, so nothing here survives a process restart. A durable
+//! implementation is separate, tracked work; until it lands, restart recovery
+//! is a gap, not a feature.
 
 pub mod memory;
+pub mod stored;
 pub mod traits;
 
 pub use memory::MemoryStore;
+pub use stored::StoredMessage;
 pub use traits::MessageStore;

--- a/ironfix-store/src/memory.rs
+++ b/ironfix-store/src/memory.rs
@@ -9,11 +9,12 @@
 //! This module provides a simple in-memory message store suitable for
 //! testing and applications that don't require persistence.
 
+use crate::stored::StoredMessage;
 use crate::traits::MessageStore;
 use async_trait::async_trait;
 use bytes::Bytes;
 use ironfix_core::error::StoreError;
-use ironfix_core::message::{MsgType, OwnedMessage};
+use ironfix_core::message::MsgType;
 use parking_lot::RwLock;
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -22,11 +23,13 @@ use std::time::SystemTime;
 /// In-memory message store.
 ///
 /// Stores messages in a `BTreeMap` for efficient range queries.
-/// Not persistent - all data is lost when the process exits.
+/// Not persistent - all data is lost when the process exits, so it cannot
+/// carry a session across a restart. It is the only implementation in this
+/// crate today.
 #[derive(Debug)]
 pub struct MemoryStore {
-    /// Stored messages indexed by sequence number.
-    messages: RwLock<BTreeMap<u64, Bytes>>,
+    /// Stored frames and their recorded `MsgType`, indexed by sequence number.
+    messages: RwLock<BTreeMap<u64, (MsgType, Bytes)>>,
     /// Next sender sequence number.
     next_sender_seq: AtomicU64,
     /// Next expected target sequence number.
@@ -83,28 +86,84 @@ impl Default for MemoryStore {
 
 #[async_trait]
 impl MessageStore for MemoryStore {
-    async fn store(&self, seq_num: u64, message: &[u8]) -> Result<(), StoreError> {
-        let mut messages = self.messages.write();
-        messages.insert(seq_num, Bytes::copy_from_slice(message));
+    async fn store(
+        &self,
+        seq_num: u64,
+        msg_type: &MsgType,
+        message: &[u8],
+    ) -> Result<(), StoreError> {
+        let entry = (msg_type.clone(), Bytes::copy_from_slice(message));
+        // The guard is scoped to this statement: it is a `parking_lot` lock,
+        // which does not yield, and must never be live across an await.
+        self.messages.write().insert(seq_num, entry);
         Ok(())
     }
 
-    async fn get_range(&self, begin: u64, end: u64) -> Result<Vec<OwnedMessage>, StoreError> {
-        let messages = self.messages.read();
+    async fn get_range(&self, begin: u64, end: u64) -> Result<Vec<StoredMessage>, StoreError> {
+        // `EndSeqNo` (16) = 0 is the FIX spelling of "to infinity". It is
+        // normalised here, before any comparison, so the inverted-range check
+        // below cannot mistake it for a bound below `begin`.
         let end = if end == 0 { u64::MAX } else { end };
 
-        let result: Vec<OwnedMessage> = messages
-            .range(begin..=end)
-            .map(|(_, bytes)| OwnedMessage::new(bytes.clone(), MsgType::default(), vec![]))
-            .collect();
+        // Both guards run before `BTreeMap::range`, which *panics* on an
+        // inverted range — and this is reachable from a plain trait call, so
+        // the panic would abort the process under `panic = "abort"`.
+        if begin == 0 || begin > end {
+            return Err(StoreError::InvalidRange { begin, end });
+        }
 
-        if result.is_empty() && begin <= end {
-            return Err(StoreError::RangeNotAvailable {
-                range: begin..end + 1,
-            });
+        let result: Vec<StoredMessage> = {
+            let messages = self.messages.read();
+            messages
+                .range(begin..=end)
+                .map(|(seq_num, (msg_type, payload))| {
+                    StoredMessage::new(*seq_num, msg_type.clone(), payload.clone())
+                })
+                .collect()
+        };
+
+        if result.is_empty() {
+            // Inclusive bounds, carried as two numbers: `end` may be
+            // `u64::MAX` here, and an `end + 1` to build a half-open range
+            // would overflow — the original defect this replaces.
+            return Err(StoreError::RangeNotAvailable { begin, end });
         }
 
         Ok(result)
+    }
+
+    async fn get_page(
+        &self,
+        begin: u64,
+        end: u64,
+        limit: usize,
+    ) -> Result<Vec<StoredMessage>, StoreError> {
+        // `BTreeMap::range` panics on an inverted range, and this is reachable
+        // from a plain trait call, so it is guarded before the map is touched.
+        // `end` is an absolute bound here — 0 is a legitimately empty page, not
+        // "to infinity" — so no normalisation happens.
+        if begin == 0 || begin > end {
+            return Err(StoreError::InvalidRange { begin, end });
+        }
+
+        // A natively bounded read: `range` seeks to the first key at or after
+        // `begin` in O(log n) and `take` stops after `limit`, so the guard is
+        // held only for the page — never the whole history — and the allocation
+        // is capped at `limit`. Cloning a payload is a `Bytes` refcount bump.
+        let page: Vec<StoredMessage> = {
+            let messages = self.messages.read();
+            messages
+                .range(begin..=end)
+                .take(limit)
+                .map(|(seq_num, (msg_type, payload))| {
+                    StoredMessage::new(*seq_num, msg_type.clone(), payload.clone())
+                })
+                .collect()
+        };
+
+        // An empty page is a normal outcome for a sparse history: unlike
+        // `get_range`, the caller resolves it by advancing its cursor.
+        Ok(page)
     }
 
     fn next_sender_seq(&self) -> u64 {
@@ -140,8 +199,25 @@ impl MessageStore for MemoryStore {
 mod tests {
     use super::*;
 
+    /// Fails the test with context instead of `.unwrap()` / `.expect()`.
+    #[track_caller]
+    fn ok<T, E: std::fmt::Debug>(result: Result<T, E>, what: &str) -> T {
+        match result {
+            Ok(value) => value,
+            Err(err) => panic!("{what}: {err:?}"),
+        }
+    }
+
+    /// Files a message, failing the test if the store rejects it.
+    async fn put(store: &MemoryStore, seq: u64, msg_type: MsgType, payload: &[u8]) {
+        ok(
+            store.store(seq, &msg_type, payload).await,
+            "store must accept the message",
+        );
+    }
+
     #[tokio::test]
-    async fn test_memory_store_new() {
+    async fn test_memory_store_new_starts_at_sequence_one() {
         let store = MemoryStore::new();
         assert_eq!(store.next_sender_seq(), 1);
         assert_eq!(store.next_target_seq(), 1);
@@ -149,12 +225,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_memory_store_store_and_retrieve() {
+    async fn test_memory_store_store_and_retrieve_tracks_every_sequence() {
         let store = MemoryStore::new();
 
-        store.store(1, b"message1").await.unwrap();
-        store.store(2, b"message2").await.unwrap();
-        store.store(3, b"message3").await.unwrap();
+        put(&store, 1, MsgType::Logon, b"message1").await;
+        put(&store, 2, MsgType::NewOrderSingle, b"message2").await;
+        put(&store, 3, MsgType::Heartbeat, b"message3").await;
 
         assert_eq!(store.message_count(), 3);
         assert!(store.contains(1));
@@ -164,23 +240,207 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_memory_store_get_range() {
+    async fn test_memory_store_get_range_returns_only_stored_sequences() {
         let store = MemoryStore::new();
 
-        store.store(1, b"msg1").await.unwrap();
-        store.store(2, b"msg2").await.unwrap();
-        store.store(3, b"msg3").await.unwrap();
-        store.store(5, b"msg5").await.unwrap();
+        put(&store, 1, MsgType::Logon, b"msg1").await;
+        put(&store, 2, MsgType::NewOrderSingle, b"msg2").await;
+        put(&store, 3, MsgType::NewOrderSingle, b"msg3").await;
+        put(&store, 5, MsgType::NewOrderSingle, b"msg5").await;
 
-        let range = store.get_range(1, 3).await.unwrap();
-        assert_eq!(range.len(), 3);
+        let range = ok(store.get_range(1, 3).await, "range 1..=3 must resolve");
+        assert_eq!(
+            range.iter().map(StoredMessage::seq_num).collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
 
-        let range = store.get_range(2, 5).await.unwrap();
-        assert_eq!(range.len(), 3);
+        // 4 was never stored: the hole is simply absent, and the caller can
+        // see that from the sequence numbers it got back.
+        let range = ok(store.get_range(2, 5).await, "range 2..=5 must resolve");
+        assert_eq!(
+            range.iter().map(StoredMessage::seq_num).collect::<Vec<_>>(),
+            vec![2, 3, 5]
+        );
     }
 
     #[tokio::test]
-    async fn test_memory_store_sequence_numbers() {
+    async fn test_memory_store_get_range_preserves_msg_type_and_payload() {
+        let store = MemoryStore::new();
+        put(&store, 4, MsgType::NewOrderSingle, b"8=FIX.4.4\x0135=D\x01").await;
+
+        let range = ok(store.get_range(4, 4).await, "range 4..=4 must resolve");
+        let [message] = range.as_slice() else {
+            panic!("exactly one message must come back, got {}", range.len());
+        };
+
+        // The old implementation rebuilt every result with `MsgType::default()`
+        // (Heartbeat) and dropped the sequence key, so what came out was never
+        // what went in.
+        assert_eq!(message.seq_num(), 4);
+        assert_eq!(message.msg_type(), &MsgType::NewOrderSingle);
+        assert_eq!(&message.payload()[..], b"8=FIX.4.4\x0135=D\x01");
+    }
+
+    #[tokio::test]
+    async fn test_memory_store_get_range_inverted_is_invalid_range_not_a_panic() {
+        let store = MemoryStore::new();
+        put(&store, 1, MsgType::Logon, b"msg1").await;
+
+        // `BTreeMap::range(5..=3)` panics; under `panic = "abort"` that kills
+        // the process from a plain trait call.
+        assert_eq!(
+            store.get_range(5, 3).await,
+            Err(StoreError::InvalidRange { begin: 5, end: 3 })
+        );
+    }
+
+    #[tokio::test]
+    async fn test_memory_store_get_range_zero_begin_is_invalid_range() {
+        let store = MemoryStore::new();
+        put(&store, 1, MsgType::Logon, b"msg1").await;
+
+        // MsgSeqNum starts at 1, so 0 names no message.
+        assert_eq!(
+            store.get_range(0, 5).await,
+            Err(StoreError::InvalidRange { begin: 0, end: 5 })
+        );
+    }
+
+    #[tokio::test]
+    async fn test_memory_store_get_range_to_infinity_on_empty_store_is_range_not_available() {
+        let store = MemoryStore::new();
+
+        // `end` = 0 normalises to `u64::MAX`; the old code then computed
+        // `end + 1` for the error payload and overflowed.
+        assert_eq!(
+            store.get_range(5, 0).await,
+            Err(StoreError::RangeNotAvailable {
+                begin: 5,
+                end: u64::MAX,
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn test_memory_store_get_range_to_infinity_returns_everything_from_begin() {
+        let store = MemoryStore::new();
+        put(&store, 1, MsgType::Logon, b"msg1").await;
+        put(&store, 2, MsgType::NewOrderSingle, b"msg2").await;
+        put(&store, u64::MAX, MsgType::NewOrderSingle, b"last").await;
+
+        let range = ok(store.get_range(2, 0).await, "range 2..=inf must resolve");
+        assert_eq!(
+            range.iter().map(StoredMessage::seq_num).collect::<Vec<_>>(),
+            vec![2, u64::MAX]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_memory_store_get_range_with_no_match_is_range_not_available() {
+        let store = MemoryStore::new();
+        put(&store, 1, MsgType::Logon, b"msg1").await;
+
+        assert_eq!(
+            store.get_range(10, 20).await,
+            Err(StoreError::RangeNotAvailable { begin: 10, end: 20 })
+        );
+    }
+
+    #[tokio::test]
+    async fn test_memory_store_get_page_caps_at_limit() {
+        let store = MemoryStore::new();
+        for seq in 1..=10 {
+            put(&store, seq, MsgType::NewOrderSingle, b"msg").await;
+        }
+
+        // Only `limit` messages come back, starting at `begin`, even though the
+        // range holds more — the whole history is never materialised.
+        let page = ok(store.get_page(1, 10, 3).await, "first page must resolve");
+        assert_eq!(
+            page.iter().map(StoredMessage::seq_num).collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_memory_store_get_page_advances_across_pages() {
+        let store = MemoryStore::new();
+        for seq in 1..=7 {
+            put(&store, seq, MsgType::NewOrderSingle, b"msg").await;
+        }
+
+        // Walk the range in bounded pages the way the resend replay does: read a
+        // batch, then ask for the next one starting past the last seq seen, and
+        // stop once the cursor passes the upper bound.
+        const END: u64 = 7;
+        let mut seen = Vec::new();
+        let mut cursor = 1;
+        while cursor <= END {
+            let page = ok(store.get_page(cursor, END, 3).await, "page must resolve");
+            let Some(last) = page.last().map(StoredMessage::seq_num) else {
+                break;
+            };
+            seen.extend(page.iter().map(StoredMessage::seq_num));
+            let Some(next) = last.checked_add(1) else {
+                break;
+            };
+            cursor = next;
+        }
+        assert_eq!(seen, vec![1, 2, 3, 4, 5, 6, 7]);
+    }
+
+    #[tokio::test]
+    async fn test_memory_store_get_page_empty_range_is_ok_not_error() {
+        let store = MemoryStore::new();
+        put(&store, 1, MsgType::Logon, b"msg1").await;
+
+        // A hole in a sparse history: paging over it is normal, so an empty page
+        // is `Ok`, unlike `get_range` which treats an empty range as an error.
+        let page = ok(store.get_page(5, 9, 4).await, "empty page must resolve");
+        assert!(page.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_memory_store_get_page_zero_limit_is_empty_page() {
+        let store = MemoryStore::new();
+        put(&store, 1, MsgType::Logon, b"msg1").await;
+
+        let page = ok(
+            store.get_page(1, 5, 0).await,
+            "zero-limit page must resolve",
+        );
+        assert!(page.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_memory_store_get_page_inverted_is_invalid_range_not_a_panic() {
+        let store = MemoryStore::new();
+        put(&store, 1, MsgType::Logon, b"msg1").await;
+
+        // `BTreeMap::range(5..=3)` panics; the guard must fire before the map is
+        // touched, exactly as `get_range` does.
+        assert_eq!(
+            store.get_page(5, 3, 4).await,
+            Err(StoreError::InvalidRange { begin: 5, end: 3 })
+        );
+    }
+
+    #[tokio::test]
+    async fn test_memory_store_get_page_preserves_msg_type_and_payload() {
+        let store = MemoryStore::new();
+        put(&store, 4, MsgType::NewOrderSingle, b"8=FIX.4.4\x0135=D\x01").await;
+
+        let page = ok(store.get_page(4, 4, 8).await, "page must resolve");
+        let [message] = page.as_slice() else {
+            panic!("exactly one message must come back, got {}", page.len());
+        };
+        assert_eq!(message.seq_num(), 4);
+        assert_eq!(message.msg_type(), &MsgType::NewOrderSingle);
+        assert_eq!(&message.payload()[..], b"8=FIX.4.4\x0135=D\x01");
+    }
+
+    #[tokio::test]
+    async fn test_memory_store_sequence_numbers_round_trip() {
         let store = MemoryStore::new();
 
         store.set_next_sender_seq(10);
@@ -191,14 +451,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_memory_store_reset() {
+    async fn test_memory_store_reset_clears_messages_and_sequences() {
         let store = MemoryStore::new();
 
-        store.store(1, b"msg1").await.unwrap();
+        put(&store, 1, MsgType::Logon, b"msg1").await;
         store.set_next_sender_seq(10);
         store.set_next_target_seq(20);
 
-        store.reset().await.unwrap();
+        ok(store.reset().await, "reset must succeed");
 
         assert_eq!(store.message_count(), 0);
         assert_eq!(store.next_sender_seq(), 1);

--- a/ironfix-store/src/stored.rs
+++ b/ironfix-store/src/stored.rs
@@ -1,0 +1,104 @@
+/******************************************************************************
+   Author: Joaquín Béjar García
+   Email: jb@taunais.com
+   Date: 21/7/26
+******************************************************************************/
+
+//! The unit a [`MessageStore`](crate::MessageStore) hands back.
+//!
+//! A store exists so a `ResendRequest` (35=2) can be answered with the traffic
+//! that was actually sent. That makes faithfulness the whole contract: what
+//! comes out has to be what went in, still carrying the sequence number it was
+//! filed under and the `MsgType` it was sent as.
+//!
+//! [`StoredMessage`] therefore keeps the **verbatim frame bytes** rather than a
+//! parsed representation. `ironfix-store` depends on `ironfix-core` only — it
+//! has no decoder, so any structure it claimed to recover would be invented.
+//! The composition root (`ironfix-engine`) owns the decoder and re-reads the
+//! bytes when it needs fields.
+
+use bytes::Bytes;
+use ironfix_core::message::MsgType;
+
+/// One message as it was filed, returned by
+/// [`MessageStore::get_range`](crate::MessageStore::get_range).
+///
+/// The payload is the complete frame that went on the wire, including
+/// `BeginString` (8), `BodyLength` (9) and `CheckSum` (10). A resend rebuilds
+/// from it — stamping `PossDupFlag` (43) and `OrigSendingTime` (122) — so it
+/// must not be a reconstruction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredMessage {
+    /// The `MsgSeqNum` (34) this message was filed under.
+    seq_num: u64,
+    /// The `MsgType` (35) it was sent as, recorded at store time.
+    msg_type: MsgType,
+    /// The verbatim frame bytes.
+    payload: Bytes,
+}
+
+impl StoredMessage {
+    /// Creates a stored message from its sequence number, type and frame.
+    ///
+    /// # Arguments
+    /// * `seq_num` - The `MsgSeqNum` (34) the message was sent under
+    /// * `msg_type` - The `MsgType` (35) the message was sent as
+    /// * `payload` - The complete frame bytes
+    #[must_use]
+    pub const fn new(seq_num: u64, msg_type: MsgType, payload: Bytes) -> Self {
+        Self {
+            seq_num,
+            msg_type,
+            payload,
+        }
+    }
+
+    /// Returns the sequence number this message was filed under.
+    #[must_use]
+    pub const fn seq_num(&self) -> u64 {
+        self.seq_num
+    }
+
+    /// Returns the message type recorded at store time.
+    #[must_use]
+    pub const fn msg_type(&self) -> &MsgType {
+        &self.msg_type
+    }
+
+    /// Returns the verbatim frame bytes.
+    #[must_use]
+    pub const fn payload(&self) -> &Bytes {
+        &self.payload
+    }
+
+    /// Consumes the message and returns its frame bytes.
+    #[must_use]
+    pub fn into_payload(self) -> Bytes {
+        self.payload
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_stored_message_accessors_return_what_was_stored() {
+        let message = StoredMessage::new(
+            7,
+            MsgType::NewOrderSingle,
+            Bytes::from_static(b"8=FIX.4.4\x0135=D\x01"),
+        );
+
+        assert_eq!(message.seq_num(), 7);
+        assert_eq!(message.msg_type(), &MsgType::NewOrderSingle);
+        assert_eq!(&message.payload()[..], b"8=FIX.4.4\x0135=D\x01");
+    }
+
+    #[test]
+    fn test_stored_message_into_payload_returns_verbatim_bytes() {
+        let message = StoredMessage::new(1, MsgType::Logon, Bytes::from_static(b"8=FIX.4.4\x01"));
+
+        assert_eq!(&message.into_payload()[..], b"8=FIX.4.4\x01");
+    }
+}

--- a/ironfix-store/src/traits.rs
+++ b/ironfix-store/src/traits.rs
@@ -8,9 +8,10 @@
 //!
 //! This module defines the abstract interface for message storage implementations.
 
+use crate::stored::StoredMessage;
 use async_trait::async_trait;
 use ironfix_core::error::StoreError;
-use ironfix_core::message::OwnedMessage;
+use ironfix_core::message::MsgType;
 
 /// Abstract interface for FIX message storage.
 ///
@@ -20,26 +21,104 @@ use ironfix_core::message::OwnedMessage;
 pub trait MessageStore: Send + Sync {
     /// Stores an outgoing message for potential resend.
     ///
+    /// `msg_type` is passed in rather than parsed out of `message`: this crate
+    /// depends on `ironfix-core` only and owns no decoder, and a store that
+    /// guessed the type would hand back a message that is not the one that was
+    /// filed. The caller has already encoded the frame and knows its type.
+    ///
+    /// `message` must be the **complete frame**, from `BeginString` (8) through
+    /// `CheckSum` (10), because a resend rebuilds from it verbatim.
+    ///
     /// # Arguments
-    /// * `seq_num` - The message sequence number
-    /// * `message` - The raw message bytes
+    /// * `seq_num` - The `MsgSeqNum` (34) the message was sent under
+    /// * `msg_type` - The `MsgType` (35) the message was sent as
+    /// * `message` - The complete raw frame bytes
     ///
     /// # Errors
     /// Returns `StoreError` if the message cannot be stored.
-    async fn store(&self, seq_num: u64, message: &[u8]) -> Result<(), StoreError>;
+    async fn store(
+        &self,
+        seq_num: u64,
+        msg_type: &MsgType,
+        message: &[u8],
+    ) -> Result<(), StoreError>;
 
     /// Retrieves messages for a resend request.
+    ///
+    /// The result is ordered by sequence number and may be **sparse**: a range
+    /// covering sequence numbers that were never stored, or have been evicted,
+    /// yields only what is present. Each [`StoredMessage`] carries the sequence
+    /// number it was filed under, so a caller can tell exactly which numbers it
+    /// received and gap-fill the holes.
     ///
     /// # Arguments
     /// * `begin` - Begin sequence number (inclusive)
     /// * `end` - End sequence number (inclusive, or 0 for infinity)
     ///
     /// # Returns
-    /// A vector of messages in the requested range.
+    /// The stored messages inside the requested range, in ascending sequence
+    /// order.
     ///
     /// # Errors
-    /// Returns `StoreError` if messages cannot be retrieved.
-    async fn get_range(&self, begin: u64, end: u64) -> Result<Vec<OwnedMessage>, StoreError>;
+    /// Returns [`StoreError::InvalidRange`] if `begin` is above `end` (with
+    /// `end` = 0 meaning infinity, which is never below `begin`), or `begin`
+    /// is 0, which is not a legal `MsgSeqNum`;
+    /// [`StoreError::RangeNotAvailable`] if the range is legal but holds no
+    /// stored message at all; or another `StoreError` if retrieval fails.
+    ///
+    /// An entirely empty range is an error rather than an empty vector so a
+    /// caller cannot mistake "nothing was stored" for "nothing was asked for".
+    async fn get_range(&self, begin: u64, end: u64) -> Result<Vec<StoredMessage>, StoreError>;
+
+    /// Reads at most `limit` stored messages inside `begin..=end`, in ascending
+    /// sequence order, starting at or after `begin`.
+    ///
+    /// This is the paging primitive a resend replays over: answering a
+    /// `ResendRequest` (35=2) whose `EndSeqNo` (16) = 0 means "replay the whole
+    /// session", and materialising an entire long history in one
+    /// [`get_range`](MessageStore::get_range) call would allocate it all at once
+    /// and, for a lock-based store, hold the lock across the whole build. A
+    /// caller pages instead: it reads one bounded batch, replays it, yields, and
+    /// asks for the next batch starting past the last sequence number it saw.
+    ///
+    /// Unlike [`get_range`](MessageStore::get_range), an **empty page is not an
+    /// error**: paging over a sparse history naturally lands on stretches that
+    /// hold nothing, and the caller tells "this page is empty" from "the range
+    /// is exhausted" by advancing its own cursor. `end` here is an absolute
+    /// bound — `0` does **not** mean infinity, because the caller has already
+    /// resolved that to the last sequence number it actually sent.
+    ///
+    /// # Arguments
+    /// * `begin` - First sequence number to read from, inclusive
+    /// * `end` - Last sequence number to read, inclusive
+    /// * `limit` - Maximum number of messages to return; `0` yields an empty page
+    ///
+    /// # Errors
+    /// Returns [`StoreError::InvalidRange`] if `begin` is 0 or above `end`, or
+    /// another `StoreError` if retrieval fails. An empty result is `Ok`, not an
+    /// error.
+    ///
+    /// The default implementation materialises the whole range through
+    /// [`get_range`](MessageStore::get_range) and truncates it; a store whose
+    /// history can be large should override this with a natively bounded read so
+    /// one resend cannot allocate the entire history.
+    async fn get_page(
+        &self,
+        begin: u64,
+        end: u64,
+        limit: usize,
+    ) -> Result<Vec<StoredMessage>, StoreError> {
+        match self.get_range(begin, end).await {
+            Ok(mut messages) => {
+                messages.truncate(limit);
+                Ok(messages)
+            }
+            // An empty range is `get_range`'s error; for a page it is a normal,
+            // non-terminal outcome the caller resolves by advancing its cursor.
+            Err(StoreError::RangeNotAvailable { .. }) => Ok(Vec::new()),
+            Err(other) => Err(other),
+        }
+    }
 
     /// Returns the next sender sequence number.
     fn next_sender_seq(&self) -> u64;
@@ -85,11 +164,20 @@ mod tests {
 
     #[async_trait]
     impl MessageStore for MockStore {
-        async fn store(&self, _seq_num: u64, _message: &[u8]) -> Result<(), StoreError> {
+        async fn store(
+            &self,
+            _seq_num: u64,
+            _msg_type: &MsgType,
+            _message: &[u8],
+        ) -> Result<(), StoreError> {
             Ok(())
         }
 
-        async fn get_range(&self, _begin: u64, _end: u64) -> Result<Vec<OwnedMessage>, StoreError> {
+        async fn get_range(
+            &self,
+            _begin: u64,
+            _end: u64,
+        ) -> Result<Vec<StoredMessage>, StoreError> {
             Ok(vec![])
         }
 
@@ -119,7 +207,7 @@ mod tests {
         let store = MockStore;
         assert_eq!(store.next_sender_seq(), 1);
         assert_eq!(store.next_target_seq(), 1);
-        assert!(store.store(1, b"test").await.is_ok());
+        assert!(store.store(1, &MsgType::Heartbeat, b"test").await.is_ok());
         assert!(store.reset().await.is_ok());
     }
 }


### PR DESCRIPTION
## Summary

Makes `MemoryStore` sound and wires it into the engine, so a ResendRequest replays real messages instead of gap-filling the whole range.

Closes #15.

## Stack

- **Base branch:** `stack/12-tagvalue-encoder` (PR #36)

## Part one — the store could panic and lied about what it stored

`get_range` **panicked through a public API**: an open-ended range mapped zero to `u64::MAX` and the following `end + 1` overflowed, while an inverted range made `BTreeMap::range` panic outright. Under `panic = "abort"` either one kills the caller's process.

Worse, for a type whose entire job is faithful replay: returned messages were reassembled with a **fabricated `MsgType`**, so what came out was not what went in.

## Part two — the engine never used the store at all

An inbound ResendRequest was answered with a single blanket `SequenceReset-GapFill` covering the whole requested range, so **no application message was ever replayed**. The spec's Resend Request section asks for four things — retrieve from the store, resend with `PossDupFlag=Y`, gap-fill administrative messages, preserve `OrigSendingTime` — and three were missing.

Now: outbound messages are persisted as they are sent, and a ResendRequest replays the stored application messages in range carrying `43=Y` and the **original** `SendingTime` in `122`. That is why part one had to be fixed first — replaying a message reassembled with a fabricated MsgType would have been worse than not replaying it.

Administrative messages, and any sequence number the store cannot satisfy (evicted, never stored, store error), are gap-filled — which is what the spec asks for, so a range with holes still leaves the counterparty synchronised rather than silently skipped.

## What did not change

The reply's own framing: a gap fill still carries `MsgSeqNum = BeginSeqNo` and allocates no sender sequence number, because it occupies the range it replaces. The bounds from #25 — tags 7 and 16 validated, `16=0` as infinity, `min(EndSeqNo + 1, next_sender)` — are intact and still tested.

## Two limits, stated rather than left to be discovered

- **The store is opt-in.** Without one attached, the whole range is still answered with a single gap fill, exactly as before.
- **`MemoryStore` is not persistent.** Nothing is replayable after a restart.

Both are in `doc/fix_operations.md`, and the Phase 1 "Resend Request" entry is ticked with them attached rather than ticked bare.

## Tests

Workspace goes to **428 passing**, including an end-to-end test that drives a stub acceptor sending a ResendRequest and asserts the replayed messages carry `43=Y` and `122` with the original sending time — not merely that something was sent.

## Verification

```
cargo test --workspace                                    # 428 passed
cargo clippy --all-targets --all-features -- -D warnings  # clean
cargo fmt --all --check                                   # clean
make doc                                                  # clean
```
