### PR TITLE
fix(engine): make the outbound and callback paths do what they promise

### DIFF
--- a/ironfix-engine/src/application.rs
+++ b/ironfix-engine/src/application.rs
@@ -9,8 +9,9 @@
 //! This module defines the callback interface for handling FIX messages,
 //! following the QuickFIX pattern with async support.
 
+use crate::outbound::OutboundMessage;
 use async_trait::async_trait;
-use ironfix_core::message::{OwnedMessage, RawMessage};
+use ironfix_core::message::RawMessage;
 
 /// Session identifier.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -103,6 +104,29 @@ impl RejectReason {
 ///
 /// Implement this trait to receive callbacks for session events
 /// and message processing.
+///
+/// # Where each callback runs
+///
+/// [`Application::to_admin`] and [`Application::to_app`] run **inline in the
+/// session reactor**, on the message the engine is about to encode and
+/// number. That is what makes their mutations effective, and it is why they
+/// cannot be moved off the reactor: the message they hand back is the one that
+/// gets a sequence number. A slow implementation delays the session's own
+/// timers.
+///
+/// [`Application::from_admin`] also runs inline, because its verdict decides
+/// what the session does next — whether a `SequenceReset` is applied, whether
+/// the Logon is accepted — and that decision cannot be taken before the
+/// verdict exists.
+///
+/// [`Application::from_app`] runs on a **separate dispatcher task** fed by a
+/// bounded queue, so a slow handler no longer stalls socket reads, heartbeat
+/// generation or timeout detection. Messages reach it in ascending
+/// `MsgSeqNum` order. The only consequence of a rejection — a session-level
+/// Reject carrying `RefSeqNum` — is emitted by the reactor when it next polls,
+/// so it may follow messages that arrived after the rejected one. See
+/// [`Initiator::with_app_queue_capacity`](crate::Initiator::with_app_queue_capacity)
+/// for the queue depth and what happens when it fills.
 #[async_trait]
 pub trait Application: Send + Sync {
     /// Called when a session is created.
@@ -123,14 +147,26 @@ pub trait Application: Send + Sync {
     /// * `session_id` - The session identifier
     async fn on_logout(&self, session_id: &SessionId);
 
-    /// Called before sending an admin message.
+    /// Called before an administrative message (Logon, Heartbeat, Logout, …)
+    /// is encoded.
     ///
-    /// Allows modification of outgoing admin messages (Logon, Heartbeat, etc.).
+    /// The body is mutable and the mutation is effective: the engine encodes
+    /// exactly the message this callback hands back. Fields appended here land
+    /// after the ones the session layer wrote, in insertion order. The
+    /// canonical use is stamping `Username` (553) and `Password` (554) onto the
+    /// outbound Logon.
+    ///
+    /// The standard header is not visible: it is stamped after this returns,
+    /// and `MsgSeqNum` (34) is not decided until the frame exists. A body that
+    /// carries a tag the engine stamps itself, or a value with no legal wire
+    /// form, is refused — the message is dropped with a warning and the session
+    /// continues, having spent no sequence number. See
+    /// [`crate::outbound::RESERVED_TAGS`].
     ///
     /// # Arguments
-    /// * `message` - The message to be sent (mutable)
+    /// * `message` - The message about to be encoded (mutable)
     /// * `session_id` - The session identifier
-    async fn to_admin(&self, message: &mut OwnedMessage, session_id: &SessionId);
+    async fn to_admin(&self, message: &mut OutboundMessage, session_id: &SessionId);
 
     /// Called when an admin message is received.
     ///
@@ -147,14 +183,16 @@ pub trait Application: Send + Sync {
         session_id: &SessionId,
     ) -> Result<(), RejectReason>;
 
-    /// Called before sending an application message.
+    /// Called before an application message is encoded.
     ///
-    /// Allows modification of outgoing application messages.
+    /// Same contract as [`Application::to_admin`]: the body is mutable, the
+    /// mutation is effective, and the header — including `MsgSeqNum` (34) — is
+    /// stamped afterwards.
     ///
     /// # Arguments
-    /// * `message` - The message to be sent (mutable)
+    /// * `message` - The message about to be encoded (mutable)
     /// * `session_id` - The session identifier
-    async fn to_app(&self, message: &mut OwnedMessage, session_id: &SessionId);
+    async fn to_app(&self, message: &mut OutboundMessage, session_id: &SessionId);
 
     /// Called when an application message is received.
     ///
@@ -184,7 +222,7 @@ impl Application for NoOpApplication {
 
     async fn on_logout(&self, _session_id: &SessionId) {}
 
-    async fn to_admin(&self, _message: &mut OwnedMessage, _session_id: &SessionId) {}
+    async fn to_admin(&self, _message: &mut OutboundMessage, _session_id: &SessionId) {}
 
     async fn from_admin(
         &self,
@@ -194,7 +232,7 @@ impl Application for NoOpApplication {
         Ok(())
     }
 
-    async fn to_app(&self, _message: &mut OwnedMessage, _session_id: &SessionId) {}
+    async fn to_app(&self, _message: &mut OutboundMessage, _session_id: &SessionId) {}
 
     async fn from_app(
         &self,

--- a/ironfix-engine/src/connection.rs
+++ b/ironfix-engine/src/connection.rs
@@ -41,6 +41,14 @@ pub(crate) struct SessionRuntime {
 /// Cloning is cheap; all clones refer to the same session. The session is
 /// closed when the transport drops, the counterparty logs out, a heartbeat
 /// timeout is detected, or [`Connection::logout`] completes.
+///
+/// # Dropping every handle logs out
+///
+/// The reactor stops when the last clone is dropped: it reads that as "nobody
+/// can drive this session any more" and performs a graceful Logout rather than
+/// leaving a task holding a socket forever. A consumer that wants the session
+/// to outlive its handle must keep one alive — typically by holding it until
+/// [`Connection::wait_closed`] returns.
 #[derive(Debug, Clone)]
 pub struct Connection {
     /// Session identifier.
@@ -63,14 +71,34 @@ impl Connection {
     /// Sends an application message on the session.
     ///
     /// The engine stamps the standard header (including MsgSeqNum) and
-    /// trailer; the message only needs body fields.
+    /// trailer; the message only needs body fields. It is checked here, before
+    /// it is queued, so a message the session layer will not carry is refused
+    /// to the caller rather than dropped later.
     ///
     /// # Arguments
     /// * `message` - The application message to send
     ///
     /// # Errors
-    /// Returns [`EngineError::Closed`] if the session is already closed.
+    /// * [`EngineError::ReservedMsgType`] for an administrative MsgType.
+    ///   Logon, Logout, SequenceReset and the rest belong to the session state
+    ///   machine; one sent here would bypass the typestate and the engine's
+    ///   phase tracking — a Logout sent this way never arms the logout timeout.
+    /// * [`EngineError::ReservedTag`] for a body field that repeats a tag the
+    ///   engine stamps itself (see [`crate::outbound::RESERVED_TAGS`]), which
+    ///   would put two occurrences of it in the frame.
+    /// * [`EngineError::InvalidField`] for a value with no legal wire form.
+    /// * [`EngineError::Closed`] if the session is already closed.
+    ///
+    /// # Accepted is not sent
+    ///
+    /// `Ok` means the message was queued for the reactor, not that it reached
+    /// the counterparty. A message queued while a Logout is already pending is
+    /// dropped with a warning — the session is on its way out and a new
+    /// application message would arrive after the Logout the counterparty has
+    /// already seen. Use [`Connection::wait_closed`] to observe the end of the
+    /// session and `next_sender_seq` to observe progress.
     pub async fn send(&self, message: OutboundMessage) -> Result<(), EngineError> {
+        crate::outbound::check_sendable(&message)?;
         self.commands
             .send(Command::Send(message))
             .await
@@ -97,6 +125,11 @@ impl Connection {
     /// Fires on transport drop, counterparty logout, heartbeat timeout, or
     /// completion of a locally initiated logout. Returns immediately if the
     /// session is already closed.
+    ///
+    /// It fires **after** the inbound application messages already queued have
+    /// been through `from_app` and `on_logout` has run, so a handler still in
+    /// flight when the session ends delays this by however long it takes to
+    /// finish, up to an internal drain bound.
     pub async fn wait_closed(&self) {
         let mut closed = self.closed.clone();
         // An error means the reactor is gone, which also means closed.
@@ -113,10 +146,16 @@ impl Connection {
     /// (a TestRequest went unanswered for a full heartbeat interval).
     #[must_use]
     pub fn is_timed_out(&self) -> bool {
+        // A poisoned lock means a previous holder panicked. The heartbeat state
+        // is plain timestamps with no invariant a panic could leave
+        // half-applied, so the guard is recovered rather than propagated:
+        // taking the consumer's process down over a heartbeat timestamp — and
+        // under `panic = "abort"` that is what propagating means — is never the
+        // right trade.
         self.runtime
             .heartbeat
             .lock()
-            .expect("heartbeat lock poisoned")
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .is_timed_out()
     }
 

--- a/ironfix-engine/src/error.rs
+++ b/ironfix-engine/src/error.rs
@@ -153,6 +153,69 @@ pub enum EngineError {
     #[error("store error: {0}")]
     Store(#[from] StoreError),
 
+    /// A write to the counterparty did not complete within the write timeout.
+    ///
+    /// A peer that stops reading parks a socket write forever once its receive
+    /// window closes, which would take the reactor's liveness timers with it.
+    /// The write is therefore bounded and its expiry closes the session, which
+    /// is the same verdict heartbeat detection would have reached.
+    #[error("write timed out after {0:?}")]
+    WriteTimeout(Duration),
+
+    /// An administrative MsgType was offered on the application send path.
+    ///
+    /// Logon (A), Logout (5), SequenceReset (4) and the rest of the
+    /// administrative set belong to the session state machine. One emitted
+    /// through [`Connection::send`](crate::Connection::send) would bypass the
+    /// typestate and the engine's phase tracking — a Logout sent that way, for
+    /// instance, never arms the logout timeout.
+    #[error("MsgType {msg_type} is administrative and belongs to the session layer")]
+    ReservedMsgType {
+        /// The offered MsgType (tag 35) value.
+        msg_type: String,
+    },
+
+    /// An outbound body carried a tag the engine stamps itself.
+    ///
+    /// See [`crate::outbound::RESERVED_TAGS`]. The frame would carry two
+    /// occurrences of the tag, which a conforming counterparty rejects or
+    /// misparses.
+    #[error(
+        "tag {tag} is stamped by the engine's standard header or trailer and must not be set on \
+         an outbound message"
+    )]
+    ReservedTag {
+        /// The offending tag.
+        tag: u32,
+    },
+
+    /// An outbound field value has no legal wire form.
+    ///
+    /// The reason never quotes the value: an outbound Logon body carries
+    /// `Password` (554) and `NewPassword` (925).
+    #[error("invalid outbound field {tag}: {reason}")]
+    InvalidField {
+        /// The offending tag.
+        tag: u32,
+        /// Why the value cannot be framed.
+        reason: String,
+    },
+
+    /// An administrative message lost a field its MsgType cannot go out without.
+    ///
+    /// A `to_admin` callback removed a required body field — `HeartBtInt` (108)
+    /// from a Logon, `TestReqID` (112) from a TestRequest, `NewSeqNo` (36) from
+    /// a SequenceReset, and the like. Emitting the message anyway would put a
+    /// malformed administrative frame on the wire that a conforming
+    /// counterparty rejects; the session refuses it instead.
+    #[error("administrative message {msg_type} is missing required field {tag}")]
+    MissingRequiredField {
+        /// The administrative MsgType (tag 35) value.
+        msg_type: String,
+        /// The required tag that is absent.
+        tag: u32,
+    },
+
     /// The connection is closed; no more messages can be sent.
     #[error("connection closed")]
     Closed,

--- a/ironfix-engine/src/initiator.rs
+++ b/ironfix-engine/src/initiator.rs
@@ -63,7 +63,28 @@
 //! All sequence arithmetic goes through the checked
 //! [`SequenceManager::try_allocate_sender_seq`] /
 //! [`SequenceManager::try_increment_target_seq`]; an exhausted counter tears
-//! the session down rather than wrapping.
+//! the session down rather than wrapping. A sender number is spent only once
+//! the frame that carries it exists, so a body with no legal wire form is a
+//! dropped message rather than a hole the counterparty must resend over.
+//!
+//! # What blocks the reactor, and what does not
+//!
+//! The reactor is a single task owning the socket. Two things used to be able
+//! to park it indefinitely, and neither can now:
+//!
+//! - **A stalled peer.** A counterparty that stops reading closes its receive
+//!   window and parks a socket write forever. Every write is therefore bounded
+//!   by [`Initiator::with_write_timeout`], and its expiry closes the session —
+//!   the same verdict heartbeat detection would have reached, reached in
+//!   bounded time.
+//! - **A slow `from_app`.** Inbound application messages are handed to a
+//!   separate dispatcher task over a bounded queue
+//!   ([`Initiator::with_app_queue_capacity`]), so an application handler never
+//!   delays a socket read, a heartbeat, or timeout detection.
+//!
+//! `to_admin`, `to_app` and `from_admin` still run inline, because each one's
+//! result decides what the reactor does next. See [`Application`] for the
+//! ordering that buys and the ordering it costs.
 //!
 //! # Example
 //!
@@ -97,8 +118,9 @@
 use crate::application::{Application, NoOpApplication, RejectReason, SessionId};
 use crate::connection::{Command, Connection, SessionRuntime};
 use crate::error::EngineError;
-use crate::wire::{self, MessageFactory, PeerIdentity, UnsupportedVersion};
-use bytes::BytesMut;
+use crate::outbound;
+use crate::wire::{self, MessageFactory, PeerIdentity, PendingMessage, UnsupportedVersion};
+use bytes::{Bytes, BytesMut};
 use futures_util::{SinkExt, StreamExt};
 use ironfix_core::error::{DecodeError, EncodeError};
 use ironfix_core::message::{MsgType, RawMessage};
@@ -117,6 +139,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::net::{TcpStream, ToSocketAddrs};
 use tokio::sync::{mpsc, watch};
+use tokio::task::JoinHandle;
 use tokio::time::{MissedTickBehavior, interval, timeout};
 use tokio_util::codec::Framed;
 
@@ -125,6 +148,27 @@ type FixFramed = Framed<TcpStream, FixCodec>;
 
 /// Default capacity of the outbound command queue.
 const DEFAULT_OUTBOUND_CAPACITY: usize = 1024;
+
+/// Default capacity of the inbound application queue, in messages.
+///
+/// The queue is bounded by message **count**, not bytes, and each entry retains
+/// its whole frame (a reference-counted [`Bytes`] up to
+/// [`SessionConfig::max_message_size`]). The worst-case retained memory is
+/// therefore `capacity * max_message_size`: with the defaults, 1024 * 1 MiB =
+/// 1 GiB, and up to 1024 * 64 MiB = 64 GiB if `max_message_size` is raised to
+/// its ceiling. See [`Initiator::with_app_queue_capacity`] to size it.
+const DEFAULT_APP_QUEUE_CAPACITY: usize = 1024;
+
+/// Default bound on a single socket write.
+const DEFAULT_WRITE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// How long the reactor waits for the application dispatcher to finish the
+/// messages already queued before it reports the session closed.
+///
+/// The dispatcher always terminates — its queue is closed when the reactor
+/// drops the sender — so this only bounds how long `on_logout` waits to follow
+/// the last `from_app` rather than run beside it.
+const APP_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Reactor tick granularity for heartbeat/timeout checks.
 const TICK_INTERVAL: Duration = Duration::from_millis(100);
@@ -159,10 +203,14 @@ pub struct Initiator<A: Application = NoOpApplication> {
     config_check: Result<(), SessionConfigError>,
     /// TCP connect timeout.
     connect_timeout: Duration,
+    /// Bound on a single socket write.
+    write_timeout: Duration,
     /// Initial (sender, target) sequence numbers for session continuity.
     initial_sequences: Option<(u64, u64)>,
     /// Capacity of the outbound command queue.
     outbound_capacity: usize,
+    /// Capacity of the inbound application queue.
+    app_queue_capacity: usize,
     /// Optional message store: outbound frames are filed here and replayed
     /// from here when the counterparty asks for a resend.
     store: Option<Arc<dyn MessageStore>>,
@@ -177,8 +225,10 @@ impl<A: Application> std::fmt::Debug for Initiator<A> {
             .field("session_id", &self.session_id)
             .field("version", &self.version)
             .field("connect_timeout", &self.connect_timeout)
+            .field("write_timeout", &self.write_timeout)
             .field("initial_sequences", &self.initial_sequences)
             .field("outbound_capacity", &self.outbound_capacity)
+            .field("app_queue_capacity", &self.app_queue_capacity)
             .field("store", &self.store.is_some())
             .finish_non_exhaustive()
     }
@@ -218,8 +268,10 @@ impl<A: Application + 'static> Initiator<A> {
             version,
             config_check,
             connect_timeout: Duration::from_secs(30),
+            write_timeout: DEFAULT_WRITE_TIMEOUT,
             initial_sequences: None,
             outbound_capacity: DEFAULT_OUTBOUND_CAPACITY,
+            app_queue_capacity: DEFAULT_APP_QUEUE_CAPACITY,
             store: None,
         }
     }
@@ -254,6 +306,54 @@ impl<A: Application + 'static> Initiator<A> {
     #[must_use]
     pub fn with_connect_timeout(mut self, timeout: Duration) -> Self {
         self.connect_timeout = timeout;
+        self
+    }
+
+    /// Sets how long a single socket write may take before the session is
+    /// closed (default 10s).
+    ///
+    /// A counterparty that stops reading closes its TCP receive window, and a
+    /// write into a closed window never completes. Without a bound the reactor
+    /// parks inside that write with its liveness timers, so the session hangs
+    /// instead of being declared dead. Expiry closes the session with
+    /// [`EngineError::WriteTimeout`].
+    ///
+    /// A zero timeout is raised to one tick: a write that is given no time at
+    /// all can never succeed.
+    ///
+    /// # Arguments
+    /// * `timeout` - Maximum duration of one write
+    #[must_use]
+    pub fn with_write_timeout(mut self, timeout: Duration) -> Self {
+        self.write_timeout = timeout.max(TICK_INTERVAL);
+        self
+    }
+
+    /// Sets the capacity of the inbound application queue (default 1024).
+    ///
+    /// Inbound application messages are handed to a dispatcher task over this
+    /// queue so that a slow [`Application::from_app`] cannot stall socket
+    /// reads or heartbeat generation. Messages are delivered in ascending
+    /// `MsgSeqNum` order.
+    ///
+    /// **Lag policy:** when the queue is full the session is closed rather than
+    /// the message silently dropped. The frame is offered to the dispatcher
+    /// *before* the inbound sequence expectation advances past it, so the close
+    /// leaves the counterparty free to resend from that number. Raise the
+    /// capacity for an application that legitimately bursts.
+    ///
+    /// **Memory:** the bound is on message count, not bytes, and each queued
+    /// frame retains up to [`SessionConfig::max_message_size`]. The worst-case
+    /// retained memory is `capacity * max_message_size` — with the default
+    /// capacity of 1024 that is 1 GiB at the default 1 MiB frame size and 64 GiB
+    /// at the 64 MiB ceiling — so raise this and `max_message_size` together
+    /// with that product in mind.
+    ///
+    /// # Arguments
+    /// * `capacity` - Queue depth in messages, at least 1
+    #[must_use]
+    pub fn with_app_queue_capacity(mut self, capacity: usize) -> Self {
+        self.app_queue_capacity = capacity.max(1);
         self
     }
 
@@ -368,6 +468,15 @@ impl<A: Application + 'static> Initiator<A> {
     /// owns the socket and handles heartbeats, TestRequests, sequence
     /// validation, and admin replies until the session closes.
     ///
+    /// # Dropping the handle logs out
+    ///
+    /// The reactor stops when the last [`Connection`] clone is dropped: it
+    /// reads that as "nobody can drive this session any more" and performs a
+    /// graceful Logout rather than leaving a task holding a socket forever.
+    /// A consumer that wants the session to outlive its handle must keep one
+    /// alive — typically by holding it until [`Connection::wait_closed`]
+    /// returns.
+    ///
     /// # Arguments
     /// * `addr` - The counterparty address to dial
     ///
@@ -461,38 +570,34 @@ impl<A: Application + 'static> Initiator<A> {
             sequences,
             heartbeat: Mutex::new(HeartbeatManager::new(self.config.heartbeat_interval)),
         });
-        let factory = MessageFactory::new(&self.config, version);
+        let mut factory = MessageFactory::new(&self.config, version);
         let identity = PeerIdentity::new(&self.config);
+        let write_timeout = self.write_timeout;
+        let store = self.store.as_ref();
 
         // Typestate: Connecting -> LogonSent.
-        let seq = match runtime.sequences.try_allocate_sender_seq() {
-            Ok(seq) => seq.value(),
-            Err(err) => {
-                let _ = session.disconnect();
-                return Err(err.into());
-            }
-        };
-        // Mirror the advanced sender counter into the store before the Logon —
-        // the first numbered frame of the session — reaches the wire, so a store
-        // reused across a reconnect cannot report a number the peer has seen.
-        mirror_sender_seq(self.store.as_ref(), &runtime.sequences);
+        //
+        // `to_admin` runs on the message before it is framed, so a stamped
+        // Username/Password reaches the wire — the callback's whole purpose.
         let logon = factory.logon(
-            seq,
             self.config.heartbeat_interval_secs(),
             self.config.reset_on_logon,
-        )?;
-        if let Ok(mut owned) = wire::owned_from_frame(&logon) {
-            self.application.to_admin(&mut owned, &session_id).await;
-        }
-        persist_outbound(
-            self.store.as_ref(),
+        );
+        if let Err(err) = send_handshake_admin(
+            self.application.as_ref(),
             &session_id,
-            seq,
-            &MsgType::Logon,
-            &logon,
+            &mut framed,
+            &mut factory,
+            &runtime.sequences,
+            store,
+            write_timeout,
+            logon,
         )
-        .await;
-        framed.send(logon).await?;
+        .await
+        {
+            let _ = session.disconnect();
+            return Err(err);
+        }
         lock_heartbeat(&runtime).on_message_sent();
         let session = session.send_logon();
 
@@ -565,45 +670,53 @@ impl<A: Application + 'static> Initiator<A> {
             if let Err(mismatch) = identity.validate(&raw) {
                 let detail = mismatch.to_string();
                 let reason = RejectReason::new(9, detail.clone()).with_ref_tag(mismatch.tag);
-                if let Ok(out_seq) = runtime.sequences.try_allocate_sender_seq()
-                    && let Ok(reject) = factory.session_reject(
-                        out_seq.value(),
-                        ack_seq,
-                        MsgType::Logon.as_str(),
-                        &reason,
-                    )
-                {
-                    mirror_sender_seq(self.store.as_ref(), &runtime.sequences);
-                    let _ = framed.send(reject).await;
-                }
-                if let Ok(out_seq) = runtime.sequences.try_allocate_sender_seq()
-                    && let Ok(logout) = factory.logout(out_seq.value(), Some(&detail))
-                {
-                    mirror_sender_seq(self.store.as_ref(), &runtime.sequences);
-                    let _ = framed.send(logout).await;
-                }
+                let reject = factory.session_reject(ack_seq, MsgType::Logon.as_str(), &reason);
+                let _ = send_handshake_admin(
+                    self.application.as_ref(),
+                    &session_id,
+                    &mut framed,
+                    &mut factory,
+                    &runtime.sequences,
+                    store,
+                    write_timeout,
+                    reject,
+                )
+                .await;
+                let logout = factory.logout(Some(&detail));
+                let _ = send_handshake_admin(
+                    self.application.as_ref(),
+                    &session_id,
+                    &mut framed,
+                    &mut factory,
+                    &runtime.sequences,
+                    store,
+                    write_timeout,
+                    logout,
+                )
+                .await;
                 let _ = session.on_logon_reject();
                 return Err(EngineError::IdentityMismatch { detail });
             }
 
             if let Err(reason) = self.application.from_admin(&raw, &session_id).await {
-                match runtime.sequences.try_allocate_sender_seq() {
-                    Ok(seq) => match factory.logout(seq.value(), Some(&reason.text)) {
-                        Ok(logout) => {
-                            mirror_sender_seq(self.store.as_ref(), &runtime.sequences);
-                            let _ = framed.send(logout).await;
-                        }
-                        Err(err) => tracing::warn!(
-                            session = %session_id,
-                            error = %err,
-                            "cannot encode Logout after from_admin rejection"
-                        ),
-                    },
-                    Err(err) => tracing::warn!(
+                let logout = factory.logout(Some(&reason.text));
+                if let Err(err) = send_handshake_admin(
+                    self.application.as_ref(),
+                    &session_id,
+                    &mut framed,
+                    &mut factory,
+                    &runtime.sequences,
+                    store,
+                    write_timeout,
+                    logout,
+                )
+                .await
+                {
+                    tracing::warn!(
                         session = %session_id,
                         error = %err,
                         "cannot send Logout after from_admin rejection"
-                    ),
+                    );
                 }
                 let _ = session.on_logon_reject();
                 return Err(EngineError::LogonRejected {
@@ -639,21 +752,30 @@ impl<A: Application + 'static> Initiator<A> {
                         (6, err.to_string())
                     };
                     let reason = RejectReason::new(code, detail.clone()).with_ref_tag(108);
-                    if let Ok(out_seq) = runtime.sequences.try_allocate_sender_seq()
-                        && let Ok(reject) = factory.session_reject(
-                            out_seq.value(),
-                            ack_seq,
-                            MsgType::Logon.as_str(),
-                            &reason,
-                        )
-                    {
-                        let _ = framed.send(reject).await;
-                    }
-                    if let Ok(out_seq) = runtime.sequences.try_allocate_sender_seq()
-                        && let Ok(logout) = factory.logout(out_seq.value(), Some(&detail))
-                    {
-                        let _ = framed.send(logout).await;
-                    }
+                    let reject = factory.session_reject(ack_seq, MsgType::Logon.as_str(), &reason);
+                    let _ = send_handshake_admin(
+                        self.application.as_ref(),
+                        &session_id,
+                        &mut framed,
+                        &mut factory,
+                        &runtime.sequences,
+                        store,
+                        write_timeout,
+                        reject,
+                    )
+                    .await;
+                    let logout = factory.logout(Some(&detail));
+                    let _ = send_handshake_admin(
+                        self.application.as_ref(),
+                        &session_id,
+                        &mut framed,
+                        &mut factory,
+                        &runtime.sequences,
+                        store,
+                        write_timeout,
+                        logout,
+                    )
+                    .await;
                     let _ = session.on_logon_reject();
                     return Err(EngineError::HeartbeatInterval { detail });
                 }
@@ -663,21 +785,30 @@ impl<A: Application + 'static> Initiator<A> {
                 Err(err) => {
                     let detail = err.to_string();
                     let reason = RejectReason::new(5, detail.clone()).with_ref_tag(108);
-                    if let Ok(out_seq) = runtime.sequences.try_allocate_sender_seq()
-                        && let Ok(reject) = factory.session_reject(
-                            out_seq.value(),
-                            ack_seq,
-                            MsgType::Logon.as_str(),
-                            &reason,
-                        )
-                    {
-                        let _ = framed.send(reject).await;
-                    }
-                    if let Ok(out_seq) = runtime.sequences.try_allocate_sender_seq()
-                        && let Ok(logout) = factory.logout(out_seq.value(), Some(&detail))
-                    {
-                        let _ = framed.send(logout).await;
-                    }
+                    let reject = factory.session_reject(ack_seq, MsgType::Logon.as_str(), &reason);
+                    let _ = send_handshake_admin(
+                        self.application.as_ref(),
+                        &session_id,
+                        &mut framed,
+                        &mut factory,
+                        &runtime.sequences,
+                        store,
+                        write_timeout,
+                        reject,
+                    )
+                    .await;
+                    let logout = factory.logout(Some(&detail));
+                    let _ = send_handshake_admin(
+                        self.application.as_ref(),
+                        &session_id,
+                        &mut framed,
+                        &mut factory,
+                        &runtime.sequences,
+                        store,
+                        write_timeout,
+                        logout,
+                    )
+                    .await;
                     let _ = session.on_logon_reject();
                     return Err(EngineError::HeartbeatInterval { detail });
                 }
@@ -747,26 +878,34 @@ impl<A: Application + 'static> Initiator<A> {
 
         // A gap in the Logon ack means we missed messages: request a resend.
         if let Some(expected) = pending_resend {
-            let seq = runtime.sequences.try_allocate_sender_seq()?.value();
-            mirror_sender_seq(self.store.as_ref(), &runtime.sequences);
-            let frame = factory.resend_request(seq, expected, 0)?;
-            if let Ok(mut owned) = wire::owned_from_frame(&frame) {
-                self.application.to_admin(&mut owned, &session_id).await;
-            }
-            persist_outbound(
-                self.store.as_ref(),
+            let request = factory.resend_request(expected, 0);
+            send_handshake_admin(
+                self.application.as_ref(),
                 &session_id,
-                seq,
-                &MsgType::ResendRequest,
-                &frame,
+                &mut framed,
+                &mut factory,
+                &runtime.sequences,
+                store,
+                write_timeout,
+                request,
             )
-            .await;
-            framed.send(frame).await?;
+            .await?;
             lock_heartbeat(&runtime).on_message_sent();
         }
 
         let (command_tx, command_rx) = mpsc::channel(self.outbound_capacity);
         let (closed_tx, closed_rx) = watch::channel(false);
+        let (app_tx, app_rx) = mpsc::channel(self.app_queue_capacity);
+        let (reject_tx, reject_rx) = mpsc::channel(self.app_queue_capacity);
+
+        // The dispatcher stops when the reactor drops `app_tx`, which
+        // `run_reactor` does on every exit path.
+        let dispatcher = tokio::spawn(run_app_dispatcher(
+            Arc::clone(&self.application),
+            session_id.clone(),
+            app_rx,
+            reject_tx,
+        ));
 
         let reactor = Reactor {
             factory,
@@ -777,9 +916,17 @@ impl<A: Application + 'static> Initiator<A> {
             session_id: session_id.clone(),
             store: self.store.clone(),
             pending_resend,
+            write_timeout,
+            app_tx,
         };
         reactor.sync_sequences();
-        tokio::spawn(run_reactor(framed, command_rx, closed_tx, reactor, session));
+        let channels = ReactorChannels {
+            commands: command_rx,
+            app_rejects: reject_rx,
+            closed: closed_tx,
+            dispatcher,
+        };
+        tokio::spawn(run_reactor(framed, channels, reactor, session));
 
         Ok(Connection {
             session_id,
@@ -790,6 +937,91 @@ impl<A: Application + 'static> Initiator<A> {
     }
 }
 
+/// Runs `to_admin`, checks the body, and writes one administrative frame
+/// during the handshake, before the reactor exists.
+///
+/// Every administrative message goes through the callback, including the ones
+/// on the failure paths: now that a mutation is effective, a counterparty that
+/// requires a stamped field requires it on the Reject and the Logout too. When
+/// a store is attached the frame is filed and the sender counter mirrored, the
+/// same as [`send_handshake`] does.
+///
+/// # Errors
+/// The same as [`send_handshake`], plus [`EngineError::ReservedTag`] /
+/// [`EngineError::InvalidField`] when the callback left a body the engine will
+/// not frame.
+#[allow(clippy::too_many_arguments)]
+async fn send_handshake_admin<A: Application>(
+    application: &A,
+    session_id: &SessionId,
+    framed: &mut FixFramed,
+    factory: &mut MessageFactory,
+    sequences: &SequenceManager,
+    store: Option<&Arc<dyn MessageStore>>,
+    write_timeout: Duration,
+    mut pending: PendingMessage,
+) -> Result<(), EngineError> {
+    application
+        .to_admin(pending.message_mut(), session_id)
+        .await;
+    outbound::check_body(pending.message())?;
+    send_handshake(
+        session_id,
+        framed,
+        factory,
+        sequences,
+        store,
+        write_timeout,
+        &pending,
+    )
+    .await
+}
+
+/// Encodes and writes one frame during the handshake, before the reactor
+/// exists.
+///
+/// The sequence number is peeked, the frame is built, and only then is the
+/// number spent — the same order the reactor uses. A body with no legal wire
+/// form therefore costs nothing, instead of leaving a hole the counterparty
+/// would have to resend over. When a store is attached the frame is filed under
+/// its `MsgSeqNum` and the sender counter mirrored into it before it goes on the
+/// wire, so a store reused across a reconnect can replay it and never reports a
+/// number the peer has already seen.
+///
+/// # Errors
+/// [`EngineError::Encode`] when the body has no legal wire form,
+/// [`EngineError::SequenceExhausted`] when the sender counter has reached
+/// `u64::MAX`, [`EngineError::WriteTimeout`] when the peer is not reading, and
+/// the transport's own error otherwise.
+async fn send_handshake(
+    session_id: &SessionId,
+    framed: &mut FixFramed,
+    factory: &mut MessageFactory,
+    sequences: &SequenceManager,
+    store: Option<&Arc<dyn MessageStore>>,
+    write_timeout: Duration,
+    pending: &PendingMessage,
+) -> Result<(), EngineError> {
+    let seq = sequences.next_sender_seq().value();
+    let frame = factory.encode(seq, pending)?;
+    let allocated = sequences.try_allocate_sender_seq()?.value();
+    if allocated != seq {
+        return Err(EngineError::Sequence(format!(
+            "sender sequence moved from {seq} to {allocated} while a frame was being built"
+        )));
+    }
+    // File the frame and mirror the sender counter before it reaches the wire:
+    // a message on the wire that was never stored is one this session can be
+    // asked to replay and cannot.
+    mirror_sender_seq(store, sequences);
+    persist_outbound(store, session_id, seq, pending.msg_type(), frame).await;
+    match timeout(write_timeout, framed.send(frame)).await {
+        Err(_) => Err(EngineError::WriteTimeout(write_timeout)),
+        Ok(Err(err)) => Err(err.into()),
+        Ok(Ok(())) => Ok(()),
+    }
+}
+
 /// Mirrors the sender sequence counter into the store, if one is attached.
 ///
 /// The reactor mirrors both counters after every event through
@@ -797,9 +1029,9 @@ impl<A: Application + 'static> Initiator<A> {
 /// Logon handshake. This closes the window: it is called after each handshake
 /// frame is numbered, before that frame reaches the wire, so a store reused
 /// across a reconnect never reports a sender counter behind a `MsgSeqNum` the
-/// counterparty has already seen — which would reuse that number on the next
-/// session. Only the sender counter is mirrored; the target counter advances
-/// only once an inbound message is accepted, which the reactor then mirrors.
+/// counterparty has already seen. Only the sender counter is mirrored; the
+/// target counter advances only once an inbound message is accepted, which the
+/// reactor then mirrors.
 fn mirror_sender_seq(store: Option<&Arc<dyn MessageStore>>, sequences: &SequenceManager) {
     if let Some(store) = store {
         store.set_next_sender_seq(sequences.next_sender_seq().value());
@@ -898,9 +1130,88 @@ fn exhausted(phase: Phase, err: SequenceExhausted) -> SessionClosed {
     closed(err.to_string(), false)
 }
 
+/// One inbound application message on its way to the dispatcher task.
+///
+/// Carries the frame as [`Bytes`], which the reactor already owns, so handing
+/// it over is a reference-count bump rather than a copy.
+#[derive(Debug)]
+struct AppFrame {
+    /// The complete frame.
+    frame: Bytes,
+    /// Its `MsgSeqNum` (34), already validated by the reactor.
+    seq: u64,
+}
+
+/// A rejection the application returned from `from_app`, on its way back to
+/// the reactor as a session-level Reject.
+#[derive(Debug)]
+struct AppRejection {
+    /// `RefSeqNum` (45): the MsgSeqNum of the rejected message.
+    ref_seq: u64,
+    /// `RefMsgType` (372).
+    ref_msg_type: MsgType,
+    /// The reason the application gave.
+    reason: RejectReason,
+}
+
+/// Runs `from_app` off the reactor.
+///
+/// Messages arrive in the order the reactor validated them, and this task is
+/// their only consumer, so the application sees them in ascending `MsgSeqNum`
+/// order. A rejection travels back to the reactor, which numbers and sends the
+/// session-level Reject; nothing here touches session state.
+///
+/// The task ends when the reactor drops the queue's sender, which every exit
+/// path of [`run_reactor`] does.
+async fn run_app_dispatcher<A: Application>(
+    application: Arc<A>,
+    session_id: SessionId,
+    mut frames: mpsc::Receiver<AppFrame>,
+    rejections: mpsc::Sender<AppRejection>,
+) {
+    while let Some(AppFrame { frame, seq }) = frames.recv().await {
+        // The reactor decoded this frame already; a failure here cannot
+        // happen, and inventing a session action for it is not this task's
+        // job.
+        let Ok(raw) = wire::decode_frame(&frame) else {
+            tracing::warn!(
+                session = %session_id,
+                seq,
+                "dropping an application message that no longer decodes"
+            );
+            continue;
+        };
+        if let Err(reason) = application.from_app(&raw, &session_id).await {
+            let rejection = AppRejection {
+                ref_seq: seq,
+                ref_msg_type: raw.msg_type().clone(),
+                reason,
+            };
+            if rejections.send(rejection).await.is_err() {
+                // The reactor is gone; the session it would have rejected
+                // into no longer exists.
+                break;
+            }
+        }
+    }
+}
+
+/// Everything the reactor loop owns besides the socket and the session.
+struct ReactorChannels {
+    /// Commands from [`Connection`] handles.
+    commands: mpsc::Receiver<Command>,
+    /// Rejections coming back from the application dispatcher.
+    app_rejects: mpsc::Receiver<AppRejection>,
+    /// Closed-flag channel observed by [`Connection::wait_closed`].
+    closed: watch::Sender<bool>,
+    /// The application dispatcher, joined on close so `on_logout` follows the
+    /// last `from_app` rather than racing it.
+    dispatcher: JoinHandle<()>,
+}
+
 /// Reactor state shared across event handlers.
 struct Reactor<A: Application> {
-    /// Outbound frame factory.
+    /// Outbound frame factory, holding the encoder reused for every message.
     factory: MessageFactory,
     /// Identity every inbound message must carry.
     identity: PeerIdentity,
@@ -920,19 +1231,30 @@ struct Reactor<A: Application> {
     /// carries the instant the Logout went out, so the phase itself is the
     /// deadline.
     pending_resend: Option<u64>,
+    /// Bound on a single socket write.
+    write_timeout: Duration,
+    /// Hand-off queue to the application dispatcher.
+    app_tx: mpsc::Sender<AppFrame>,
 }
 
 /// The session reactor: owns the socket, multiplexes inbound frames,
-/// outbound commands, and heartbeat timers until the session closes.
+/// outbound commands, application rejections, and heartbeat timers until the
+/// session closes.
 async fn run_reactor<A: Application + 'static>(
     mut framed: FixFramed,
-    mut commands: mpsc::Receiver<Command>,
-    closed_tx: watch::Sender<bool>,
+    channels: ReactorChannels,
     mut ctx: Reactor<A>,
     session: Session<Active>,
 ) {
+    let ReactorChannels {
+        mut commands,
+        mut app_rejects,
+        closed: closed_tx,
+        mut dispatcher,
+    } = channels;
     let mut phase = Some(Phase::Active(session));
     let mut commands_open = true;
+    let mut rejects_open = true;
     let mut tick = interval(TICK_INTERVAL);
     tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
@@ -963,6 +1285,24 @@ async fn run_reactor<A: Application + 'static>(
                     ctx.on_command(&mut framed, current, Command::Logout).await
                 }
             },
+            rejection = app_rejects.recv(), if rejects_open => match rejection {
+                Some(rejection) => {
+                    let ref_msg_type = rejection.ref_msg_type.as_str().to_string();
+                    ctx.send_session_reject(
+                        &mut framed,
+                        current,
+                        rejection.ref_seq,
+                        &ref_msg_type,
+                        &rejection.reason,
+                    )
+                    .await
+                }
+                None => {
+                    // The dispatcher stopped; nothing more can be rejected.
+                    rejects_open = false;
+                    Ok(current)
+                }
+            },
             _ = tick.tick() => ctx.on_tick(&mut framed, current).await,
         };
         match result {
@@ -990,6 +1330,22 @@ async fn run_reactor<A: Application + 'static>(
         }
     }
     ctx.sync_sequences();
+
+    // Closing the queue is what stops the dispatcher; joining it is what keeps
+    // `on_logout` from running beside a `from_app` still in flight. A wedged
+    // handler bounds the wait rather than the shutdown — and is then aborted, so
+    // it cannot outlive `on_logout`/`wait_closed`. Awaiting `&mut dispatcher`
+    // keeps ownership of the handle across the timeout: dropping it would only
+    // detach the task, leaving the stuck handler running.
+    drop(ctx.app_tx);
+    if timeout(APP_DRAIN_TIMEOUT, &mut dispatcher).await.is_err() {
+        dispatcher.abort();
+        tracing::warn!(
+            session = %ctx.session_id,
+            "application dispatcher did not drain before the session closed; aborting it"
+        );
+    }
+
     ctx.application.on_logout(&ctx.session_id).await;
     let _ = closed_tx.send(true);
     if outcome.graceful {
@@ -997,6 +1353,32 @@ async fn run_reactor<A: Application + 'static>(
     } else {
         tracing::warn!(session = %ctx.session_id, reason = %outcome.reason, "FIX session closed");
     }
+}
+
+/// Why an outbound message never reached the transport.
+enum WriteFailure {
+    /// The body has no legal wire form. **No sequence number was spent**, so
+    /// the session is intact and the message can simply be dropped.
+    Encode(EncodeError),
+    /// The session cannot continue.
+    Fatal(EngineError),
+}
+
+/// Whether an outbound message actually reached the transport.
+///
+/// [`Reactor::send`] returning `Ok` used to conflate "sent" with "dropped
+/// because a callback left the body unsendable". A caller that arms follow-on
+/// state — the logout deadline, a pending TestRequest, a pending resend — must
+/// distinguish the two, or it advances the session on a frame the peer never
+/// saw.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Sent {
+    /// The frame went out and a sequence number was spent.
+    Yes,
+    /// The message was dropped before the wire: `to_admin`/`to_app` left it
+    /// unframeable or dropped a required field. No sequence number was spent
+    /// and the session is intact.
+    Dropped,
 }
 
 impl<A: Application> Reactor<A> {
@@ -1013,66 +1395,200 @@ impl<A: Application> Reactor<A> {
         store.set_next_target_seq(self.runtime.sequences.next_target_seq().value());
     }
 
-    /// Sends an admin frame, running the `to_admin` callback and updating
-    /// heartbeat bookkeeping.
+    /// Frames `pending` under an explicit `seq` and writes it, bounded by the
+    /// write timeout. Spends no sequence number.
     ///
-    /// `seq` is the sender sequence number allocated for this frame, and the
-    /// key it is filed under. It is `None` only for a `SequenceReset`-GapFill,
-    /// which allocates no number of its own: it re-occupies the range it
-    /// replaces, and filing it would overwrite a message that is still
-    /// resendable.
+    /// When `persist` is set and a store is attached the frame is filed under
+    /// `seq` before it goes on the wire. A gap fill passes `false`: it
+    /// re-occupies a range it does not own, so filing it would overwrite a
+    /// message under `seq` that is still resendable.
     ///
-    /// The message is filed **before** it is written to the socket. A frame
-    /// stored but never sent is harmless — the counterparty never saw it and so
-    /// never asks for it — whereas a frame sent but never stored is a message
-    /// this session can be asked to replay and cannot produce.
-    async fn send_admin(
-        &self,
+    /// # Errors
+    /// [`WriteFailure::Encode`] leaves the session untouched — nothing was
+    /// written and nothing was spent. [`WriteFailure::Fatal`] does not: a
+    /// stalled or broken transport ends the session.
+    async fn write_at(
+        &mut self,
         framed: &mut FixFramed,
-        seq: Option<u64>,
-        frame: Result<BytesMut, EncodeError>,
-    ) -> Result<(), EngineError> {
-        // The frame arrives as the encoder's result so every caller reports an
-        // unencodable message through the path it already uses for a failed
-        // send, rather than each deciding for itself.
-        let frame = frame?;
-        let mut msg_type = None;
-        if let Ok(mut owned) = wire::owned_from_frame(&frame) {
-            msg_type = Some(owned.msg_type().clone());
+        seq: u64,
+        pending: &PendingMessage,
+        persist: bool,
+    ) -> Result<(), WriteFailure> {
+        let write_timeout = self.write_timeout;
+        let frame = match self.factory.encode(seq, pending) {
+            Ok(frame) => frame,
+            Err(err) => return Err(WriteFailure::Encode(err)),
+        };
+        if persist {
+            persist_outbound(
+                self.store.as_ref(),
+                &self.session_id,
+                seq,
+                pending.msg_type(),
+                frame,
+            )
+            .await;
+        }
+        // A peer that stops reading parks this write forever once its receive
+        // window closes, and the reactor's liveness timers park with it.
+        match timeout(write_timeout, framed.send(frame)).await {
+            Err(_) => Err(WriteFailure::Fatal(EngineError::WriteTimeout(
+                write_timeout,
+            ))),
+            Ok(Err(err)) => Err(WriteFailure::Fatal(err.into())),
+            Ok(Ok(())) => Ok(()),
+        }
+    }
+
+    /// Runs the outbound application callback, checks the body, files the
+    /// frame, frames the message under the next sender sequence number and
+    /// writes it.
+    ///
+    /// `to_admin` or `to_app` is chosen by the MsgType, and each runs on the
+    /// message **before** it is framed, so what the callback hands back is what
+    /// goes on the wire.
+    ///
+    /// The sequence number is peeked to frame the message and spent only once
+    /// the frame has actually gone out. A body with no legal wire form is
+    /// therefore dropped with a warning and [`Sent::Dropped`] is returned: the
+    /// session is intact and there is no hole for the counterparty to resend
+    /// over. A caller that arms follow-on state — the logout deadline, a
+    /// pending TestRequest, a pending resend — must act only on [`Sent::Yes`],
+    /// or it advances the session on a frame the peer never saw. Only the
+    /// reactor allocates sender sequence numbers and only this method writes, so
+    /// nothing can take the peeked number in between — the mismatch branch
+    /// exists so a wrong `MsgSeqNum` can never reach the wire, not because it is
+    /// reachable.
+    ///
+    /// # Errors
+    /// Every [`EngineError`] returned here is terminal for the session: an
+    /// exhausted sender counter, a write timeout, or a transport failure.
+    async fn send(
+        &mut self,
+        framed: &mut FixFramed,
+        mut pending: PendingMessage,
+    ) -> Result<Sent, EngineError> {
+        if !self.prepare(&mut pending).await {
+            return Ok(Sent::Dropped);
+        }
+        let seq = self.runtime.sequences.next_sender_seq().value();
+        match self.write_at(framed, seq, &pending, true).await {
+            Ok(()) => {}
+            Err(WriteFailure::Encode(err)) => {
+                tracing::warn!(
+                    session = %self.session_id,
+                    error = %err,
+                    "dropping outbound message with no legal wire form; no sequence number spent"
+                );
+                return Ok(Sent::Dropped);
+            }
+            Err(WriteFailure::Fatal(err)) => return Err(err),
+        }
+        let allocated = self.runtime.sequences.try_allocate_sender_seq()?.value();
+        if allocated != seq {
+            return Err(EngineError::Sequence(format!(
+                "sender sequence moved from {seq} to {allocated} while a frame was being built"
+            )));
+        }
+        mirror_sender_seq(self.store.as_ref(), &self.runtime.sequences);
+        lock_heartbeat(&self.runtime).on_message_sent();
+        Ok(Sent::Yes)
+    }
+
+    /// Runs `to_admin` / `to_app` on `pending` and rechecks its body.
+    ///
+    /// Returns `false` when the callback left a body the engine will not
+    /// frame — a tag the standard header already carries, or a value with no
+    /// wire form. The message is then dropped; the warning names the tag and
+    /// never the value, because an outbound Logon body carries `Password`
+    /// (554).
+    async fn prepare(&mut self, pending: &mut PendingMessage) -> bool {
+        if pending.msg_type().is_admin() {
             self.application
-                .to_admin(&mut owned, &self.session_id)
+                .to_admin(pending.message_mut(), &self.session_id)
+                .await;
+        } else {
+            self.application
+                .to_app(pending.message_mut(), &self.session_id)
                 .await;
         }
-        if let (Some(seq), Some(msg_type)) = (seq, msg_type.as_ref()) {
-            self.persist(seq, msg_type, &frame).await;
+        if let Err(err) = outbound::check_body(pending.message()) {
+            tracing::warn!(
+                session = %self.session_id,
+                msg_type = %pending.msg_type(),
+                error = %err,
+                "dropping outbound message rejected after the application callback"
+            );
+            return false;
         }
-        framed.send(frame).await?;
-        lock_heartbeat(&self.runtime).on_message_sent();
-        Ok(())
+        true
     }
 
-    /// Files one outbound frame in the store, if there is one.
-    async fn persist(&self, seq: u64, msg_type: &MsgType, frame: &[u8]) {
-        persist_outbound(self.store.as_ref(), &self.session_id, seq, msg_type, frame).await;
-    }
-
-    /// Writes an already-built replay frame to the socket.
+    /// Writes an already-built replay frame to the socket, bounded by the write
+    /// timeout.
     ///
-    /// A replayed message keeps the sequence number and the body it was first
-    /// sent with, so nothing is allocated and nothing is re-filed. `to_app`
-    /// still runs, because from the application's point of view this is another
-    /// transmission of one of its messages.
+    /// A replayed message keeps the sequence number and body it was first sent
+    /// with, so nothing is allocated and nothing is re-filed. It already
+    /// carries `PossDupFlag` (43) = Y and its original `OrigSendingTime` (122),
+    /// both stamped by [`wire::resend_frame`], so it is written verbatim rather
+    /// than run back through the callback path.
+    ///
+    /// # Errors
+    /// [`EngineError::WriteTimeout`] when the peer is not reading, and the
+    /// transport's own error otherwise. Both are terminal for the session.
     async fn send_replay(
         &self,
         framed: &mut FixFramed,
         frame: BytesMut,
     ) -> Result<(), EngineError> {
-        if let Ok(mut owned) = wire::owned_from_frame(&frame) {
-            self.application.to_app(&mut owned, &self.session_id).await;
+        let write_timeout = self.write_timeout;
+        match timeout(write_timeout, framed.send(frame)).await {
+            Err(_) => return Err(EngineError::WriteTimeout(write_timeout)),
+            Ok(Err(err)) => return Err(err.into()),
+            Ok(Ok(())) => {}
         }
-        framed.send(frame).await?;
         lock_heartbeat(&self.runtime).on_message_sent();
         Ok(())
+    }
+
+    /// Writes a SequenceReset-GapFill covering `at_seq..new_seq`, numbered with
+    /// `at_seq`, without spending a sender sequence number.
+    ///
+    /// A gap fill re-occupies the range it replaces, so it is written at
+    /// `at_seq` rather than through [`Reactor::send`], and is **not** filed:
+    /// filing it would overwrite a message under `at_seq` that is still
+    /// resendable.
+    ///
+    /// # Errors
+    /// Only a fatal transport failure ([`EngineError::WriteTimeout`] or a
+    /// transport error) is returned. A body the callback left unframeable is a
+    /// hole the peer will re-request and is dropped rather than closing the
+    /// session.
+    async fn send_gap_fill(
+        &mut self,
+        framed: &mut FixFramed,
+        at_seq: u64,
+        new_seq: u64,
+    ) -> Result<(), EngineError> {
+        let mut gap_fill = self.factory.sequence_reset_gap_fill(new_seq);
+        if !self.prepare(&mut gap_fill).await {
+            return Ok(());
+        }
+        match self.write_at(framed, at_seq, &gap_fill, false).await {
+            Ok(()) => {
+                lock_heartbeat(&self.runtime).on_message_sent();
+                Ok(())
+            }
+            Err(WriteFailure::Encode(err)) => {
+                tracing::warn!(
+                    session = %self.session_id,
+                    error = %err,
+                    "dropping SequenceReset-GapFill with no legal wire form"
+                );
+                Ok(())
+            }
+            Err(WriteFailure::Fatal(err)) => Err(err),
+        }
     }
 
     /// Handles a command from a [`Connection`] handle.
@@ -1092,68 +1608,35 @@ impl<A: Application> Reactor<A> {
                     );
                     return Ok(phase);
                 }
-                // Build the frame against the sequence number that *would* be
-                // allocated next, without consuming it. An application may hand
-                // us a message with no legal wire form — an ordinary field
-                // carrying SOH, an empty value, a DATA half without its LENGTH.
-                // Validating before allocation makes that a clean drop that
-                // leaves the session and the sequence counter intact, rather
-                // than a teardown over a spent number the counterparty would
-                // have to resend over. The reactor is the sole allocator of the
-                // sender counter and does not await between this peek and the
-                // commit below, so the number it commits is the one framed here.
-                let seq = self.runtime.sequences.next_sender_seq().value();
-                let frame = match self.factory.application_message(seq, &message) {
-                    Ok(frame) => frame,
-                    Err(err) => {
-                        // The message never reached the wire and no number was
-                        // spent. The value itself is not logged: it may carry a
-                        // credential (554/925) or RawData.
-                        tracing::warn!(
-                            session = %self.session_id,
-                            msg_type = %message.msg_type(),
-                            error = %err,
-                            "dropping outbound message: cannot encode"
-                        );
-                        return Ok(phase);
-                    }
-                };
-                // The frame encoded; commit the sequence number it carries.
-                if let Err(err) = self.runtime.sequences.try_allocate_sender_seq() {
-                    return Err(exhausted(phase, err));
-                }
-                if let Ok(mut owned) = wire::owned_from_frame(&frame) {
-                    self.application.to_app(&mut owned, &self.session_id).await;
-                }
-                // Filed before it is sent: this is the traffic a ResendRequest
-                // actually asks for, and a message on the wire that was never
-                // stored is one this session can be asked to replay and cannot.
-                self.persist(seq, message.msg_type(), &frame).await;
-                if let Err(err) = framed.send(frame).await {
+                if let Err(err) = self
+                    .send(framed, PendingMessage::application(message))
+                    .await
+                {
                     teardown(phase);
                     return Err(closed(format!("send failed: {err}"), false));
                 }
-                lock_heartbeat(&self.runtime).on_message_sent();
                 Ok(phase)
             }
             Command::Logout => match phase {
                 Phase::LogoutPending(_) => Ok(phase),
                 Phase::Active(session) => {
-                    let seq = match self.runtime.sequences.try_allocate_sender_seq() {
-                        Ok(seq) => seq.value(),
+                    let logout = self.factory.logout(None);
+                    match self.send(framed, logout).await {
                         Err(err) => {
                             let _ = session.disconnect();
-                            return Err(closed(err.to_string(), false));
+                            Err(closed(format!("send failed: {err}"), false))
                         }
-                    };
-                    let frame = self.factory.logout(seq, None);
-                    if let Err(err) = self.send_admin(framed, Some(seq), frame).await {
-                        let _ = session.disconnect();
-                        return Err(closed(format!("send failed: {err}"), false));
+                        // The Logout never reached the wire — a `to_admin`
+                        // callback left it unframeable. Staying Active is the
+                        // honest verdict: arming the logout deadline for a frame
+                        // the peer never saw would tear the session down over a
+                        // Logout it was never told about.
+                        Ok(Sent::Dropped) => Ok(Phase::Active(session)),
+                        // Typestate: Active -> LogoutPending. The new state
+                        // records when the Logout went out, which is what
+                        // on_tick times.
+                        Ok(Sent::Yes) => Ok(Phase::LogoutPending(session.initiate_logout())),
                     }
-                    // Typestate: Active -> LogoutPending. The new state records
-                    // when the Logout went out, which is what on_tick times.
-                    Ok(Phase::LogoutPending(session.initiate_logout()))
                 }
             },
         }
@@ -1193,23 +1676,21 @@ impl<A: Application> Reactor<A> {
         }
         if send_test_request {
             let test_req_id = generate_test_req_id();
-            let seq = match self.runtime.sequences.try_allocate_sender_seq() {
-                Ok(seq) => seq.value(),
-                Err(err) => return Err(exhausted(phase, err)),
-            };
-            let frame = self.factory.test_request(seq, &test_req_id);
-            if let Err(err) = self.send_admin(framed, Some(seq), frame).await {
-                teardown(phase);
-                return Err(closed(format!("send failed: {err}"), false));
+            let request = self.factory.test_request(&test_req_id);
+            match self.send(framed, request).await {
+                Err(err) => {
+                    teardown(phase);
+                    return Err(closed(format!("send failed: {err}"), false));
+                }
+                // Only a TestRequest that actually went out starts the timeout
+                // countdown. Arming it for a dropped probe would time the
+                // session out waiting for an answer to a frame never sent.
+                Ok(Sent::Yes) => lock_heartbeat(&self.runtime).on_test_request_sent(test_req_id),
+                Ok(Sent::Dropped) => {}
             }
-            lock_heartbeat(&self.runtime).on_test_request_sent(test_req_id);
         } else if send_heartbeat {
-            let seq = match self.runtime.sequences.try_allocate_sender_seq() {
-                Ok(seq) => seq.value(),
-                Err(err) => return Err(exhausted(phase, err)),
-            };
-            let frame = self.factory.heartbeat(seq, None);
-            if let Err(err) = self.send_admin(framed, Some(seq), frame).await {
+            let heartbeat = self.factory.heartbeat(None);
+            if let Err(err) = self.send(framed, heartbeat).await {
                 teardown(phase);
                 return Err(closed(format!("send failed: {err}"), false));
             }
@@ -1226,14 +1707,8 @@ impl<A: Application> Reactor<A> {
         ref_msg_type: &str,
         reason: &RejectReason,
     ) -> Result<Phase, SessionClosed> {
-        let out_seq = match self.runtime.sequences.try_allocate_sender_seq() {
-            Ok(seq) => seq.value(),
-            Err(err) => return Err(exhausted(phase, err)),
-        };
-        let frame = self
-            .factory
-            .session_reject(out_seq, ref_seq, ref_msg_type, reason);
-        if let Err(err) = self.send_admin(framed, Some(out_seq), frame).await {
+        let reject = self.factory.session_reject(ref_seq, ref_msg_type, reason);
+        if let Err(err) = self.send(framed, reject).await {
             teardown(phase);
             return Err(closed(format!("send failed: {err}"), false));
         }
@@ -1251,14 +1726,17 @@ impl<A: Application> Reactor<A> {
         if self.pending_resend == Some(expected) {
             return Ok(phase);
         }
-        let out_seq = match self.runtime.sequences.try_allocate_sender_seq() {
-            Ok(seq) => seq.value(),
-            Err(err) => return Err(exhausted(phase, err)),
-        };
-        let frame = self.factory.resend_request(out_seq, expected, 0);
-        if let Err(err) = self.send_admin(framed, Some(out_seq), frame).await {
-            teardown(phase);
-            return Err(closed(format!("send failed: {err}"), false));
+        let request = self.factory.resend_request(expected, 0);
+        match self.send(framed, request).await {
+            Err(err) => {
+                teardown(phase);
+                return Err(closed(format!("send failed: {err}"), false));
+            }
+            // The ResendRequest never went out; leaving the range unmarked lets
+            // the next frame on the same gap try again, instead of suppressing
+            // it as already-requested against a request the peer never received.
+            Ok(Sent::Dropped) => return Ok(phase),
+            Ok(Sent::Yes) => {}
         }
         self.pending_resend = Some(expected);
         Ok(phase)
@@ -1275,10 +1753,8 @@ impl<A: Application> Reactor<A> {
         received: u64,
     ) -> SessionClosed {
         let reason = format!("MsgSeqNum too low: expected {expected}, received {received}");
-        if let Ok(out_seq) = self.runtime.sequences.try_allocate_sender_seq() {
-            let frame = self.factory.logout(out_seq.value(), Some(&reason));
-            let _ = self.send_admin(framed, Some(out_seq.value()), frame).await;
-        }
+        let logout = self.factory.logout(Some(&reason));
+        let _ = self.send(framed, logout).await;
         teardown(phase);
         closed(reason, false)
     }
@@ -1301,16 +1777,10 @@ impl<A: Application> Reactor<A> {
         tracing::warn!(session = %self.session_id, detail = %detail, "inbound identity mismatch");
 
         let reason = RejectReason::new(9, detail.clone()).with_ref_tag(mismatch.tag);
-        if let Ok(out_seq) = self.runtime.sequences.try_allocate_sender_seq() {
-            let frame =
-                self.factory
-                    .session_reject(out_seq.value(), ref_seq, ref_msg_type, &reason);
-            let _ = self.send_admin(framed, Some(out_seq.value()), frame).await;
-        }
-        if let Ok(out_seq) = self.runtime.sequences.try_allocate_sender_seq() {
-            let frame = self.factory.logout(out_seq.value(), Some(&detail));
-            let _ = self.send_admin(framed, Some(out_seq.value()), frame).await;
-        }
+        let reject = self.factory.session_reject(ref_seq, ref_msg_type, &reason);
+        let _ = self.send(framed, reject).await;
+        let logout = self.factory.logout(Some(&detail));
+        let _ = self.send(framed, logout).await;
         teardown(phase);
         closed(detail, false)
     }
@@ -1583,12 +2053,11 @@ impl<A: Application> Reactor<A> {
         // Whatever the replay did not cover — a trailing run of admin messages,
         // holes, or the entire range when there is no store — is gap-filled, so
         // the counterparty's expectation always lands exactly on `new_seq`.
-        if cursor < new_seq {
-            let frame = self.factory.sequence_reset_gap_fill(cursor, new_seq);
-            if let Err(err) = self.send_admin(framed, None, frame).await {
-                teardown(phase);
-                return Err(closed(format!("send failed: {err}"), false));
-            }
+        if cursor < new_seq
+            && let Err(err) = self.send_gap_fill(framed, cursor, new_seq).await
+        {
+            teardown(phase);
+            return Err(closed(format!("send failed: {err}"), false));
         }
         Ok(phase)
     }
@@ -1614,12 +2083,15 @@ impl<A: Application> Reactor<A> {
     /// is then closed by the caller. Every other failure — an unreadable store,
     /// an unrebuildable frame — degrades to a gap fill.
     async fn replay_range(
-        &self,
+        &mut self,
         framed: &mut FixFramed,
         begin_seq: u64,
         new_seq: u64,
     ) -> Result<u64, EngineError> {
-        let Some(store) = &self.store else {
+        // Cloned so the loop does not hold a borrow of `self.store` across the
+        // `&mut self` replay/gap-fill calls below; an `Arc` clone is a
+        // reference-count bump.
+        let Some(store) = self.store.clone() else {
             return Ok(begin_seq);
         };
         // `new_seq` is the exclusive upper bound of the reply, so the last
@@ -1690,8 +2162,7 @@ impl<A: Application> Reactor<A> {
                 // Everything between the cursor and this message — holes, admin
                 // messages, frames that would not rebuild — is one fill.
                 if seq > reply_cursor {
-                    let fill = self.factory.sequence_reset_gap_fill(reply_cursor, seq);
-                    self.send_admin(framed, None, fill).await?;
+                    self.send_gap_fill(framed, reply_cursor, seq).await?;
                 }
                 self.send_replay(framed, frame).await?;
 
@@ -1731,6 +2202,9 @@ impl<A: Application> Reactor<A> {
         phase: Phase,
         frame: BytesMut,
     ) -> Result<Phase, SessionClosed> {
+        // Frozen once: handing an application message to the dispatcher is
+        // then a reference-count bump on this buffer, not a copy of it.
+        let frame = frame.freeze();
         let raw = match wire::decode_frame(&frame) {
             Ok(raw) => raw,
             Err(err) => {
@@ -1785,19 +2259,36 @@ impl<A: Application> Reactor<A> {
 
         match self.runtime.sequences.validate_incoming(seq) {
             SequenceResult::Ok => {
-                if let Err(err) = self.runtime.sequences.try_increment_target_seq() {
-                    return Err(exhausted(phase, err));
+                if msg_type.is_admin() {
+                    // Consume the number before the admin handler runs: any
+                    // reply it sends is numbered against the advanced
+                    // expectation, and admin messages never queue.
+                    if let Err(err) = self.runtime.sequences.try_increment_target_seq() {
+                        return Err(exhausted(phase, err));
+                    }
+                    self.pending_resend = None;
+                    self.dispatch_admin(framed, phase, &raw, seq).await
+                } else {
+                    // Hand the frame to the dispatcher *before* the inbound
+                    // expectation advances past it. A full queue is then a
+                    // session close with the sequence number unspent, never a
+                    // message dropped after its number was already consumed.
+                    let phase = self.enqueue_app(phase, seq, &frame)?;
+                    if let Err(err) = self.runtime.sequences.try_increment_target_seq() {
+                        return Err(exhausted(phase, err));
+                    }
+                    self.pending_resend = None;
+                    Ok(phase)
                 }
-                self.pending_resend = None;
             }
             SequenceResult::TooLow { expected, received } => {
                 if raw.get_field_str(43) == Some("Y") {
                     // Duplicate delivery of an already-processed message.
                     return Ok(phase);
                 }
-                return Err(self
+                Err(self
                     .close_on_too_low(framed, phase, expected, received)
-                    .await);
+                    .await)
             }
             SequenceResult::Gap { expected, .. } => {
                 let phase = self.request_resend(framed, phase, expected).await?;
@@ -1807,32 +2298,54 @@ impl<A: Application> Reactor<A> {
                     // (without advancing the target sequence).
                     return Ok(phase);
                 }
-                return self.dispatch(framed, phase, &raw, &msg_type, seq).await;
+                self.dispatch_admin(framed, phase, &raw, seq).await
             }
         }
-
-        self.dispatch(framed, phase, &raw, &msg_type, seq).await
     }
 
-    /// Runs the application callback and the admin reply for a message whose
-    /// sequence number has already been validated.
-    async fn dispatch(
+    /// Hands one validated inbound application frame to the dispatcher task.
+    ///
+    /// The caller has not yet advanced the inbound expectation, so a full queue
+    /// closes the session with the sequence number intact — the counterparty
+    /// stays free to resend, rather than the message being silently lost past a
+    /// number already consumed.
+    fn enqueue_app(&self, phase: Phase, seq: u64, frame: &Bytes) -> Result<Phase, SessionClosed> {
+        let queued = AppFrame {
+            frame: frame.clone(),
+            seq,
+        };
+        match self.app_tx.try_send(queued) {
+            Ok(()) => Ok(phase),
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                teardown(phase);
+                Err(closed(
+                    "application queue full: the application is not consuming inbound \
+                     messages fast enough",
+                    false,
+                ))
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                teardown(phase);
+                Err(closed("application dispatcher stopped", false))
+            }
+        }
+    }
+
+    /// Runs `from_admin` and the admin reply for an administrative message whose
+    /// sequence number has already been validated (and, on the in-sequence
+    /// path, consumed).
+    ///
+    /// Application messages never reach here — they are handed to the dispatcher
+    /// task by [`Reactor::enqueue_app`], so a slow `from_app` cannot delay the
+    /// next socket read or the heartbeat clock.
+    async fn dispatch_admin(
         &mut self,
         framed: &mut FixFramed,
         phase: Phase,
         raw: &RawMessage<'_>,
-        msg_type: &MsgType,
         seq: u64,
     ) -> Result<Phase, SessionClosed> {
-        if !msg_type.is_admin() {
-            if let Err(reason) = self.application.from_app(raw, &self.session_id).await {
-                return self
-                    .send_session_reject(framed, phase, seq, msg_type.as_str(), &reason)
-                    .await;
-            }
-            return Ok(phase);
-        }
-
+        let msg_type = raw.msg_type();
         if let Err(reason) = self.application.from_admin(raw, &self.session_id).await {
             return self
                 .send_session_reject(framed, phase, seq, msg_type.as_str(), &reason)
@@ -1842,17 +2355,13 @@ impl<A: Application> Reactor<A> {
         match msg_type {
             MsgType::Heartbeat => Ok(phase),
             MsgType::TestRequest => {
-                let out_seq = match self.runtime.sequences.try_allocate_sender_seq() {
-                    Ok(out_seq) => out_seq.value(),
-                    Err(err) => return Err(exhausted(phase, err)),
-                };
                 // `112=` with no value is a malformed TestRequest. There is
                 // nothing to echo, and an empty field has no legal wire form,
                 // so the Heartbeat is sent without TestReqID rather than the
                 // session being torn down over the peer's mistake.
                 let test_req_id = raw.get_field_str(112).filter(|id| !id.is_empty());
-                let frame = self.factory.heartbeat(out_seq, test_req_id);
-                if let Err(err) = self.send_admin(framed, Some(out_seq), frame).await {
+                let heartbeat = self.factory.heartbeat(test_req_id);
+                if let Err(err) = self.send(framed, heartbeat).await {
                     teardown(phase);
                     return Err(closed(format!("send failed: {err}"), false));
                 }
@@ -1881,10 +2390,8 @@ impl<A: Application> Reactor<A> {
                     Err(closed("logout complete", true))
                 }
                 Phase::Active(session) => {
-                    if let Ok(out_seq) = self.runtime.sequences.try_allocate_sender_seq() {
-                        let frame = self.factory.logout(out_seq.value(), None);
-                        let _ = self.send_admin(framed, Some(out_seq.value()), frame).await;
-                    }
+                    let logout = self.factory.logout(None);
+                    let _ = self.send(framed, logout).await;
                     let _ = session.disconnect();
                     let text = raw
                         .get_field_str(58)

--- a/ironfix-engine/src/outbound.rs
+++ b/ironfix-engine/src/outbound.rs
@@ -4,9 +4,29 @@
    Date: 14/7/26
 ******************************************************************************/
 
-//! Outbound application message builder.
+//! Outbound message builder and the rules an outbound body must satisfy.
+//!
+//! [`OutboundMessage`] is the **pre-encoding form of every message the engine
+//! sends** — application messages handed to
+//! [`Connection::send`](crate::Connection::send) and the administrative
+//! messages the session layer builds for itself. It is what
+//! [`Application::to_app`](crate::Application::to_app) and
+//! [`Application::to_admin`](crate::Application::to_admin) receive, and it is
+//! what the engine encodes, so a mutation made in a callback reaches the wire.
+//!
+//! # What a body may not carry
+//!
+//! The engine stamps the standard header and trailer itself. A body field that
+//! repeats one of those tags produces a frame with two occurrences of it, which
+//! a conforming counterparty rejects or misparses, so [`RESERVED_TAGS`] are
+//! refused at the public boundary rather than duplicated. Administrative
+//! MsgTypes are refused there too: Logon, Logout, SequenceReset and the rest
+//! belong to the session state machine, and one emitted behind its back leaves
+//! the engine's phase tracking describing a session that no longer exists.
 
+use crate::error::EngineError;
 use ironfix_core::message::MsgType;
+use ironfix_tagvalue::SOH;
 
 /// A single body field of an [`OutboundMessage`], in the form the encoder
 /// needs to stamp it.
@@ -38,18 +58,238 @@ pub enum OutboundField {
     },
 }
 
-/// An outbound application message: a MsgType plus ordered body fields.
+/// Tags the engine stamps into the standard header or trailer itself.
+///
+/// In order: `BeginString` (8), `BodyLength` (9), `CheckSum` (10),
+/// `MsgSeqNum` (34), `MsgType` (35), `PossDupFlag` (43), `SenderCompID` (49),
+/// `SenderSubID` (50), `SendingTime` (52), `TargetCompID` (56),
+/// `TargetSubID` (57), `OrigSendingTime` (122) and `ApplVerID` (1128).
+///
+/// A body carrying any of them is refused with [`EngineError::ReservedTag`].
+pub const RESERVED_TAGS: [u32; 13] = [8, 9, 10, 34, 35, 43, 49, 50, 52, 56, 57, 122, 1128];
+
+/// Tags whose values may carry a credential and must never appear in a log.
+///
+/// In order: `RawData` (96), `Password` (554) and `NewPassword` (925). The
+/// [`Debug`] impl of [`OutboundMessage`] replaces their values with a redaction
+/// marker so that logging the message — the object a `to_admin` callback stamps
+/// a password onto — cannot leak a secret.
+const SENSITIVE_TAGS: [u32; 3] = [96, 554, 925];
+
+/// Body tags an administrative MsgType may not go out without.
+///
+/// The engine's [`MessageFactory`](crate::wire::MessageFactory) always builds
+/// these in, but `to_admin` receives the message by `&mut` and can
+/// [`remove`](OutboundMessage::remove) them. A Logon stripped of `HeartBtInt`
+/// (108) or a TestRequest stripped of `TestReqID` (112) is malformed, and every
+/// conforming counterparty rejects it — so the drop is caught here rather than
+/// emitted. Header and trailer tags are covered separately by [`RESERVED_TAGS`].
+///
+/// The lookup is by wire code so a [`MsgType::Custom`] holding an administrative
+/// code is protected the same way. `Password` (554) and the rest are optional
+/// on the wire and are not listed. Returns an empty slice for every application
+/// MsgType and for administrative types with no required body field (Heartbeat,
+/// Logout).
+fn admin_required_tags(msg_type: &MsgType) -> &'static [u32] {
+    match msg_type.as_str() {
+        "A" => &[98, 108], // Logon: EncryptMethod, HeartBtInt.
+        "1" => &[112],     // TestRequest: TestReqID.
+        "2" => &[7, 16],   // ResendRequest: BeginSeqNo, EndSeqNo.
+        "4" => &[36],      // SequenceReset: NewSeqNo.
+        _ => &[],
+    }
+}
+
+/// Checks that a message may be sent on the application path.
+///
+/// Enforces the two rules the public boundary owns: the MsgType must not be
+/// administrative, and the body must not repeat a tag the engine stamps.
+///
+/// # Errors
+/// [`EngineError::ReservedMsgType`] for an administrative MsgType, otherwise
+/// whatever [`check_body`] reports.
+pub(crate) fn check_sendable(message: &OutboundMessage) -> Result<(), EngineError> {
+    if message.msg_type().is_admin() {
+        return Err(EngineError::ReservedMsgType {
+            msg_type: message.msg_type().as_str().to_string(),
+        });
+    }
+    check_body(message)
+}
+
+/// Checks that every body field has a legal wire form, is not one the engine
+/// stamps itself, and — for an administrative MsgType — that no field the
+/// message cannot go out without has been dropped.
+///
+/// Run again after `to_admin` / `to_app`, because a callback can append fields
+/// the caller never wrote and can [`remove`](OutboundMessage::remove) fields the
+/// session layer built in.
+///
+/// # Errors
+/// [`EngineError::ReservedTag`] for a tag in [`RESERVED_TAGS`],
+/// [`EngineError::InvalidField`] for tag `0`, an empty value, or a value
+/// carrying the SOH delimiter — which would terminate its own field early and
+/// let the remainder inject further fields into the frame — and
+/// [`EngineError::MissingRequiredField`] when an administrative message no
+/// longer carries a tag in [`admin_required_tags`].
+///
+/// The reported reason never quotes the value: an outbound Logon body carries
+/// `Password` (554) and `NewPassword` (925).
+pub(crate) fn check_body(message: &OutboundMessage) -> Result<(), EngineError> {
+    for field in message.fields() {
+        match field {
+            OutboundField::Raw { tag, value } => {
+                check_body_tag(*tag)?;
+                if value.is_empty() {
+                    return Err(EngineError::InvalidField {
+                        tag: *tag,
+                        reason: "value is empty; a FIX field carries at least one byte".to_string(),
+                    });
+                }
+                if value.contains(&SOH) {
+                    return Err(EngineError::InvalidField {
+                        tag: *tag,
+                        reason:
+                            "value contains the SOH delimiter, which would terminate the field \
+                                 early and inject the remainder as further fields"
+                                .to_string(),
+                    });
+                }
+            }
+            // A DATA field legally carries the SOH delimiter and `=`: it is
+            // framed as a counted LENGTH/DATA pair, so the payload's bytes are
+            // never read as field terminators and are not checked for SOH here.
+            // Both tags are still the engine's to refuse if reserved or zero.
+            OutboundField::Data {
+                length_tag,
+                data_tag,
+                ..
+            } => {
+                check_body_tag(*length_tag)?;
+                check_body_tag(*data_tag)?;
+            }
+        }
+    }
+    // An administrative message that lost a required body field — a `to_admin`
+    // that removed HeartBtInt (108) from a Logon, say — must not reach the wire:
+    // the counterparty rejects it and the session's own handshake stalls.
+    for &required in admin_required_tags(message.msg_type()) {
+        if message.get(required).is_none() {
+            return Err(EngineError::MissingRequiredField {
+                msg_type: message.msg_type().as_str().to_string(),
+                tag: required,
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Refuses a body tag that is `0` (no such FIX tag) or one the engine stamps
+/// into the standard header or trailer itself.
+///
+/// # Errors
+/// [`EngineError::InvalidField`] for tag `0`, [`EngineError::ReservedTag`] for a
+/// tag in [`RESERVED_TAGS`].
+fn check_body_tag(tag: u32) -> Result<(), EngineError> {
+    if tag == 0 {
+        return Err(EngineError::InvalidField {
+            tag,
+            reason: "0 is not a legal FIX field tag: tags are positive integers starting at 1"
+                .to_string(),
+        });
+    }
+    if RESERVED_TAGS.contains(&tag) {
+        return Err(EngineError::ReservedTag { tag });
+    }
+    Ok(())
+}
+
+/// An outbound message: a MsgType plus ordered body fields.
 ///
 /// The engine stamps the standard header (BeginString, BodyLength, MsgType,
 /// SenderCompID, TargetCompID, MsgSeqNum, SendingTime) and the trailer when
 /// the message is sent, so the builder only carries body fields. Fields are
 /// encoded in insertion order.
-#[derive(Debug, Clone)]
+///
+/// # Mutating one in a callback
+///
+/// [`Application::to_admin`](crate::Application::to_admin) and
+/// [`Application::to_app`](crate::Application::to_app) receive this type by
+/// `&mut` **before** the header is stamped and before a sequence number is
+/// spent, so a field added there is encoded into the frame that goes out. The
+/// canonical use is stamping `Username` (553) and `Password` (554) onto the
+/// outbound Logon.
+///
+/// The header fields are not visible here — in particular `MsgSeqNum` (34) is
+/// not yet decided when the callback runs, which is what lets a rejected
+/// message cost nothing.
+///
+/// # Constraints
+///
+/// [`OutboundMessage::new`] accepts any MsgType so the engine can build its own
+/// administrative messages with it; the restriction to application MsgTypes is
+/// enforced by [`Connection::send`](crate::Connection::send), which is the
+/// public path. See [`RESERVED_TAGS`] for the tags a body may not carry.
+///
+/// # Credentials never print
+///
+/// This is the object a `to_admin` callback stamps a `Password` (554) onto, so
+/// its [`Debug`] impl is hand-written to redact the values of `Password` (554),
+/// `NewPassword` (925) and `RawData` (96) — a derived `Debug` would let a single
+/// `tracing::debug!(?message)` leak a secret. Every other field is shown as
+/// normal.
+#[derive(Clone)]
 pub struct OutboundMessage {
     /// Message type (tag 35).
     msg_type: MsgType,
     /// Body fields in insertion order.
     fields: Vec<OutboundField>,
+}
+
+impl std::fmt::Debug for OutboundMessage {
+    /// Redacts the value of every credential-bearing field so the type cannot
+    /// leak a `Password` (554), `NewPassword` (925) or `RawData` (96) through a
+    /// log line.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        /// Renders the body list, redacting the values of sensitive tags.
+        struct RedactedFields<'a>(&'a [OutboundField]);
+        impl std::fmt::Debug for RedactedFields<'_> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                let mut list = f.debug_list();
+                for field in self.0 {
+                    match field {
+                        OutboundField::Raw { tag, value } => {
+                            if SENSITIVE_TAGS.contains(tag) {
+                                list.entry(&(tag, "<redacted>"));
+                            } else {
+                                list.entry(&(tag, &String::from_utf8_lossy(value)));
+                            }
+                        }
+                        OutboundField::Data {
+                            length_tag,
+                            data_tag,
+                            value,
+                        } => {
+                            if SENSITIVE_TAGS.contains(data_tag) {
+                                list.entry(&(length_tag, data_tag, "<redacted>"));
+                            } else {
+                                list.entry(&(
+                                    length_tag,
+                                    data_tag,
+                                    &String::from_utf8_lossy(value),
+                                ));
+                            }
+                        }
+                    }
+                }
+                list.finish()
+            }
+        }
+        f.debug_struct("OutboundMessage")
+            .field("msg_type", &self.msg_type)
+            .field("fields", &RedactedFields(&self.fields))
+            .finish()
+    }
 }
 
 impl OutboundMessage {
@@ -160,6 +400,44 @@ impl OutboundMessage {
         self.push_raw(tag, if value { b"Y".to_vec() } else { b"N".to_vec() })
     }
 
+    /// Returns the value of the first field with `tag`, if present.
+    ///
+    /// # Arguments
+    /// * `tag` - The field tag number
+    #[must_use]
+    pub fn get(&self, tag: u32) -> Option<&[u8]> {
+        self.fields.iter().find_map(|field| match field {
+            OutboundField::Raw {
+                tag: field_tag,
+                value,
+            } if *field_tag == tag => Some(value.as_slice()),
+            OutboundField::Data {
+                data_tag, value, ..
+            } if *data_tag == tag => Some(value.as_slice()),
+            _ => None,
+        })
+    }
+
+    /// Removes every field carrying `tag`, returning how many were removed.
+    ///
+    /// A [`OutboundField::Data`] pair is removed when either its `LENGTH` or its
+    /// `DATA` tag matches, so the counted halves never survive apart.
+    ///
+    /// # Arguments
+    /// * `tag` - The field tag number
+    pub fn remove(&mut self, tag: u32) -> usize {
+        let before = self.fields.len();
+        self.fields.retain(|field| match field {
+            OutboundField::Raw { tag: field_tag, .. } => *field_tag != tag,
+            OutboundField::Data {
+                length_tag,
+                data_tag,
+                ..
+            } => *length_tag != tag && *data_tag != tag,
+        });
+        before - self.fields.len()
+    }
+
     /// Returns the body fields in insertion order.
     #[must_use]
     pub fn fields(&self) -> &[OutboundField] {
@@ -252,5 +530,164 @@ mod tests {
                 value: b"after".to_vec()
             }
         );
+    }
+
+    #[test]
+    fn test_outbound_message_get_and_remove_round_trip() {
+        let mut msg = OutboundMessage::new(MsgType::Logon);
+        msg.push_str(553, "trader").push_str(554, "secret");
+
+        assert_eq!(msg.get(553), Some(&b"trader"[..]));
+        assert_eq!(msg.get(9999), None);
+        assert_eq!(msg.remove(554), 1);
+        assert_eq!(msg.get(554), None);
+        assert_eq!(msg.remove(554), 0);
+        assert_eq!(msg.fields().len(), 1);
+    }
+
+    #[test]
+    fn test_check_sendable_application_message_is_accepted() {
+        let mut msg = OutboundMessage::new(MsgType::NewOrderSingle);
+        msg.push_str(11, "ORDER-1").push_char(54, '1');
+        assert!(check_sendable(&msg).is_ok());
+    }
+
+    #[test]
+    fn test_check_sendable_admin_msg_type_is_reserved() {
+        // Every administrative MsgType belongs to the session layer: one sent
+        // behind the state machine's back leaves the engine's phase tracking
+        // describing a session that no longer exists.
+        for msg_type in [
+            MsgType::Logon,
+            MsgType::Logout,
+            MsgType::SequenceReset,
+            MsgType::Heartbeat,
+            MsgType::TestRequest,
+            MsgType::ResendRequest,
+            MsgType::Reject,
+        ] {
+            let expected = msg_type.as_str().to_string();
+            let msg = OutboundMessage::new(msg_type);
+            match check_sendable(&msg) {
+                Err(EngineError::ReservedMsgType { msg_type }) => assert_eq!(msg_type, expected),
+                other => panic!("35={expected} must be refused, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_check_sendable_reserved_tag_is_refused() {
+        for tag in RESERVED_TAGS {
+            let mut msg = OutboundMessage::new(MsgType::NewOrderSingle);
+            msg.push_str(tag, "1");
+            match check_sendable(&msg) {
+                Err(EngineError::ReservedTag { tag: actual }) => assert_eq!(actual, tag),
+                other => panic!("tag {tag} must be refused, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_check_body_zero_tag_is_refused() {
+        let mut msg = OutboundMessage::new(MsgType::NewOrderSingle);
+        msg.push_str(0, "x");
+        match check_body(&msg) {
+            Err(EngineError::InvalidField { tag: 0, .. }) => {}
+            other => panic!("tag 0 must be refused, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_check_body_empty_value_is_refused() {
+        let mut msg = OutboundMessage::new(MsgType::NewOrderSingle);
+        msg.push_str(11, "");
+        match check_body(&msg) {
+            Err(EngineError::InvalidField { tag: 11, .. }) => {}
+            other => panic!("an empty value must be refused, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_check_body_soh_in_value_is_refused_without_quoting_it() {
+        let mut msg = OutboundMessage::new(MsgType::NewOrderSingle);
+        msg.push_str(58, "text\x0149=EVIL");
+        match check_body(&msg) {
+            Err(EngineError::InvalidField { tag: 58, reason }) => {
+                assert!(
+                    !reason.contains("EVIL"),
+                    "the rejection must not quote the value, got {reason}"
+                );
+            }
+            other => panic!("an embedded SOH must be refused, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_check_body_admin_missing_required_field_is_refused() {
+        // The (MsgType, required-tag) pairs a `to_admin` callback must not be
+        // able to strip and still have the message reach the wire.
+        for (msg_type, required) in [
+            (MsgType::Logon, 98u32),
+            (MsgType::Logon, 108),
+            (MsgType::TestRequest, 112),
+            (MsgType::ResendRequest, 7),
+            (MsgType::ResendRequest, 16),
+            (MsgType::SequenceReset, 36),
+        ] {
+            let mut msg = OutboundMessage::new(msg_type.clone());
+            // Populate every required tag, then drop just the one under test.
+            for &tag in admin_required_tags(&msg_type) {
+                msg.push_str(tag, "1");
+            }
+            assert_eq!(msg.remove(required), 1);
+            match check_body(&msg) {
+                Err(EngineError::MissingRequiredField {
+                    msg_type: reported,
+                    tag,
+                }) => {
+                    assert_eq!(reported, msg_type.as_str());
+                    assert_eq!(tag, required);
+                }
+                other => {
+                    panic!("{msg_type:?} without tag {required} must be refused, got {other:?}")
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_check_body_admin_with_all_required_fields_is_accepted() {
+        let mut logon = OutboundMessage::new(MsgType::Logon);
+        logon.push_uint(98, 0).push_uint(108, 30);
+        assert!(check_body(&logon).is_ok());
+    }
+
+    #[test]
+    fn test_check_body_application_message_has_no_required_admin_fields() {
+        // An application MsgType places no admin-required-field demand, so an
+        // empty body is fine here (per-field checks aside).
+        let msg = OutboundMessage::new(MsgType::NewOrderSingle);
+        assert!(check_body(&msg).is_ok());
+    }
+
+    #[test]
+    fn test_outbound_message_debug_redacts_credentials() {
+        let mut msg = OutboundMessage::new(MsgType::Logon);
+        msg.push_str(553, "trader")
+            .push_str(554, "s3cret-password")
+            .push_str(925, "n3w-password")
+            .push_str(96, "raw-secret-bytes");
+        let rendered = format!("{msg:?}");
+
+        // The username is not a credential and stays visible.
+        assert!(rendered.contains("trader"), "got {rendered}");
+        // None of the credential values may appear.
+        for secret in ["s3cret-password", "n3w-password", "raw-secret-bytes"] {
+            assert!(
+                !rendered.contains(secret),
+                "Debug must not print {secret}, got {rendered}"
+            );
+        }
+        assert!(rendered.contains("<redacted>"), "got {rendered}");
     }
 }

--- a/ironfix-engine/src/wire.rs
+++ b/ironfix-engine/src/wire.rs
@@ -7,16 +7,34 @@
 //! Internal helpers for building and parsing FIX frames.
 //!
 //! Admin messages (Logon, Heartbeat, TestRequest, Logout, ResendRequest,
-//! SequenceReset, Reject) are constructed here with the standard header
-//! stamped from the session configuration. Application messages built by
-//! consumers via [`OutboundMessage`] get the same header treatment.
+//! SequenceReset, Reject) are built here as [`PendingMessage`]s — a MsgType
+//! plus body fields, with no header and no sequence number yet — exactly the
+//! form an application message arrives in. [`MessageFactory::encode`] stamps
+//! the standard header and trailer around either.
+//!
+//! The split is what makes `to_admin` / `to_app` mean something: the callback
+//! mutates the [`OutboundMessage`] inside a [`PendingMessage`], and that is the
+//! value the encoder then reads. It is also what lets the caller encode
+//! **before** spending a sequence number, so a body with no legal wire form
+//! costs nothing.
+//!
+//! One [`Encoder`] lives for the life of the factory and is rewound with
+//! [`Encoder::clear`] between messages, so its buffer is allocated once and
+//! [`MessageFactory::encode`] hands back a slice of it rather than a fresh
+//! owned frame.
+//!
+//! A resend of a **stored** message takes a different path: [`resend_frame`]
+//! rebuilds a verbatim frame the store handed back, keeping its original
+//! `MsgSeqNum` and stamping `PossDupFlag` (43) / `OrigSendingTime` (122). That
+//! is a replay of real traffic, not a freshly numbered message, so it does not
+//! go through the factory's sequence-numbering `encode`.
 
 use crate::application::RejectReason;
 use crate::outbound::{OutboundField, OutboundMessage};
 use bytes::BytesMut;
 use ironfix_core::error::{DecodeError, EncodeError};
 use ironfix_core::field::FieldRef;
-use ironfix_core::message::{OwnedMessage, RawMessage};
+use ironfix_core::message::{MsgType, RawMessage};
 use ironfix_core::types::Timestamp;
 use ironfix_core::version::FixVersion;
 use ironfix_session::SessionConfig;
@@ -189,12 +207,6 @@ pub(crate) fn decode_frame(frame: &[u8]) -> Result<RawMessage<'_>, DecodeError> 
     decoder.decode()
 }
 
-/// Decodes a frame into an [`OwnedMessage`] for the `to_admin`/`to_app`
-/// application callbacks.
-pub(crate) fn owned_from_frame(frame: &[u8]) -> Result<OwnedMessage, DecodeError> {
-    Ok(decode_frame(frame)?.to_owned())
-}
-
 /// Why a stored message could not be rebuilt as a resend.
 ///
 /// Every variant means the same thing to the reactor — this particular message
@@ -310,18 +322,70 @@ const RESEND_HEADROOM: usize = 64;
 
 /// Stamps the frame and moves it into a buffer the transport owns.
 ///
+/// Used by [`resend_frame`], which builds a fresh encoder per replayed message
+/// rather than sharing the factory's reused one.
+///
 /// # Errors
 /// Returns the [`EncodeError`] the encoder recorded — a field value that
 /// cannot be represented on the wire, such as a `Text` (58) carrying the SOH
-/// delimiter or an empty `TestReqID` (112) echoed back from a peer. A frame is
-/// never produced from a rejected value.
+/// delimiter. A frame is never produced from a rejected value.
 fn into_frame(encoder: &mut Encoder) -> Result<BytesMut, EncodeError> {
     let mut frame = BytesMut::new();
     encoder.finish_into(&mut frame)?;
     Ok(frame)
 }
 
-/// Builds outbound frames with the session header stamped.
+/// A message built but not yet framed: body fields, plus the one header
+/// property that is not derivable from the MsgType.
+///
+/// This is what the `to_admin` / `to_app` callbacks mutate and what
+/// [`MessageFactory::encode`] reads, so the two cannot disagree about what
+/// goes on the wire.
+#[derive(Debug, Clone)]
+pub(crate) struct PendingMessage {
+    /// MsgType and body fields.
+    message: OutboundMessage,
+    /// Whether the header carries `PossDupFlag` (43) and `OrigSendingTime`
+    /// (122). Only a SequenceReset-GapFill answering a ResendRequest sets it.
+    poss_dup: bool,
+}
+
+impl PendingMessage {
+    /// Wraps a message that is not a possible duplicate.
+    #[must_use]
+    fn plain(message: OutboundMessage) -> Self {
+        Self {
+            message,
+            poss_dup: false,
+        }
+    }
+
+    /// Wraps an application message handed in by a consumer.
+    #[must_use]
+    pub(crate) fn application(message: OutboundMessage) -> Self {
+        Self::plain(message)
+    }
+
+    /// Returns the message type.
+    #[must_use]
+    pub(crate) fn msg_type(&self) -> &MsgType {
+        self.message.msg_type()
+    }
+
+    /// Returns the message body.
+    #[must_use]
+    pub(crate) fn message(&self) -> &OutboundMessage {
+        &self.message
+    }
+
+    /// Returns the message body for the `to_admin` / `to_app` callbacks.
+    #[must_use]
+    pub(crate) fn message_mut(&mut self) -> &mut OutboundMessage {
+        &mut self.message
+    }
+}
+
+/// Builds outbound messages and frames them with the session header stamped.
 #[derive(Debug)]
 pub(crate) struct MessageFactory {
     version: FixVersion,
@@ -331,6 +395,9 @@ pub(crate) struct MessageFactory {
     target_sub_id: Option<String>,
     sender_location_id: Option<String>,
     target_location_id: Option<String>,
+    /// Reused across every message: [`Encoder::clear`] rewinds it while
+    /// retaining its buffer, so framing does not allocate per message.
+    encoder: Encoder,
 }
 
 impl MessageFactory {
@@ -345,196 +412,188 @@ impl MessageFactory {
             target_sub_id: config.target_sub_id.clone(),
             sender_location_id: config.sender_location_id.clone(),
             target_location_id: config.target_location_id.clone(),
+            encoder: Encoder::new(version.begin_string()),
         }
     }
 
-    /// Starts an encoder with the standard header:
-    /// 35, [1128], 49, 56, [50], [142], [57], [143], 34, [43], 52, [122].
+    /// Frames `pending` under `seq` and returns the finished frame, which
+    /// borrows the factory's own buffer until the next call.
+    ///
+    /// The standard header is stamped first —
+    /// 35, [1128], 49, 56, [50], [142], [57], [143], 34, [43], 52, [122] —
+    /// then the body fields in insertion order.
     ///
     /// `SenderLocationID` (142) follows `SenderSubID` (50) and
     /// `TargetLocationID` (143) follows `TargetSubID` (57), the standard-header
-    /// pairing of the routing fields. Both are stamped only when configured;
-    /// an unset LocationID places nothing on the wire.
+    /// pairing of the routing fields. Both are stamped only when configured; an
+    /// unset LocationID places nothing on the wire.
     ///
-    /// `poss_dup` stamps both `PossDupFlag` (43) and `OrigSendingTime` (122),
-    /// because FIX requires 122 on every message carrying 43=Y. Its only user
-    /// is [`MessageFactory::sequence_reset_gap_fill`], which is not a replay of
-    /// anything: a gap fill's "original" is administrative filler that was
-    /// never sent, so there is no recorded sending time to copy and 122 takes
-    /// the same value as `SendingTime` (52) — the FIX handling for an
-    /// unavailable OrigSendingTime. A genuine replay of a stored message goes
-    /// through [`resend_frame`], which copies the real original 52 into 122.
+    /// `PossDupFlag` (43) is always accompanied by `OrigSendingTime` (122):
+    /// FIX requires 122 on every message carrying 43=Y. Its only user here is a
+    /// SequenceReset-GapFill, whose "original" messages are administrative
+    /// filler that was never sent, so there is no recorded sending time to copy
+    /// and 122 takes the same value as `SendingTime` (52) — the FIX handling
+    /// for an unavailable OrigSendingTime. A genuine replay of a stored message
+    /// goes through [`resend_frame`], which copies the real original 52 into
+    /// 122.
     ///
-    /// `appl_ver_id` stamps `ApplVerID` (1128) immediately after MsgType,
-    /// its position in the FIXT.1.1 standard header. It is passed only for
-    /// application messages; session-level messages are versioned by the
-    /// FIXT.1.1 BeginString itself.
-    fn header(
-        &self,
-        msg_type: &str,
+    /// `ApplVerID` (1128) is stamped immediately after MsgType, its position in
+    /// the FIXT.1.1 standard header, and only for application messages;
+    /// session-level messages are versioned by the FIXT.1.1 BeginString itself.
+    ///
+    /// # Errors
+    /// Returns the [`EncodeError`] the encoder recorded — a field value with no
+    /// on-the-wire form, such as a `Text` (58) carrying the SOH delimiter or an
+    /// empty `TestReqID` (112) echoed back from a peer. A frame is never
+    /// produced from a rejected value, and the caller has not yet spent a
+    /// sequence number on it.
+    pub(crate) fn encode(
+        &mut self,
         seq: u64,
-        poss_dup: bool,
-        appl_ver_id: Option<&str>,
-    ) -> Encoder {
-        let mut encoder = Encoder::new(self.version.begin_string());
-        encoder.put_str(35, msg_type);
+        pending: &PendingMessage,
+    ) -> Result<&[u8], EncodeError> {
+        let poss_dup = pending.poss_dup;
+        let message = &pending.message;
+        // Session-level messages are versioned by the BeginString; only
+        // application messages carry ApplVerID.
+        let appl_ver_id = if message.msg_type().is_admin() {
+            None
+        } else {
+            self.version.appl_ver_id()
+        };
+
+        self.encoder.clear();
+        self.encoder.put_str(35, message.msg_type().as_str());
         if let Some(appl_ver_id) = appl_ver_id {
-            encoder.put_str(1128, appl_ver_id);
+            self.encoder.put_str(1128, appl_ver_id);
         }
-        encoder.put_str(49, &self.sender_comp_id);
-        encoder.put_str(56, &self.target_comp_id);
+        self.encoder.put_str(49, &self.sender_comp_id);
+        self.encoder.put_str(56, &self.target_comp_id);
         if let Some(sub) = &self.sender_sub_id {
-            encoder.put_str(50, sub);
+            self.encoder.put_str(50, sub);
         }
         if let Some(location) = &self.sender_location_id {
-            encoder.put_str(142, location);
+            self.encoder.put_str(142, location);
         }
         if let Some(sub) = &self.target_sub_id {
-            encoder.put_str(57, sub);
+            self.encoder.put_str(57, sub);
         }
         if let Some(location) = &self.target_location_id {
-            encoder.put_str(143, location);
+            self.encoder.put_str(143, location);
         }
-        encoder.put_uint(34, seq);
+        self.encoder.put_uint(34, seq);
         if poss_dup {
-            encoder.put_bool(43, true);
+            self.encoder.put_bool(43, true);
         }
         let sending_time = Timestamp::now().format_millis();
-        encoder.put_str(52, sending_time.as_str());
+        self.encoder.put_str(52, sending_time.as_str());
         if poss_dup {
-            encoder.put_str(122, sending_time.as_str());
+            self.encoder.put_str(122, sending_time.as_str());
         }
-        encoder
-    }
 
-    /// Builds a Logon (35=A) with EncryptMethod=0, HeartBtInt and, for a
-    /// FIXT.1.1 session, DefaultApplVerID (1137).
-    pub(crate) fn logon(
-        &self,
-        seq: u64,
-        heartbeat_secs: u64,
-        reset_seq: bool,
-    ) -> Result<BytesMut, EncodeError> {
-        let mut encoder = self.header("A", seq, false, None);
-        encoder.put_uint(98, 0);
-        encoder.put_uint(108, heartbeat_secs);
-        if reset_seq {
-            encoder.put_bool(141, true);
-        }
-        if let Some(appl_ver_id) = self.version.appl_ver_id() {
-            encoder.put_str(1137, appl_ver_id);
-        }
-        into_frame(&mut encoder)
-    }
-
-    /// Builds a Heartbeat (35=0), echoing TestReqID (112) when replying to
-    /// a TestRequest.
-    pub(crate) fn heartbeat(
-        &self,
-        seq: u64,
-        test_req_id: Option<&str>,
-    ) -> Result<BytesMut, EncodeError> {
-        let mut encoder = self.header("0", seq, false, None);
-        if let Some(id) = test_req_id {
-            encoder.put_str(112, id);
-        }
-        into_frame(&mut encoder)
-    }
-
-    /// Builds a TestRequest (35=1) with TestReqID (112).
-    pub(crate) fn test_request(
-        &self,
-        seq: u64,
-        test_req_id: &str,
-    ) -> Result<BytesMut, EncodeError> {
-        let mut encoder = self.header("1", seq, false, None);
-        encoder.put_str(112, test_req_id);
-        into_frame(&mut encoder)
-    }
-
-    /// Builds a Logout (35=5) with optional Text (58).
-    pub(crate) fn logout(&self, seq: u64, text: Option<&str>) -> Result<BytesMut, EncodeError> {
-        let mut encoder = self.header("5", seq, false, None);
-        if let Some(text) = text {
-            encoder.put_str(58, text);
-        }
-        into_frame(&mut encoder)
-    }
-
-    /// Builds a ResendRequest (35=2) for `begin_seq..end_seq`
-    /// (`end_seq` = 0 means "up to infinity").
-    pub(crate) fn resend_request(
-        &self,
-        seq: u64,
-        begin_seq: u64,
-        end_seq: u64,
-    ) -> Result<BytesMut, EncodeError> {
-        let mut encoder = self.header("2", seq, false, None);
-        encoder.put_uint(7, begin_seq);
-        encoder.put_uint(16, end_seq);
-        into_frame(&mut encoder)
-    }
-
-    /// Builds a SequenceReset-GapFill (35=4, 123=Y) that answers a
-    /// ResendRequest by jumping the counterparty's expectation to `new_seq`.
-    /// Stamped with the gap's begin sequence, PossDupFlag (43=Y) and
-    /// OrigSendingTime (122).
-    pub(crate) fn sequence_reset_gap_fill(
-        &self,
-        seq: u64,
-        new_seq: u64,
-    ) -> Result<BytesMut, EncodeError> {
-        let mut encoder = self.header("4", seq, true, None);
-        encoder.put_bool(123, true);
-        encoder.put_uint(36, new_seq);
-        into_frame(&mut encoder)
-    }
-
-    /// Builds a session-level Reject (35=3).
-    pub(crate) fn session_reject(
-        &self,
-        seq: u64,
-        ref_seq: u64,
-        ref_msg_type: &str,
-        reason: &RejectReason,
-    ) -> Result<BytesMut, EncodeError> {
-        let mut encoder = self.header("3", seq, false, None);
-        encoder.put_uint(45, ref_seq);
-        if let Some(ref_tag) = reason.ref_tag {
-            encoder.put_uint(371, u64::from(ref_tag));
-        }
-        encoder.put_str(372, ref_msg_type);
-        encoder.put_uint(373, u64::from(reason.code));
-        if !reason.text.is_empty() {
-            encoder.put_str(58, &reason.text);
-        }
-        into_frame(&mut encoder)
-    }
-
-    /// Builds an application message from an [`OutboundMessage`], stamping
-    /// ApplVerID (1128) for a FIXT.1.1 session.
-    pub(crate) fn application_message(
-        &self,
-        seq: u64,
-        message: &OutboundMessage,
-    ) -> Result<BytesMut, EncodeError> {
-        let mut encoder = self.header(
-            message.msg_type().as_str(),
-            seq,
-            false,
-            self.version.appl_ver_id(),
-        );
         for field in message.fields() {
             match field {
-                OutboundField::Raw { tag, value } => encoder.put_raw(*tag, value),
+                OutboundField::Raw { tag, value } => self.encoder.put_raw(*tag, value),
                 OutboundField::Data {
                     length_tag,
                     data_tag,
                     value,
-                } => encoder.put_data(*length_tag, *data_tag, value),
+                } => self.encoder.put_data(*length_tag, *data_tag, value),
             }
         }
-        into_frame(&mut encoder)
+        self.encoder.finish()
+    }
+
+    /// Builds a Logon (35=A) with EncryptMethod=0, HeartBtInt and, for a
+    /// FIXT.1.1 session, DefaultApplVerID (1137).
+    #[must_use]
+    pub(crate) fn logon(&self, heartbeat_secs: u64, reset_seq: bool) -> PendingMessage {
+        let mut message = OutboundMessage::new(MsgType::Logon);
+        message.push_uint(98, 0).push_uint(108, heartbeat_secs);
+        if reset_seq {
+            message.push_bool(141, true);
+        }
+        if let Some(appl_ver_id) = self.version.appl_ver_id() {
+            message.push_str(1137, appl_ver_id);
+        }
+        PendingMessage::plain(message)
+    }
+
+    /// Builds a Heartbeat (35=0), echoing TestReqID (112) when replying to
+    /// a TestRequest.
+    #[must_use]
+    pub(crate) fn heartbeat(&self, test_req_id: Option<&str>) -> PendingMessage {
+        let mut message = OutboundMessage::new(MsgType::Heartbeat);
+        if let Some(id) = test_req_id {
+            message.push_str(112, id);
+        }
+        PendingMessage::plain(message)
+    }
+
+    /// Builds a TestRequest (35=1) with TestReqID (112).
+    #[must_use]
+    pub(crate) fn test_request(&self, test_req_id: &str) -> PendingMessage {
+        let mut message = OutboundMessage::new(MsgType::TestRequest);
+        message.push_str(112, test_req_id);
+        PendingMessage::plain(message)
+    }
+
+    /// Builds a Logout (35=5) with optional Text (58).
+    ///
+    /// An empty text is dropped rather than written: `58=` has no legal wire
+    /// form, and losing the reason is better than losing the Logout.
+    #[must_use]
+    pub(crate) fn logout(&self, text: Option<&str>) -> PendingMessage {
+        let mut message = OutboundMessage::new(MsgType::Logout);
+        if let Some(text) = text.filter(|text| !text.is_empty()) {
+            message.push_str(58, text);
+        }
+        PendingMessage::plain(message)
+    }
+
+    /// Builds a ResendRequest (35=2) for `begin_seq..end_seq`
+    /// (`end_seq` = 0 means "up to infinity").
+    #[must_use]
+    pub(crate) fn resend_request(&self, begin_seq: u64, end_seq: u64) -> PendingMessage {
+        let mut message = OutboundMessage::new(MsgType::ResendRequest);
+        message.push_uint(7, begin_seq).push_uint(16, end_seq);
+        PendingMessage::plain(message)
+    }
+
+    /// Builds a SequenceReset-GapFill (35=4, 123=Y) that answers a
+    /// ResendRequest by jumping the counterparty's expectation to `new_seq`.
+    /// Carries PossDupFlag (43=Y) and OrigSendingTime (122); the caller
+    /// encodes it under the gap's begin sequence.
+    #[must_use]
+    pub(crate) fn sequence_reset_gap_fill(&self, new_seq: u64) -> PendingMessage {
+        let mut message = OutboundMessage::new(MsgType::SequenceReset);
+        message.push_bool(123, true).push_uint(36, new_seq);
+        PendingMessage {
+            message,
+            poss_dup: true,
+        }
+    }
+
+    /// Builds a session-level Reject (35=3).
+    #[must_use]
+    pub(crate) fn session_reject(
+        &self,
+        ref_seq: u64,
+        ref_msg_type: &str,
+        reason: &RejectReason,
+    ) -> PendingMessage {
+        let mut message = OutboundMessage::new(MsgType::Reject);
+        message.push_uint(45, ref_seq);
+        if let Some(ref_tag) = reason.ref_tag {
+            message.push_uint(371, u64::from(ref_tag));
+        }
+        message
+            .push_str(372, ref_msg_type)
+            .push_uint(373, u64::from(reason.code));
+        if !reason.text.is_empty() {
+            message.push_str(58, &reason.text);
+        }
+        PendingMessage::plain(message)
     }
 }
 
@@ -573,12 +632,23 @@ mod tests {
         }
     }
 
-    /// Unwraps a factory frame, failing the test with the encoder's rejection.
+    /// Frames `pending` under `seq`, failing the test with the encoder's
+    /// rejection.
     #[track_caller]
-    fn framed(frame: Result<BytesMut, EncodeError>) -> BytesMut {
+    fn framed(factory: &mut MessageFactory, seq: u64, pending: &PendingMessage) -> Vec<u8> {
+        match factory.encode(seq, pending) {
+            Ok(frame) => frame.to_vec(),
+            Err(err) => panic!("factory frame must encode: {err}"),
+        }
+    }
+
+    /// Unwraps a hand-built frame, failing the test with the encoder's
+    /// rejection.
+    #[track_caller]
+    fn built(frame: Result<BytesMut, EncodeError>) -> BytesMut {
         match frame {
             Ok(frame) => frame,
-            Err(err) => panic!("factory frame must encode: {err}"),
+            Err(err) => panic!("fixture frame must encode: {err}"),
         }
     }
 
@@ -600,7 +670,9 @@ mod tests {
 
     #[test]
     fn test_logon_frame_roundtrip() {
-        let frame = framed(factory().logon(1, 30, true));
+        let mut factory = factory();
+        let logon = factory.logon(30, true);
+        let frame = framed(&mut factory, 1, &logon);
         let raw = decode(&frame);
         assert_eq!(raw.msg_type(), &MsgType::Logon);
         assert_eq!(raw.get_field_str(49), Some("CLIENT"));
@@ -615,7 +687,9 @@ mod tests {
 
     #[test]
     fn test_gap_fill_frame_carries_orig_sending_time() {
-        let frame = framed(factory().sequence_reset_gap_fill(3, 10));
+        let mut factory = factory();
+        let gap_fill = factory.sequence_reset_gap_fill(10);
+        let frame = framed(&mut factory, 3, &gap_fill);
         let raw = decode(&frame);
         assert_eq!(raw.msg_type(), &MsgType::SequenceReset);
         assert_eq!(raw.get_field_str(34), Some("3"));
@@ -630,10 +704,59 @@ mod tests {
 
     #[test]
     fn test_non_poss_dup_frame_omits_orig_sending_time() {
-        let frame = framed(factory().heartbeat(4, None));
+        let mut factory = factory();
+        let heartbeat = factory.heartbeat(None);
+        let frame = framed(&mut factory, 4, &heartbeat);
         let raw = decode(&frame);
         assert_eq!(raw.get_field_str(43), None);
         assert_eq!(raw.get_field_str(122), None);
+    }
+
+    #[test]
+    fn test_encoder_reuse_produces_independent_frames() {
+        // One encoder is reused for the life of the session; a message must
+        // never carry residue of the one before it.
+        let mut factory = factory();
+        let logon = factory.logon(30, false);
+        let first = framed(&mut factory, 1, &logon);
+        let heartbeat = factory.heartbeat(Some("TEST-1"));
+        let second = framed(&mut factory, 2, &heartbeat);
+
+        assert_eq!(decode(&first).msg_type(), &MsgType::Logon);
+        assert_eq!(decode(&first).get_field_str(108), Some("30"));
+        let raw = decode(&second);
+        assert_eq!(raw.msg_type(), &MsgType::Heartbeat);
+        assert_eq!(raw.get_field_str(34), Some("2"));
+        assert_eq!(raw.get_field_str(112), Some("TEST-1"));
+        assert_eq!(raw.get_field_str(108), None);
+    }
+
+    #[test]
+    fn test_encode_rejects_an_unframeable_body_without_a_frame() {
+        // A value with no legal wire form is refused here, before the caller
+        // spends a sequence number on it.
+        let mut factory = factory();
+        let mut logout = factory.logout(None);
+        logout.message_mut().push_str(58, "bye\x0149=EVIL");
+        match factory.encode(9, &logout) {
+            Err(EncodeError::InvalidFieldValue { tag: 58, .. }) => {}
+            other => panic!("an embedded SOH must be refused, got {other:?}"),
+        }
+
+        // And the factory still frames the next message.
+        let heartbeat = factory.heartbeat(None);
+        let frame = framed(&mut factory, 9, &heartbeat);
+        assert_eq!(decode(&frame).msg_type(), &MsgType::Heartbeat);
+    }
+
+    #[test]
+    fn test_logout_drops_an_empty_text() {
+        let mut factory = factory();
+        let logout = factory.logout(Some(""));
+        let frame = framed(&mut factory, 1, &logout);
+        let raw = decode(&frame);
+        assert_eq!(raw.msg_type(), &MsgType::Logout);
+        assert_eq!(raw.get_field_str(58), None);
     }
 
     #[test]
@@ -641,7 +764,9 @@ mod tests {
         let mut message = OutboundMessage::new(MsgType::NewOrderSingle);
         message.push_str(11, "ORDER-1").push_char(54, '1');
 
-        let frame = framed(factory().application_message(7, &message));
+        let mut factory = factory();
+        let pending = PendingMessage::application(message);
+        let frame = framed(&mut factory, 7, &pending);
         let raw = decode(&frame);
         assert_eq!(raw.msg_type(), &MsgType::NewOrderSingle);
         assert_eq!(raw.get_field_str(34), Some("7"));
@@ -661,7 +786,9 @@ mod tests {
             .push_str(11, "ORDER-1")
             .push_data(95, 96, payload.to_vec());
 
-        let frame = framed(factory().application_message(7, &message));
+        let mut factory = factory();
+        let pending = PendingMessage::application(message);
+        let frame = framed(&mut factory, 7, &pending);
         let raw = decode(&frame);
         assert_eq!(raw.get_field_str(11), Some("ORDER-1"));
         assert_eq!(raw.get_field(95).map(|f| f.value), Some(b"5".as_slice()));
@@ -677,9 +804,10 @@ mod tests {
             Ok(version) => version,
             Err(err) => panic!("test fixture uses an unsupported version: {err}"),
         };
-        let factory = MessageFactory::new(&config, version);
+        let mut factory = MessageFactory::new(&config, version);
 
-        let frame = framed(factory.logon(1, 30, false));
+        let logon = factory.logon(30, false);
+        let frame = framed(&mut factory, 1, &logon);
         let raw = decode(&frame);
         // SenderLocationID (142) and TargetLocationID (143) are routing fields
         // of the standard header, so a configured value is stamped onto every
@@ -690,7 +818,9 @@ mod tests {
 
     #[test]
     fn test_header_omits_unset_location_ids() {
-        let frame = framed(factory().logon(1, 30, false));
+        let mut factory = factory();
+        let logon = factory.logon(30, false);
+        let frame = framed(&mut factory, 1, &logon);
         let raw = decode(&frame);
         assert_eq!(raw.get_field_str(142), None);
         assert_eq!(raw.get_field_str(143), None);
@@ -725,7 +855,9 @@ mod tests {
 
             assert_eq!(resolved, Ok(version));
 
-            let frame = framed(factory_for(version.as_str()).logon(1, 30, false));
+            let mut factory = factory_for(version.as_str());
+            let logon = factory.logon(30, false);
+            let frame = framed(&mut factory, 1, &logon);
             let raw = decode(&frame);
             assert_eq!(
                 raw.begin_string(),
@@ -785,7 +917,9 @@ mod tests {
 
     #[test]
     fn test_fix50sp2_logon_carries_fixt_begin_string_and_default_appl_ver_id() {
-        let frame = framed(factory_for("FIX.5.0SP2").logon(1, 30, false));
+        let mut factory = factory_for("FIX.5.0SP2");
+        let logon = factory.logon(30, false);
+        let frame = framed(&mut factory, 1, &logon);
         let raw = decode(&frame);
         assert_eq!(raw.begin_string(), Ok("FIXT.1.1"));
         assert_eq!(raw.get_field_str(1137), Some("9"));
@@ -796,7 +930,9 @@ mod tests {
         let mut message = OutboundMessage::new(MsgType::NewOrderSingle);
         message.push_str(11, "ORDER-1");
 
-        let frame = framed(factory_for("FIX.5.0SP2").application_message(2, &message));
+        let mut factory = factory_for("FIX.5.0SP2");
+        let pending = PendingMessage::application(message);
+        let frame = framed(&mut factory, 2, &pending);
         let raw = decode(&frame);
         assert_eq!(raw.begin_string(), Ok("FIXT.1.1"));
         assert_eq!(raw.get_field_str(1128), Some("9"));
@@ -806,7 +942,9 @@ mod tests {
     fn test_resend_frame_preserves_body_and_stamps_poss_dup() {
         let mut message = OutboundMessage::new(MsgType::NewOrderSingle);
         message.push_str(11, "ORDER-1").push_char(54, '1');
-        let original = framed(factory().application_message(7, &message));
+        let mut factory = factory();
+        let pending = PendingMessage::application(message);
+        let original = framed(&mut factory, 7, &pending);
         let original_sending_time = some(
             field_of(&original, 52),
             "the original must carry SendingTime",
@@ -851,7 +989,7 @@ mod tests {
         encoder.put_str(52, PRIOR_REPLAY);
         encoder.put_str(122, FIRST_SENT);
         encoder.put_str(11, "ORDER-1");
-        let once = framed(into_frame(&mut encoder));
+        let once = built(into_frame(&mut encoder));
 
         let twice = match resend_frame(&once) {
             Ok(frame) => frame,
@@ -882,7 +1020,7 @@ mod tests {
         encoder.put_str(49, "CLIENT");
         encoder.put_str(56, "VENUE");
         encoder.put_uint(34, 4);
-        let frame = framed(into_frame(&mut encoder));
+        let frame = built(into_frame(&mut encoder));
 
         match resend_frame(&frame) {
             Err(ResendError::MissingSendingTime) => {}
@@ -912,7 +1050,7 @@ mod tests {
         encoder.put_uint(34, 9);
         encoder.put_str(52, "20260721-10:00:00.000");
         encoder.put_data(95, 96, b"opaque\x01payload");
-        let original = framed(into_frame(&mut encoder));
+        let original = built(into_frame(&mut encoder));
 
         let resent = match resend_frame(&original) {
             Ok(frame) => frame,

--- a/ironfix-engine/tests/initiator_tests.rs
+++ b/ironfix-engine/tests/initiator_tests.rs
@@ -22,6 +22,7 @@ use ironfix_session::{SessionConfig, SessionConfigError};
 use ironfix_store::{MemoryStore, MessageStore, StoredMessage};
 use ironfix_tagvalue::{Decoder, Encoder};
 use ironfix_transport::FixCodec;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::net::{TcpListener, TcpStream};
@@ -231,12 +232,7 @@ impl Application for RecordingApp {
         self.record("logout");
     }
 
-    async fn to_admin(
-        &self,
-        _message: &mut ironfix_core::message::OwnedMessage,
-        _session_id: &SessionId,
-    ) {
-    }
+    async fn to_admin(&self, _message: &mut OutboundMessage, _session_id: &SessionId) {}
 
     async fn from_admin(
         &self,
@@ -249,12 +245,7 @@ impl Application for RecordingApp {
         Ok(())
     }
 
-    async fn to_app(
-        &self,
-        _message: &mut ironfix_core::message::OwnedMessage,
-        _session_id: &SessionId,
-    ) {
-    }
+    async fn to_app(&self, _message: &mut OutboundMessage, _session_id: &SessionId) {}
 
     async fn from_app(
         &self,
@@ -417,18 +408,21 @@ async fn test_send_raw_data_field_round_trips_byte_exact() {
     ok(acceptor.await, "acceptor task");
 }
 
-/// An `OutboundMessage` with no legal wire form is dropped cleanly: it spends
-/// no sequence number and does not tear the session down, so a following
-/// encodable message still flows with an unbroken sequence.
+/// An `OutboundMessage` with no legal wire form is refused at the send
+/// boundary: it spends no sequence number and does not tear the session down,
+/// so a following encodable message still flows with an unbroken sequence.
+/// The engine validates eagerly (`Connection::send` returns a typed error)
+/// rather than queuing the message and silently dropping it at encode time,
+/// and the rejection never quotes the offending value.
 #[tokio::test]
-async fn test_unencodable_outbound_message_is_dropped_without_teardown() {
+async fn test_unencodable_outbound_message_is_refused_without_teardown() {
     let (listener, addr) = bind_listener().await;
 
     let acceptor = tokio::spawn(async move {
         let mut framed = accept_logon(listener).await;
 
         // Only the encodable message reaches the wire, and it carries seq 2:
-        // the rejected one before it neither reached the wire nor spent a
+        // the refused one before it neither reached the wire nor spent a
         // number, so there is no gap for the peer to resend over.
         let good = next_frame(&mut framed).await;
         assert_eq!(msg_type_of(&good), "D");
@@ -440,19 +434,27 @@ async fn test_unencodable_outbound_message_is_dropped_without_teardown() {
     let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
     let connection = ok(initiator.connect(addr).await, "connect");
 
-    // An ordinary field carrying SOH has no legal wire form; the encoder
-    // refuses it. This used to allocate a sender seq and then tear the session
-    // down on the encode failure.
+    // An ordinary field carrying SOH has no legal wire form; `send` refuses it
+    // at the boundary with a typed error, spending no sequence number, rather
+    // than queuing it and tearing the session down on a later encode failure.
     let mut bad = OutboundMessage::new(MsgType::NewOrderSingle);
     bad.push_str(11, "BAD").push_str(58, "text\x0149=EVIL");
-    ok(connection.send(bad).await, "queue unencodable message");
+    match connection.send(bad).await {
+        Err(EngineError::InvalidField { tag: 58, reason }) => {
+            assert!(
+                !reason.contains("EVIL"),
+                "the rejection must not quote the value, got {reason}"
+            );
+        }
+        other => panic!("an embedded SOH must be refused, got {other:?}"),
+    }
 
     let mut good = OutboundMessage::new(MsgType::NewOrderSingle);
     good.push_str(11, "GOOD");
     ok(connection.send(good).await, "queue encodable message");
 
     // The session is closed by the acceptor's transport drop after it reads the
-    // good frame, not by a teardown from the rejected message.
+    // good frame, not by a teardown from the refused message.
     ok(
         timeout(Duration::from_secs(5), connection.wait_closed()).await,
         "closed within 5s",
@@ -2461,6 +2463,7 @@ async fn test_connect_refuses_a_fractional_heartbeat_interval() {
         "the socket must never be dialled"
     );
 }
+
 // ---------------------------------------------------------------------------
 // Resend from a message store
 // ---------------------------------------------------------------------------
@@ -3195,4 +3198,775 @@ async fn test_resend_request_replays_across_store_pages() {
         ),
         "acceptor task",
     );
+}
+
+// ---------------------------------------------------------------------------
+// Outbound path: effective callbacks, a guarded public boundary, and a reactor
+// that no callback or peer can park.
+// ---------------------------------------------------------------------------
+
+/// Stamps fields onto every outbound message, so the test can look for them in
+/// the bytes the acceptor actually receives.
+#[derive(Debug)]
+struct StampingApp {
+    /// Fields appended to every administrative message.
+    admin_fields: Vec<(u32, String)>,
+    /// Fields appended to every application message.
+    app_fields: Vec<(u32, String)>,
+}
+
+impl StampingApp {
+    fn build(admin_fields: &[(u32, &str)], app_fields: &[(u32, &str)]) -> Arc<Self> {
+        let own = |fields: &[(u32, &str)]| {
+            fields
+                .iter()
+                .map(|(tag, value)| (*tag, (*value).to_string()))
+                .collect()
+        };
+        Arc::new(Self {
+            admin_fields: own(admin_fields),
+            app_fields: own(app_fields),
+        })
+    }
+}
+
+#[async_trait]
+impl Application for StampingApp {
+    async fn on_create(&self, _session_id: &SessionId) {}
+
+    async fn on_logon(&self, _session_id: &SessionId) {}
+
+    async fn on_logout(&self, _session_id: &SessionId) {}
+
+    async fn to_admin(&self, message: &mut OutboundMessage, _session_id: &SessionId) {
+        for (tag, value) in &self.admin_fields {
+            message.push_str(*tag, value);
+        }
+    }
+
+    async fn from_admin(
+        &self,
+        _message: &RawMessage<'_>,
+        _session_id: &SessionId,
+    ) -> Result<(), RejectReason> {
+        Ok(())
+    }
+
+    async fn to_app(&self, message: &mut OutboundMessage, _session_id: &SessionId) {
+        for (tag, value) in &self.app_fields {
+            message.push_str(*tag, value);
+        }
+    }
+
+    async fn from_app(
+        &self,
+        _message: &RawMessage<'_>,
+        _session_id: &SessionId,
+    ) -> Result<(), RejectReason> {
+        Ok(())
+    }
+}
+
+/// A `to_admin` mutation is what the counterparty receives. Stamping
+/// credentials onto the Logon is the documented use of the callback, and the
+/// engine used to hand the application a throwaway copy and then transmit the
+/// original.
+#[tokio::test]
+async fn test_to_admin_mutation_reaches_the_wire() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_framed(listener).await;
+        let logon = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&logon), "A");
+        // The fields the application appended, in the frame that went out.
+        assert_eq!(field(&logon, 553).as_deref(), Some("trader"));
+        assert_eq!(field(&logon, 554).as_deref(), Some("s3cret"));
+        // And the header the engine stamps is intact and unduplicated.
+        assert_eq!(field(&logon, 34).as_deref(), Some("1"));
+        assert_eq!(field(&logon, 108).as_deref(), Some("30"));
+        ok(
+            framed
+                .send(venue_msg("A", 1, &[(98, "0"), (108, "30")]))
+                .await,
+            "send logon ack",
+        );
+        framed
+    });
+
+    let app = StampingApp::build(&[(553, "trader"), (554, "s3cret")], &[]);
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), app);
+    let connection = ok(initiator.connect(addr).await, "connect");
+    let _framed = ok(acceptor.await, "acceptor task");
+    assert!(!connection.is_closed());
+}
+
+/// The same for `to_app`: a field added in the callback is encoded into the
+/// application message the counterparty receives.
+#[tokio::test]
+async fn test_to_app_mutation_reaches_the_wire() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+        let order = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&order), "D");
+        assert_eq!(field(&order, 11).as_deref(), Some("ORDER-1"));
+        assert_eq!(field(&order, 1).as_deref(), Some("ACCOUNT-9"));
+        assert_eq!(field(&order, 34).as_deref(), Some("2"));
+    });
+
+    let app = StampingApp::build(&[], &[(1, "ACCOUNT-9")]);
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), app);
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    let mut order = OutboundMessage::new(MsgType::NewOrderSingle);
+    order.push_str(11, "ORDER-1");
+    ok(connection.send(order).await, "send order");
+
+    ok(acceptor.await, "acceptor task");
+}
+
+/// Administrative traffic belongs to the session layer. A Logon, Logout or
+/// SequenceReset sent through the public path would bypass the typestate and
+/// the reactor's phase tracking.
+#[tokio::test]
+async fn test_send_refuses_admin_msg_types() {
+    let (listener, addr) = bind_listener().await;
+    let acceptor = tokio::spawn(async move { accept_logon(listener).await });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+    let connection = ok(initiator.connect(addr).await, "connect");
+    let _framed = ok(acceptor.await, "acceptor task");
+
+    for msg_type in [
+        MsgType::Logon,
+        MsgType::Logout,
+        MsgType::SequenceReset,
+        MsgType::Heartbeat,
+        MsgType::TestRequest,
+        MsgType::ResendRequest,
+        MsgType::Reject,
+    ] {
+        let expected = msg_type.as_str().to_string();
+        match connection.send(OutboundMessage::new(msg_type)).await {
+            Err(EngineError::ReservedMsgType { msg_type }) => assert_eq!(msg_type, expected),
+            other => panic!("35={expected} must be refused, got {other:?}"),
+        }
+    }
+
+    // Nothing was queued, so the session is untouched.
+    assert_eq!(connection.next_sender_seq(), 2);
+    assert!(!connection.is_closed());
+}
+
+/// A body field repeating a tag the engine stamps would give the frame two
+/// occurrences of it, which a conforming counterparty rejects or misparses.
+#[tokio::test]
+async fn test_send_refuses_reserved_header_tags() {
+    let (listener, addr) = bind_listener().await;
+    let acceptor = tokio::spawn(async move { accept_logon(listener).await });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+    let connection = ok(initiator.connect(addr).await, "connect");
+    let _framed = ok(acceptor.await, "acceptor task");
+
+    for tag in ironfix_engine::outbound::RESERVED_TAGS {
+        let mut order = OutboundMessage::new(MsgType::NewOrderSingle);
+        order.push_str(11, "ORDER-1").push_str(tag, "1");
+        match connection.send(order).await {
+            Err(EngineError::ReservedTag { tag: actual }) => assert_eq!(actual, tag),
+            other => panic!("tag {tag} must be refused, got {other:?}"),
+        }
+    }
+
+    assert_eq!(connection.next_sender_seq(), 2);
+    assert!(!connection.is_closed());
+}
+
+/// A value with no wire form is refused at the boundary rather than becoming
+/// an encoder failure after a sequence number has been spent.
+#[tokio::test]
+async fn test_send_refuses_values_with_no_wire_form() {
+    let (listener, addr) = bind_listener().await;
+    let acceptor = tokio::spawn(async move { accept_logon(listener).await });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+    let connection = ok(initiator.connect(addr).await, "connect");
+    let _framed = ok(acceptor.await, "acceptor task");
+
+    let mut empty = OutboundMessage::new(MsgType::NewOrderSingle);
+    empty.push_str(11, "");
+    match connection.send(empty).await {
+        Err(EngineError::InvalidField { tag: 11, .. }) => {}
+        other => panic!("an empty value must be refused, got {other:?}"),
+    }
+
+    let mut injected = OutboundMessage::new(MsgType::NewOrderSingle);
+    injected.push_str(58, "text\x0149=EVIL");
+    match connection.send(injected).await {
+        Err(EngineError::InvalidField { tag: 58, reason }) => {
+            assert!(
+                !reason.contains("EVIL"),
+                "the rejection must not quote the value, got {reason}"
+            );
+        }
+        other => panic!("an embedded SOH must be refused, got {other:?}"),
+    }
+
+    assert_eq!(connection.next_sender_seq(), 2);
+    assert!(!connection.is_closed());
+}
+
+/// Corrupts the first outbound application message from inside `to_app`, then
+/// leaves every later one alone.
+#[derive(Debug, Default)]
+struct CorruptFirstApp {
+    /// How many application messages have passed through `to_app`.
+    seen: AtomicU64,
+}
+
+#[async_trait]
+impl Application for CorruptFirstApp {
+    async fn on_create(&self, _session_id: &SessionId) {}
+
+    async fn on_logon(&self, _session_id: &SessionId) {}
+
+    async fn on_logout(&self, _session_id: &SessionId) {}
+
+    async fn to_admin(&self, _message: &mut OutboundMessage, _session_id: &SessionId) {}
+
+    async fn from_admin(
+        &self,
+        _message: &RawMessage<'_>,
+        _session_id: &SessionId,
+    ) -> Result<(), RejectReason> {
+        Ok(())
+    }
+
+    async fn to_app(&self, message: &mut OutboundMessage, _session_id: &SessionId) {
+        if self.seen.fetch_add(1, Ordering::SeqCst) == 0 {
+            // MsgSeqNum is stamped by the engine; a second copy would give the
+            // frame two of it.
+            message.push_str(34, "999");
+        }
+    }
+
+    async fn from_app(
+        &self,
+        _message: &RawMessage<'_>,
+        _session_id: &SessionId,
+    ) -> Result<(), RejectReason> {
+        Ok(())
+    }
+}
+
+/// A `to_app` callback that makes a message unsendable costs nothing: the
+/// message is dropped, the sequence number is not spent, and the next message
+/// takes the number the dropped one would have had. Detecting this after the
+/// allocation would leave a gap the counterparty has to resend over.
+#[tokio::test]
+async fn test_a_message_rejected_after_to_app_spends_no_sequence_number() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+        // The first order never reaches the wire; the second takes MsgSeqNum 2.
+        let order = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&order), "D");
+        assert_eq!(field(&order, 34).as_deref(), Some("2"));
+        assert_eq!(field(&order, 11).as_deref(), Some("ORDER-2"));
+        // Exactly one MsgSeqNum in the frame, not two.
+        assert_eq!(
+            String::from_utf8_lossy(&order).matches("\x0134=").count(),
+            1
+        );
+    });
+
+    let app = Arc::new(CorruptFirstApp::default());
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    let mut first = OutboundMessage::new(MsgType::NewOrderSingle);
+    first.push_str(11, "ORDER-1");
+    ok(connection.send(first).await, "queue the first order");
+
+    // Give the reactor time to process and drop it.
+    let mut waited = Duration::ZERO;
+    while app.seen.load(Ordering::SeqCst) == 0 && waited < Duration::from_secs(2) {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        waited += Duration::from_millis(20);
+    }
+    assert_eq!(
+        connection.next_sender_seq(),
+        2,
+        "a dropped message must not spend a sequence number"
+    );
+    assert!(!connection.is_closed(), "the session must survive the drop");
+
+    let mut second = OutboundMessage::new(MsgType::NewOrderSingle);
+    second.push_str(11, "ORDER-2");
+    ok(connection.send(second).await, "queue the second order");
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor must finish",
+        ),
+        "acceptor task",
+    );
+}
+
+/// Records how long `from_app` was inside the callback, so a test can hold the
+/// application up while asserting the reactor kept working.
+#[derive(Debug)]
+struct SlowApp {
+    /// How long `from_app` blocks.
+    delay: Duration,
+    /// Fires when `from_app` is entered.
+    entered: mpsc::UnboundedSender<u64>,
+}
+
+impl SlowApp {
+    fn build(delay: Duration) -> (Arc<Self>, mpsc::UnboundedReceiver<u64>) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        (Arc::new(Self { delay, entered: tx }), rx)
+    }
+}
+
+#[async_trait]
+impl Application for SlowApp {
+    async fn on_create(&self, _session_id: &SessionId) {}
+
+    async fn on_logon(&self, _session_id: &SessionId) {}
+
+    async fn on_logout(&self, _session_id: &SessionId) {}
+
+    async fn to_admin(&self, _message: &mut OutboundMessage, _session_id: &SessionId) {}
+
+    async fn from_admin(
+        &self,
+        _message: &RawMessage<'_>,
+        _session_id: &SessionId,
+    ) -> Result<(), RejectReason> {
+        Ok(())
+    }
+
+    async fn to_app(&self, _message: &mut OutboundMessage, _session_id: &SessionId) {}
+
+    async fn from_app(
+        &self,
+        message: &RawMessage<'_>,
+        _session_id: &SessionId,
+    ) -> Result<(), RejectReason> {
+        let seq = message
+            .get_field_str(34)
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or_default();
+        let _ = self.entered.send(seq);
+        tokio::time::sleep(self.delay).await;
+        Ok(())
+    }
+}
+
+/// A slow `from_app` no longer stalls the reactor: while the application is
+/// blocked inside the callback, the heartbeat the session owes its
+/// counterparty still goes out.
+#[tokio::test]
+async fn test_slow_from_app_does_not_stall_heartbeats() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_framed(listener).await;
+        let logon = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&logon), "A");
+        ok(
+            framed
+                .send(venue_msg("A", 1, &[(98, "0"), (108, "1")]))
+                .await,
+            "send logon ack",
+        );
+
+        // One application message, which the handler will sit on for 3s.
+        ok(
+            framed
+                .send(venue_msg(
+                    "8",
+                    2,
+                    &[
+                        (37, "EX-1"),
+                        (11, "ORDER-1"),
+                        (17, "E-1"),
+                        (150, "0"),
+                        (39, "0"),
+                    ],
+                ))
+                .await,
+            "send execution report",
+        );
+
+        // The reactor must keep working while the handler is blocked. Answer
+        // any TestRequest so the session stays alive, and stop as soon as a
+        // Heartbeat proves the timer arm still runs.
+        let deadline = tokio::time::Instant::now() + Duration::from_millis(2500);
+        loop {
+            let Ok(polled) = tokio::time::timeout_at(deadline, framed.next()).await else {
+                return false;
+            };
+            let Some(Ok(frame)) = polled else {
+                return false;
+            };
+            match msg_type_of(&frame).as_str() {
+                "0" => return true,
+                "1" => {
+                    let id = some(field(&frame, 112), "TestRequest must carry TestReqID");
+                    ok(
+                        framed.send(venue_msg("0", 3, &[(112, &id)])).await,
+                        "answer the TestRequest",
+                    );
+                }
+                _ => {}
+            }
+        }
+    });
+
+    let (app, mut entered) = SlowApp::build(Duration::from_secs(3));
+    let initiator = Initiator::new(client_config(Duration::from_secs(1)), Arc::clone(&app));
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    // The handler really did get the message and really is blocked in it.
+    let seq = ok(
+        timeout(Duration::from_secs(2), entered.recv()).await,
+        "from_app must be entered",
+    );
+    assert_eq!(seq, Some(2));
+
+    let saw_heartbeat = ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor must finish",
+        ),
+        "acceptor task",
+    );
+    assert!(
+        saw_heartbeat,
+        "the reactor must emit a heartbeat while from_app is blocked"
+    );
+    assert!(!connection.is_closed());
+}
+
+/// A counterparty that stops reading closes its TCP receive window, and a
+/// write into a closed window never completes. The write timeout turns that
+/// into a session close in bounded time instead of a reactor parked forever
+/// with its liveness timers.
+#[tokio::test]
+async fn test_stalled_peer_write_timeout_closes_the_session() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let framed = accept_logon(listener).await;
+        // Hold the socket open and never read again.
+        tokio::time::sleep(Duration::from_secs(20)).await;
+        drop(framed);
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app))
+        .with_write_timeout(Duration::from_millis(300));
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    // Push until the socket buffers fill and the reactor's write parks. The
+    // command queue is bounded, so this throttles itself rather than
+    // allocating without limit.
+    let pushed = timeout(Duration::from_secs(15), async {
+        loop {
+            let mut order = OutboundMessage::new(MsgType::NewOrderSingle);
+            order
+                .push_str(11, "ORDER-1")
+                .push_raw(58, vec![b'x'; 60_000]);
+            if connection.send(order).await.is_err() {
+                return;
+            }
+        }
+    })
+    .await;
+    ok(pushed, "the session must close rather than block forever");
+
+    ok(
+        timeout(Duration::from_secs(5), connection.wait_closed()).await,
+        "wait_closed must fire after the write timeout",
+    );
+    assert!(connection.is_closed());
+    acceptor.abort();
+}
+
+/// Removes a configured tag from every administrative message in `to_admin`,
+/// standing in for a callback that strips a field the message cannot go out
+/// without.
+#[derive(Debug)]
+struct DropAdminFieldApp {
+    /// The tag removed from every admin message.
+    tag: u32,
+}
+
+#[async_trait]
+impl Application for DropAdminFieldApp {
+    async fn on_create(&self, _session_id: &SessionId) {}
+
+    async fn on_logon(&self, _session_id: &SessionId) {}
+
+    async fn on_logout(&self, _session_id: &SessionId) {}
+
+    async fn to_admin(&self, message: &mut OutboundMessage, _session_id: &SessionId) {
+        message.remove(self.tag);
+    }
+
+    async fn from_admin(
+        &self,
+        _message: &RawMessage<'_>,
+        _session_id: &SessionId,
+    ) -> Result<(), RejectReason> {
+        Ok(())
+    }
+
+    async fn to_app(&self, _message: &mut OutboundMessage, _session_id: &SessionId) {}
+
+    async fn from_app(
+        &self,
+        _message: &RawMessage<'_>,
+        _session_id: &SessionId,
+    ) -> Result<(), RejectReason> {
+        Ok(())
+    }
+}
+
+/// A `to_admin` that drops a required field cannot put a malformed
+/// administrative frame on the wire: the Logon, stripped of HeartBtInt (108), is
+/// refused before it is written and the handshake fails with a typed error
+/// rather than the engine emitting a Logon every venue would reject.
+#[tokio::test]
+async fn test_to_admin_dropping_a_required_admin_field_fails_the_handshake() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_framed(listener).await;
+        // The Logon is refused before the socket write, so the venue must never
+        // receive a frame — it observes either silence or the client closing.
+        if let Ok(Some(Ok(frame))) = timeout(Duration::from_millis(500), framed.next()).await {
+            panic!("no frame must be sent, got 35={}", msg_type_of(&frame));
+        }
+    });
+
+    let app = Arc::new(DropAdminFieldApp { tag: 108 });
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), app);
+
+    match initiator.connect(addr).await {
+        Err(EngineError::MissingRequiredField { msg_type, tag }) => {
+            assert_eq!(msg_type, "A");
+            assert_eq!(tag, 108);
+        }
+        other => panic!("expected MissingRequiredField, got {other:?}"),
+    }
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+}
+
+/// Corrupts every Logout from inside `to_admin` so it has no legal wire form,
+/// leaving every other administrative message untouched.
+#[derive(Debug)]
+struct CorruptLogoutApp;
+
+#[async_trait]
+impl Application for CorruptLogoutApp {
+    async fn on_create(&self, _session_id: &SessionId) {}
+
+    async fn on_logon(&self, _session_id: &SessionId) {}
+
+    async fn on_logout(&self, _session_id: &SessionId) {}
+
+    async fn to_admin(&self, message: &mut OutboundMessage, _session_id: &SessionId) {
+        if message.msg_type() == &MsgType::Logout {
+            // An embedded SOH leaves the value with no legal wire form, so the
+            // Logout is dropped after the callback rather than framed.
+            message.push_str(58, "bye\x01evil");
+        }
+    }
+
+    async fn from_admin(
+        &self,
+        _message: &RawMessage<'_>,
+        _session_id: &SessionId,
+    ) -> Result<(), RejectReason> {
+        Ok(())
+    }
+
+    async fn to_app(&self, _message: &mut OutboundMessage, _session_id: &SessionId) {}
+
+    async fn from_app(
+        &self,
+        _message: &RawMessage<'_>,
+        _session_id: &SessionId,
+    ) -> Result<(), RejectReason> {
+        Ok(())
+    }
+}
+
+/// An administrative message a callback made unsendable must not advance the
+/// state machine as if it had gone out. A `to_admin` that corrupts the Logout
+/// leaves nothing on the wire, so the reactor must stay Active — before the fix
+/// it entered LogoutPending anyway and closed the session at the logout
+/// deadline, tearing it down over a Logout the peer was never told about.
+#[tokio::test]
+async fn test_admin_message_rejected_by_callback_does_not_enter_logout_pending() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+        // The Logout never reaches the wire; hold the socket open and readable
+        // so the client closes on neither a write nor a transport error.
+        let _ = timeout(Duration::from_secs(2), framed.next()).await;
+    });
+
+    let app = Arc::new(CorruptLogoutApp);
+    let mut config = client_config(Duration::from_secs(30));
+    config.logout_timeout = Duration::from_millis(300);
+    let initiator = Initiator::new(config, app);
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    ok(connection.logout().await, "logout");
+
+    // Wait well past the logout deadline: a session that wrongly entered
+    // LogoutPending would have closed by now.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    assert!(
+        !connection.is_closed(),
+        "a Logout that never went out must not close the session"
+    );
+    assert_eq!(
+        connection.next_sender_seq(),
+        2,
+        "the dropped Logout must spend no sequence number"
+    );
+
+    acceptor.abort();
+}
+
+/// A `from_app` that never returns, bumping a counter each time it wakes so a
+/// test can tell an aborted dispatcher (counter frozen) from a detached one
+/// (counter still climbing).
+#[derive(Debug)]
+struct WedgedApp {
+    /// Bumped on every loop iteration inside `from_app`.
+    ticks: Arc<AtomicU64>,
+    /// Fires once when `from_app` is entered.
+    entered: mpsc::UnboundedSender<()>,
+}
+
+#[async_trait]
+impl Application for WedgedApp {
+    async fn on_create(&self, _session_id: &SessionId) {}
+
+    async fn on_logon(&self, _session_id: &SessionId) {}
+
+    async fn on_logout(&self, _session_id: &SessionId) {}
+
+    async fn to_admin(&self, _message: &mut OutboundMessage, _session_id: &SessionId) {}
+
+    async fn from_admin(
+        &self,
+        _message: &RawMessage<'_>,
+        _session_id: &SessionId,
+    ) -> Result<(), RejectReason> {
+        Ok(())
+    }
+
+    async fn to_app(&self, _message: &mut OutboundMessage, _session_id: &SessionId) {}
+
+    async fn from_app(
+        &self,
+        _message: &RawMessage<'_>,
+        _session_id: &SessionId,
+    ) -> Result<(), RejectReason> {
+        let _ = self.entered.send(());
+        // Never returns: the dispatcher can only leave this handler by being
+        // aborted.
+        loop {
+            self.ticks.fetch_add(1, Ordering::SeqCst);
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    }
+}
+
+/// A `from_app` still wedged when the session closes is aborted, not detached,
+/// so it cannot outlive `on_logout` / `wait_closed`. The handler's tick counter
+/// stops climbing after the close; a detached task would keep running.
+#[tokio::test]
+async fn test_wedged_from_app_is_aborted_when_the_session_closes() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+        // One application message to wedge the handler on.
+        ok(
+            framed
+                .send(venue_msg(
+                    "8",
+                    2,
+                    &[(37, "EX-1"), (17, "E-1"), (150, "0"), (39, "0")],
+                ))
+                .await,
+            "send report",
+        );
+        // Let the handler enter, then close the session from the venue side.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        ok(framed.send(venue_msg("5", 3, &[])).await, "send logout");
+        // Keep the socket open and drain the client's reply until the test
+        // aborts this task.
+        while let Ok(Some(Ok(_))) = timeout(Duration::from_secs(10), framed.next()).await {}
+    });
+
+    let ticks = Arc::new(AtomicU64::new(0));
+    let (entered_tx, mut entered_rx) = mpsc::unbounded_channel();
+    let app = Arc::new(WedgedApp {
+        ticks: Arc::clone(&ticks),
+        entered: entered_tx,
+    });
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    // The handler really is inside from_app.
+    ok(
+        timeout(Duration::from_secs(2), entered_rx.recv()).await,
+        "from_app must be entered",
+    );
+
+    // The counterparty Logout closes the session; the reactor drains for its
+    // bounded window and then aborts the still-wedged dispatcher.
+    ok(
+        timeout(Duration::from_secs(10), connection.wait_closed()).await,
+        "closed within 10s",
+    );
+
+    // Let any in-flight cancellation land, then confirm the loop is dead: an
+    // aborted task makes no further progress, a detached one keeps ticking.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    let first = ticks.load(Ordering::SeqCst);
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    let second = ticks.load(Ordering::SeqCst);
+    assert_eq!(
+        first, second,
+        "an aborted dispatcher must stop; a detached one would keep ticking \
+         (first={first}, second={second})"
+    );
+
+    acceptor.abort();
 }

--- a/ironfix-example/examples/fix44_engine_client.rs
+++ b/ironfix-example/examples/fix44_engine_client.rs
@@ -40,11 +40,15 @@ impl Application for LoggingApp {
         info!("logged out: {session_id}");
     }
 
-    async fn to_admin(
-        &self,
-        _message: &mut ironfix_core::message::OwnedMessage,
-        _session_id: &SessionId,
-    ) {
+    /// Stamps credentials onto the outbound Logon.
+    ///
+    /// The body is mutable and the engine encodes exactly what this hands
+    /// back, so the fields added here reach the counterparty. Every other
+    /// administrative message goes out untouched.
+    async fn to_admin(&self, message: &mut OutboundMessage, _session_id: &SessionId) {
+        if message.msg_type() == &MsgType::Logon {
+            message.push_str(553, "DEMO-USER");
+        }
     }
 
     async fn from_admin(
@@ -55,12 +59,7 @@ impl Application for LoggingApp {
         Ok(())
     }
 
-    async fn to_app(
-        &self,
-        _message: &mut ironfix_core::message::OwnedMessage,
-        _session_id: &SessionId,
-    ) {
-    }
+    async fn to_app(&self, _message: &mut OutboundMessage, _session_id: &SessionId) {}
 
     async fn from_app(
         &self,


### PR DESCRIPTION
## Summary

Makes the outbound and callback paths do what their documentation promises: mutable interception that reaches the wire, a public send that cannot inject administrative traffic, and a reactor a slow callback cannot stall.

Closes #11.

## Stack

- **Base branch:** `stack/17-session-config` (PR #41)

## What was wrong

**`to_admin` / `to_app` mutations were silently discarded.** The contract promised mutable interception — the documented use is stamping authentication fields onto an outbound Logon — but the engine built a **detached** `OwnedMessage`, handed it to the application, and then transmitted the *original* frame. Neither mutating nor replacing it had any effect; the callback was a lie. The callbacks now operate on the `OutboundMessage` the engine actually encodes, so a stamped field reaches the wire.

**Administrative MsgTypes and reserved tags were injectable through `Connection::send`.** The public path accepted any MsgType, so an application could emit Logon, Logout or SequenceReset outside the state machine, and could append reserved header/trailer tags (8, 9, 10, 34, 35, 43, 49, 50, 52, 56, 57, 122, 1128) producing duplicates a conforming counterparty rejects. Both are refused at the public boundary now — administrative messages belong to the session layer alone.

**The reactor blocked on every application callback.** They were awaited inline, so a slow `from_app` stalled socket reads, heartbeat generation and timeout handling, and a stalled peer blocked all three. Inbound application messages go to a **separate dispatcher task** now, so `from_app` cannot stall the reactor. `to_admin`, `to_app` and `from_admin` stay inline by design — each for a documented reason, since each must run at a point in the outbound or handshake sequence where deferring it would change behaviour — and the ordering the session layer depends on is preserved.

## Two deferred follow-ups, now done

Both were explicitly punted to this issue by earlier PRs:

- **`OutboundMessage` is validated before its sequence number is allocated.** Encoding became fallible earlier in the stack, and a value with no legal wire form was detected *after* the number was spent, tearing the session down to avoid a gap. Validating first turns that into a clean rejection with the session intact.
- **`MessageFactory` reuses one encoder** rather than building a fresh one per message.

No performance number is claimed — there is no benchmark harness on this branch.

## What must not regress

The inbound path from #25/#37 is untouched and still tested: GapFill distinguished from Reset, bounded ResendRequest reply carrying `MsgSeqNum = BeginSeqNo`, CompID reason 9, inbound `141=Y` requiring MsgSeqNum 1, checked sequence arithmetic, and the rejected-in-sequence-GapFill-consumes-its-number path.

## Public API changes (semver)

`to_admin`/`to_app` take `&mut OutboundMessage`; `EngineError` gains `ReservedMsgType` and `ReservedTag`; `RESERVED_TAGS` is exposed. Workspace is at 0.4.0.

## Tests

Workspace goes to **493 passing**, including a stub-acceptor test with a deliberately slow callback that asserts heartbeats still go out — the one that proves the reactor no longer blocks.

## Verification

```
cargo test --workspace                                    # 493 passed
cargo clippy --all-targets --all-features -- -D warnings  # clean
cargo fmt --all --check                                   # clean
make doc                                                  # clean
```
