### PR TITLE
fix(engine): bound resend recovery, validate SendingTime, place CompIDs

### DIFF
--- a/doc/fix_operations.md
+++ b/doc/fix_operations.md
@@ -63,12 +63,17 @@ and stops at the first failure:
    `target_comp_id` and inbound `TargetCompID` (56) the configured
    `sender_comp_id`; when `sender_sub_id` / `target_sub_id` are configured,
    inbound `TargetSubID` (57) and `SenderSubID` (50) are checked the same way.
-   A mismatch produces a session Reject with reason 9 (CompID problem) followed
-   by a Logout, and the handshake fails. This is checked before any callback
-   runs and before sequence state moves, so a cross-wired connection can never
-   establish a session.
-3. **`from_admin`.** A rejection sends a Logout and fails the handshake.
-4. **`HeartBtInt` (108).** 108 is a *required* field of the Logon, so an ack
+   Each must both carry the expected value **and** occur in the standard header:
+   a CompID that appears only after the message body identifies nothing and is
+   treated as missing. A mismatch or a misplacement produces a session Reject
+   with reason 9 (CompID problem) followed by a Logout, and the handshake fails.
+   This is checked before any callback runs and before sequence state moves, so
+   a cross-wired connection can never establish a session.
+3. **`SendingTime` (52).** Validated against the local clock (see "Reject",
+   reason 10). A skew beyond the tolerance, an absent field, or an unparseable
+   one Rejects and fails the handshake, before the heartbeat clock is set.
+4. **`from_admin`.** A rejection sends a Logout and fails the handshake.
+5. **`HeartBtInt` (108).** 108 is a *required* field of the Logon, so an ack
    that omits it (session Reject, reason 1 — required tag missing) or carries a
    non-numeric value (session Reject, reason 6 — incorrect data format for
    value), `RefTagID` = 108 in both cases and each followed by a Logout, fails
@@ -86,7 +91,7 @@ and stops at the first failure:
    requested: echoing our own configuration back is our choice, not the
    counterparty pushing us past the ceiling. `108=0` is legal and always
    accepted; see "Heartbeat" below for what it means.
-5. **`ResetSeqNumFlag` (141).** `141=Y` on the ack must arrive under
+6. **`ResetSeqNumFlag` (141).** `141=Y` on the ack must arrive under
    `MsgSeqNum = 1` — the reset and the number carrying it have to describe the
    same stream — and a peer that sends any other number fails the handshake
    rather than having one half of the contradiction guessed for it. It is
@@ -101,12 +106,14 @@ and stops at the first failure:
    — its initiator would set 1, its acceptor 2 — and IronFix matches the
    acceptor. The mismatch self-heals: the peer sees a gap at 2, requests a
    resend of 1, and receives a GapFill that resynchronises it.
-6. **`MsgSeqNum` (34).** Too low fails the handshake; a gap completes the
+7. **`MsgSeqNum` (34).** Too low fails the handshake; a gap completes the
    handshake and immediately issues a ResendRequest.
 
-The same identity check (step 2) runs on every inbound frame once the session
-is established; there a mismatch produces the Reject and Logout and then tears
-the session down.
+The same identity and `SendingTime` checks (steps 2 and 3) run on every inbound
+frame once the session is established; there a failure produces the Reject and
+Logout and then tears the session down. An unsatisfied ResendRequest from step 7
+does not stall forever — it is retried and then escalated to Logout; see "Resend
+Request".
 
 Outbound `ResetSeqNumFlag` is driven by `SessionConfig::reset_on_logon`.
 
@@ -367,6 +374,18 @@ isolated follow-up work. (The inbound direction is unaffected in practice: a
 because the GapFill's `NewSeqNo` is capped at our next outbound sequence
 regardless.)
 
+**Outbound resend recovery is bounded.** When *this* engine detects an inbound
+gap it sends a `ResendRequest` and waits. A peer that never satisfies it — while
+its other traffic keeps the heartbeat clock alive — used to hold the session
+open indefinitely, the inbound expectation pinned and nothing reaching the
+application. The request is now retried every
+`SessionConfig::resend_timeout` (default **10 seconds**), up to
+`SessionConfig::resend_attempt_limit` attempts (default **3**, counting the
+first). Once the attempts are spent the session is logged out with a `Text` (58)
+naming the stalled sequence number, turning a silent stall into an observable,
+graceful close. Any in-sequence message clears the outstanding request, so the
+timer measures a gap that is making no progress at all, not a slow replay.
+
 ---
 
 ### Reject (MsgType = 3)
@@ -410,18 +429,25 @@ regardless.)
 
 | Code | Emitted when |
 |---|---|
-| 1 | `SequenceReset` without `NewSeqNo` (36); `ResendRequest` without `BeginSeqNo` (7) or `EndSeqNo` (16) |
+| 1 | `SequenceReset` without `NewSeqNo` (36); `ResendRequest` without `BeginSeqNo` (7) or `EndSeqNo` (16); inbound `SendingTime` (52) absent |
 | 5 | `SequenceReset` whose `NewSeqNo` would rewind or fails to advance; `ResendRequest` whose range is outside what we have sent |
-| 6 | `SequenceReset` with a malformed `GapFillFlag` (123) that is present but neither `Y` nor `N` |
-| 9 | Inbound `SenderCompID`/`TargetCompID` (and `SenderSubID`/`TargetSubID` when configured) do not match the session configuration |
+| 6 | `SequenceReset` with a malformed `GapFillFlag` (123) that is present but neither `Y` nor `N`; inbound `SendingTime` (52) present but not a `UTCTimestamp` |
+| 9 | Inbound `SenderCompID`/`TargetCompID` (and `SenderSubID`/`TargetSubID` when configured) do not match the session configuration, **or** appear outside the standard header |
+| 10 | Inbound `SendingTime` (52) differs from the local clock by more than the configured tolerance |
 | any | Whatever an `Application::from_admin` / `from_app` implementation returns in its `RejectReason` |
 
-**Reason 10 (SendingTime accuracy) is not implemented.** `SendingTime` (52) is
-never compared against the local clock. Doing so requires a tolerance window,
-and a tolerance is a policy decision — it needs its own typed
-`SessionConfig` knob with a defensible default and a documented unit and range,
-not a guessed constant. Until that decision is made, a message with a wildly
-skewed `SendingTime` is accepted. This is a known, deliberate omission.
+**Reason 10 (SendingTime accuracy) is implemented.** Every inbound frame's
+`SendingTime` (52) is compared against the local clock, immediately after the
+CompID check and before the heartbeat clock is refreshed. The tolerance is the
+typed `SessionConfig::sending_time_tolerance`, defaulting to **120 seconds** in
+either direction — the interval FIX engines have converged on (QuickFIX's
+`MaxLatency`): far more slack than an NTP-synchronised host ever needs, yet
+tight enough that an unsynchronised clock is caught within days. A value outside
+the window is rejected with reason 10 (`RefTagID` = 52), an absent field with
+reason 1, and an unparseable one with reason 6; in each case the session is then
+logged out, because a wrong clock is systemic rather than per-message. Setting
+the tolerance to `Duration::ZERO` disables the check — including the presence and
+format checks — for a peer with a known clock problem.
 
 ---
 
@@ -989,7 +1015,10 @@ Rationale for the two policies:
   messages and unavailable sequence numbers gap-filled. Two limits are worth
   stating: the store is **opt-in**, and without one the whole range is still
   answered with a single gap fill; and `MemoryStore` is not persistent, so
-  nothing is replayable after a restart. See "Resend Request" above.
+  nothing is replayable after a restart. An *outbound* request the peer never
+  satisfies is also bounded — retried every `SessionConfig::resend_timeout` and
+  then escalated to Logout after `SessionConfig::max_resend_requests` attempts,
+  rather than stalling the session forever. See "Resend Request" above.
 
 ### Phase 2: Order Entry (High Priority)
 - [ ] New Order Single

--- a/ironfix-engine/src/error.rs
+++ b/ironfix-engine/src/error.rs
@@ -129,6 +129,15 @@ pub enum EngineError {
         received: String,
     },
 
+    /// The counterparty's `SendingTime` (52) failed validation: absent,
+    /// unparseable, or further from the local clock than
+    /// `SessionConfig::sending_time_tolerance` allows.
+    #[error("SendingTime problem: {detail}")]
+    SendingTime {
+        /// Which check failed, with the offending value or the measured skew.
+        detail: String,
+    },
+
     /// The configured `BeginString` cannot be framed conformantly.
     ///
     /// An unknown version, or `FIXT.1.1` on its own — which names the

--- a/ironfix-engine/src/initiator.rs
+++ b/ironfix-engine/src/initiator.rs
@@ -20,10 +20,27 @@
 //! # Inbound conformance
 //!
 //! Every inbound frame is checked in this order: decode, `MsgSeqNum` (34)
-//! presence, counterparty identity (49/56, plus 50/57 when configured), then
-//! heartbeat bookkeeping, then sequence validation. Identity comes before the
-//! heartbeat clock deliberately — traffic from the wrong counterparty must not
-//! keep the session alive, reach the [`Application`], or move sequence state.
+//! presence, counterparty identity (49/56, plus 50/57 when configured),
+//! `SendingTime` (52) accuracy, then heartbeat bookkeeping, then sequence
+//! validation. Identity and clock come before the heartbeat bookkeeping
+//! deliberately — traffic from the wrong counterparty, or from one whose clock
+//! is wrong, must not keep the session alive, reach the [`Application`], or
+//! move sequence state.
+//!
+//! Both of those failures end the session after a Reject and a Logout, because
+//! both are systemic rather than per-message: a peer that is cross-wired, or
+//! whose clock is two minutes out, will be so on its next message too.
+//!
+//! # Bounded recovery
+//!
+//! A gap is answered with a `ResendRequest` (2), and a request that goes
+//! unanswered does not wait forever: it is retried every
+//! [`SessionConfig::resend_timeout`] up to
+//! [`SessionConfig::resend_attempt_limit`] attempts, after which the session is
+//! logged out. Without that bound a peer that keeps sending gapped frames holds
+//! a session open indefinitely — the frames refresh the heartbeat clock, so
+//! nothing times out, while the inbound expectation never moves and nothing
+//! reaches the application.
 //!
 //! # Heartbeats
 //!
@@ -119,7 +136,10 @@ use crate::application::{Application, NoOpApplication, RejectReason, SessionId};
 use crate::connection::{Command, Connection, SessionRuntime};
 use crate::error::EngineError;
 use crate::outbound;
-use crate::wire::{self, MessageFactory, PeerIdentity, PendingMessage, UnsupportedVersion};
+use crate::wire::{
+    self, MessageFactory, PeerIdentity, PendingMessage, SendingTimeGuard, SendingTimeProblem,
+    UnsupportedVersion,
+};
 use bytes::{Bytes, BytesMut};
 use futures_util::{SinkExt, StreamExt};
 use ironfix_core::error::{DecodeError, EncodeError};
@@ -136,7 +156,7 @@ use ironfix_store::MessageStore;
 use ironfix_transport::FixCodec;
 use std::num::NonZeroU64;
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::net::{TcpStream, ToSocketAddrs};
 use tokio::sync::{mpsc, watch};
 use tokio::task::JoinHandle;
@@ -572,6 +592,7 @@ impl<A: Application + 'static> Initiator<A> {
         });
         let mut factory = MessageFactory::new(&self.config, version);
         let identity = PeerIdentity::new(&self.config);
+        let sending_time = SendingTimeGuard::new(&self.config);
         let write_timeout = self.write_timeout;
         let store = self.store.as_ref();
 
@@ -618,7 +639,8 @@ impl<A: Application + 'static> Initiator<A> {
             Ok(Some(Ok(frame))) => frame,
         };
 
-        let mut pending_resend = None;
+        // (gap start, high-water) of a gap detected in the Logon ack itself.
+        let mut pending_resend: Option<(u64, u64)> = None;
         {
             let raw = wire::decode_frame(&ack)?;
             match raw.msg_type() {
@@ -696,6 +718,41 @@ impl<A: Application + 'static> Initiator<A> {
                 .await;
                 let _ = session.on_logon_reject();
                 return Err(EngineError::IdentityMismatch { detail });
+            }
+
+            // The clock is checked on the ack for the same reason it is checked
+            // on every later frame: a peer whose SendingTime is wildly skewed
+            // cannot be trusted to sequence a session, and the handshake is the
+            // cheapest place to refuse it.
+            if let Err(problem) = sending_time.validate(&raw) {
+                let detail = problem.to_string();
+                let reason = problem.reject_reason();
+                let reject = factory.session_reject(ack_seq, MsgType::Logon.as_str(), &reason);
+                let _ = send_handshake_admin(
+                    self.application.as_ref(),
+                    &session_id,
+                    &mut framed,
+                    &mut factory,
+                    &runtime.sequences,
+                    store,
+                    write_timeout,
+                    reject,
+                )
+                .await;
+                let logout = factory.logout(Some(&detail));
+                let _ = send_handshake_admin(
+                    self.application.as_ref(),
+                    &session_id,
+                    &mut framed,
+                    &mut factory,
+                    &runtime.sequences,
+                    store,
+                    write_timeout,
+                    logout,
+                )
+                .await;
+                let _ = session.on_logon_reject();
+                return Err(EngineError::SendingTime { detail });
             }
 
             if let Err(reason) = self.application.from_admin(&raw, &session_id).await {
@@ -867,7 +924,9 @@ impl<A: Application + 'static> Initiator<A> {
                         "logon ack MsgSeqNum too low: expected {expected}, received {received}"
                     )));
                 }
-                SequenceResult::Gap { expected, .. } => pending_resend = Some(expected),
+                SequenceResult::Gap { expected, received } => {
+                    pending_resend = Some((expected, received));
+                }
             }
         }
 
@@ -877,7 +936,7 @@ impl<A: Application + 'static> Initiator<A> {
         tracing::info!(session = %session_id, "FIX session established");
 
         // A gap in the Logon ack means we missed messages: request a resend.
-        if let Some(expected) = pending_resend {
+        if let Some((expected, _high_water)) = pending_resend {
             let request = factory.resend_request(expected, 0);
             send_handshake_admin(
                 self.application.as_ref(),
@@ -907,15 +966,18 @@ impl<A: Application + 'static> Initiator<A> {
             reject_tx,
         ));
 
+        let resend = pending_resend
+            .map(|(expected, high_water)| ResendState::first(expected, high_water, &self.config));
         let reactor = Reactor {
             factory,
             identity,
+            sending_time,
             runtime: Arc::clone(&runtime),
             config: self.config.clone(),
             application: Arc::clone(&self.application),
             session_id: session_id.clone(),
             store: self.store.clone(),
-            pending_resend,
+            resend,
             write_timeout,
             app_tx,
         };
@@ -1209,12 +1271,90 @@ struct ReactorChannels {
     dispatcher: JoinHandle<()>,
 }
 
+/// Bookkeeping for an outstanding `ResendRequest` (2).
+///
+/// A resend that is never satisfied must not keep the session open forever:
+/// gapped frames refresh the heartbeat clock, so the heartbeat timeout never
+/// fires while the inbound expectation sits pinned. This tracks the gap so the
+/// reactor can retry the request and, once the attempts are spent, log the
+/// session out instead of waiting on a peer that is not answering.
+#[derive(Debug, Clone, Copy)]
+struct ResendState {
+    /// The next sequence number the recovery is waiting to receive. It advances
+    /// with in-order inbound progress so a retry re-requests from the current
+    /// gap start, never a number already consumed.
+    expected: u64,
+    /// The top of the outstanding range: the highest sequence number seen while
+    /// the gap has been open. The request is open-ended (`EndSeqNo` = 0), so
+    /// this is the water mark the expectation must cross for the gap to be
+    /// considered closed — clearing recovery on the first in-order message
+    /// instead would forget that later numbers in the range are still missing.
+    high_water: u64,
+    /// When the most recent request for this gap was sent.
+    requested_at: Instant,
+    /// How many requests have been sent for this gap, counting the first.
+    attempts: u32,
+    /// Attempt ceiling, resolved once from the configuration.
+    limit: u32,
+    /// How long a request may make no progress before it is retried.
+    timeout: Duration,
+}
+
+impl ResendState {
+    /// Opens recovery for a gap at `expected`, with `high_water` the highest
+    /// sequence number outstanding, counting the first request.
+    #[must_use]
+    fn first(expected: u64, high_water: u64, config: &SessionConfig) -> Self {
+        Self {
+            expected,
+            high_water,
+            requested_at: Instant::now(),
+            attempts: 1,
+            limit: config.resend_attempt_limit(),
+            timeout: config.resend_timeout,
+        }
+    }
+
+    /// Whether this gap has waited longer than its retry timeout.
+    #[must_use]
+    fn is_stalled(&self) -> bool {
+        self.requested_at.elapsed() >= self.timeout
+    }
+
+    /// Whether another request may still be sent for this gap.
+    #[must_use]
+    const fn can_retry(&self) -> bool {
+        self.attempts < self.limit
+    }
+
+    /// Records that another request for this same gap has gone out.
+    fn record_retry(&mut self) {
+        self.requested_at = Instant::now();
+        self.attempts = self.attempts.saturating_add(1);
+    }
+
+    /// Records genuine in-order progress within the outstanding range.
+    ///
+    /// The gap start has advanced to `expected`, so the stall clock and the
+    /// retry budget both reset: a peer that is actively feeding the gap has
+    /// proved itself responsive and must not be logged out for being slow. A
+    /// duplicate or an out-of-order frame makes no such progress and so does not
+    /// reach here.
+    fn record_progress(&mut self, expected: u64) {
+        self.expected = expected;
+        self.requested_at = Instant::now();
+        self.attempts = 1;
+    }
+}
+
 /// Reactor state shared across event handlers.
 struct Reactor<A: Application> {
     /// Outbound frame factory, holding the encoder reused for every message.
     factory: MessageFactory,
     /// Identity every inbound message must carry.
     identity: PeerIdentity,
+    /// Clock-skew check applied to every inbound `SendingTime` (52).
+    sending_time: SendingTimeGuard,
     /// Shared session runtime (sequences + heartbeat).
     runtime: Arc<SessionRuntime>,
     /// Session configuration.
@@ -1225,12 +1365,12 @@ struct Reactor<A: Application> {
     session_id: SessionId,
     /// Optional message store for outbound frames and resend replay.
     store: Option<Arc<dyn MessageStore>>,
-    /// Expected sequence number a pending ResendRequest was issued for.
+    /// The outstanding ResendRequest, if a gap is being recovered.
     ///
     /// The logout deadline is *not* tracked here: `Session<LogoutPending>`
     /// carries the instant the Logout went out, so the phase itself is the
     /// deadline.
-    pending_resend: Option<u64>,
+    resend: Option<ResendState>,
     /// Bound on a single socket write.
     write_timeout: Duration,
     /// Hand-off queue to the application dispatcher.
@@ -1619,26 +1759,42 @@ impl<A: Application> Reactor<A> {
             }
             Command::Logout => match phase {
                 Phase::LogoutPending(_) => Ok(phase),
-                Phase::Active(session) => {
-                    let logout = self.factory.logout(None);
-                    match self.send(framed, logout).await {
-                        Err(err) => {
-                            let _ = session.disconnect();
-                            Err(closed(format!("send failed: {err}"), false))
-                        }
-                        // The Logout never reached the wire — a `to_admin`
-                        // callback left it unframeable. Staying Active is the
-                        // honest verdict: arming the logout deadline for a frame
-                        // the peer never saw would tear the session down over a
-                        // Logout it was never told about.
-                        Ok(Sent::Dropped) => Ok(Phase::Active(session)),
-                        // Typestate: Active -> LogoutPending. The new state
-                        // records when the Logout went out, which is what
-                        // on_tick times.
-                        Ok(Sent::Yes) => Ok(Phase::LogoutPending(session.initiate_logout())),
-                    }
-                }
+                Phase::Active(session) => self.begin_logout(framed, session, None).await,
             },
+        }
+    }
+
+    /// Sends a Logout (35=5) and moves the session to LogoutPending, where it
+    /// waits for the acknowledgement until `logout_timeout` expires.
+    ///
+    /// `text` is the `Text` (58) explaining an engine-initiated logout; a
+    /// consumer-initiated one carries none.
+    async fn begin_logout(
+        &mut self,
+        framed: &mut FixFramed,
+        session: Session<Active>,
+        text: Option<&str>,
+    ) -> Result<Phase, SessionClosed> {
+        let logout = self.factory.logout(text);
+        match self.send(framed, logout).await {
+            Err(err) => {
+                let _ = session.disconnect();
+                Err(closed(format!("send failed: {err}"), false))
+            }
+            // The Logout never reached the wire — a `to_admin` callback left it
+            // unframeable. Staying Active is the honest verdict: arming the
+            // logout deadline for a frame the peer never saw would tear the
+            // session down over a Logout it was never told about.
+            Ok(Sent::Dropped) => Ok(Phase::Active(session)),
+            Ok(Sent::Yes) => {
+                // Recovery is over: a session on its way out will not process a
+                // replay, and leaving the gap armed would keep asking for one.
+                self.resend = None;
+                // Typestate: Active -> LogoutPending. The new state records when
+                // the Logout went out, which is what `on_tick` times through
+                // `Session::sent_at`.
+                Ok(Phase::LogoutPending(session.initiate_logout()))
+            }
         }
     }
 
@@ -1656,6 +1812,15 @@ impl<A: Application> Reactor<A> {
         {
             teardown(phase);
             return Err(closed("logout ack timeout", true));
+        }
+
+        // A gap that is making no progress is chased on its own clock,
+        // independent of the heartbeat: gapped frames keep the heartbeat alive,
+        // so this is the only thing that bounds an unsatisfied resend.
+        if let Some(resend) = self.resend
+            && resend.is_stalled()
+        {
+            return self.on_resend_stalled(framed, phase, resend).await;
         }
 
         let (timed_out, send_test_request, send_heartbeat) = {
@@ -1715,16 +1880,29 @@ impl<A: Application> Reactor<A> {
         Ok(phase)
     }
 
-    /// Requests retransmission from `expected` onwards, unless the same
-    /// range is already outstanding.
+    /// Requests retransmission from `expected` onwards, unless the same range
+    /// is already outstanding. `high_water` is the highest sequence number seen
+    /// for this gap — the top of the range the request must eventually fill.
+    ///
+    /// The first request for a gap opens a [`ResendState`], whose timer bounds
+    /// how long the gap may sit unfilled (see [`Reactor::on_resend_stalled`]).
+    /// A frame that reaches beyond an already-open gap only raises the recorded
+    /// water mark; it does not emit a second overlapping request.
     async fn request_resend(
         &mut self,
         framed: &mut FixFramed,
         phase: Phase,
         expected: u64,
+        high_water: u64,
     ) -> Result<Phase, SessionClosed> {
-        if self.pending_resend == Some(expected) {
-            return Ok(phase);
+        if let Some(state) = self.resend.as_mut() {
+            if high_water > state.high_water {
+                state.high_water = high_water;
+            }
+            // The request from this gap start is already on the wire.
+            if state.expected == expected {
+                return Ok(phase);
+            }
         }
         let request = self.factory.resend_request(expected, 0);
         match self.send(framed, request).await {
@@ -1738,7 +1916,86 @@ impl<A: Application> Reactor<A> {
             Ok(Sent::Dropped) => return Ok(phase),
             Ok(Sent::Yes) => {}
         }
-        self.pending_resend = Some(expected);
+        // A re-request at a new gap start keeps the highest water mark seen so
+        // far, so the range is never narrowed by a later, lower frame.
+        let high_water = self
+            .resend
+            .map_or(high_water, |state| state.high_water.max(high_water));
+        self.resend = Some(ResendState::first(expected, high_water, &self.config));
+        Ok(phase)
+    }
+
+    /// Reconciles the outstanding resend, if any, with in-order inbound
+    /// progress.
+    ///
+    /// Called after the target expectation advances by one in order. Recovery
+    /// is cleared only once the expectation has moved past the whole outstanding
+    /// range (above the water mark); until then the state is kept and its gap
+    /// start advanced, so a single in-order message can no longer wipe all
+    /// knowledge of a still-open gap. Leaving the marker armed also keeps the
+    /// stall timer honest against a peer that fills the gap start and then
+    /// stalls while spamming timely duplicates.
+    fn note_inbound_progress(&mut self) {
+        let Some(high_water) = self.resend.as_ref().map(|state| state.high_water) else {
+            return;
+        };
+        let next_target = self.runtime.sequences.next_target_seq().value();
+        if next_target > high_water {
+            self.resend = None;
+        } else if let Some(state) = self.resend.as_mut() {
+            state.record_progress(next_target);
+        }
+    }
+
+    /// Handles an outstanding ResendRequest that has gone unanswered past its
+    /// timeout: retry it while attempts remain, otherwise log the session out.
+    ///
+    /// A peer that keeps a gap open indefinitely — answering neither the gap
+    /// nor a fresh request, while its other traffic keeps the heartbeat clock
+    /// alive — is one this session cannot make progress with. Retrying a bounded
+    /// number of times absorbs a lost request or a slow store; exhausting the
+    /// retries turns a silent stall into an observable, graceful close.
+    async fn on_resend_stalled(
+        &mut self,
+        framed: &mut FixFramed,
+        phase: Phase,
+        resend: ResendState,
+    ) -> Result<Phase, SessionClosed> {
+        if !resend.can_retry() {
+            let reason = format!(
+                "resend of MsgSeqNum {} unanswered after {} request(s)",
+                resend.expected, resend.attempts
+            );
+            tracing::warn!(session = %self.session_id, reason = %reason, "abandoning stalled resend");
+            return match phase {
+                // A logout already in flight cannot be reissued; let its own
+                // deadline close the session.
+                Phase::LogoutPending(_) => Ok(phase),
+                Phase::Active(session) => self.begin_logout(framed, session, Some(&reason)).await,
+            };
+        }
+
+        let expected = resend.expected;
+        let request = self.factory.resend_request(expected, 0);
+        match self.send(framed, request).await {
+            Err(err) => {
+                teardown(phase);
+                return Err(closed(format!("send failed: {err}"), false));
+            }
+            // The retry never went out; leave the state untouched so the next
+            // stall tick tries again rather than counting a request the peer
+            // never received.
+            Ok(Sent::Dropped) => return Ok(phase),
+            Ok(Sent::Yes) => {}
+        }
+        if let Some(state) = self.resend.as_mut() {
+            state.record_retry();
+        }
+        tracing::debug!(
+            session = %self.session_id,
+            expected,
+            "retrying unanswered ResendRequest"
+        );
         Ok(phase)
     }
 
@@ -1785,6 +2042,37 @@ impl<A: Application> Reactor<A> {
         closed(detail, false)
     }
 
+    /// Rejects an inbound message whose `SendingTime` (52) is missing,
+    /// unparseable, or outside the configured tolerance, then logs out and
+    /// tears the session down.
+    ///
+    /// A wrong clock is a systemic problem, not a per-message one: the peer's
+    /// next frame will be just as skewed, so accepting this one and moving on
+    /// would only defer the same failure while advancing sequence state on
+    /// timestamps that cannot be trusted. The Reject carries
+    /// `SessionRejectReason` 10 for a skew, 1 for an absent field and 6 for a
+    /// malformed one (`doc/fix_operations.md`, "Session Reject Reasons"), then
+    /// the session is closed as it is for an identity mismatch.
+    async fn close_on_sending_time(
+        &mut self,
+        framed: &mut FixFramed,
+        phase: Phase,
+        ref_seq: u64,
+        ref_msg_type: &str,
+        problem: SendingTimeProblem,
+    ) -> SessionClosed {
+        let detail = problem.to_string();
+        tracing::warn!(session = %self.session_id, detail = %detail, "inbound SendingTime problem");
+
+        let reason = problem.reject_reason();
+        let reject = self.factory.session_reject(ref_seq, ref_msg_type, &reason);
+        let _ = self.send(framed, reject).await;
+        let logout = self.factory.logout(Some(&detail));
+        let _ = self.send(framed, logout).await;
+        teardown(phase);
+        closed(detail, false)
+    }
+
     /// Consumes the MsgSeqNum of a `SequenceReset` that is being rejected.
     ///
     /// A Gap Fill participates in normal sequencing: it occupies the number it
@@ -1793,14 +2081,34 @@ impl<A: Application> Reactor<A> {
     /// everything that follows. A Reset-mode message does not participate in
     /// sequencing, so nothing is consumed for it, and neither is anything
     /// consumed for a fill that was not in sequence to begin with.
-    fn consume_if_in_sequence(&self, gap_fill: bool, seq: u64) -> Result<(), SequenceExhausted> {
+    ///
+    /// Returns whether the target expectation actually advanced, so the caller
+    /// can keep an outstanding resend in step with the consumed number.
+    fn consume_if_in_sequence(&self, gap_fill: bool, seq: u64) -> Result<bool, SequenceExhausted> {
         if !gap_fill || !self.runtime.sequences.validate_incoming(seq).is_ok() {
-            return Ok(());
+            return Ok(false);
         }
         self.runtime
             .sequences
             .try_increment_target_seq()
-            .map(|_| ())
+            .map(|_| true)
+    }
+
+    /// Consumes a rejected in-sequence GapFill's MsgSeqNum and keeps recovery in
+    /// step with the advance.
+    ///
+    /// The reject paths in [`Reactor::on_sequence_reset`] discard the fill's
+    /// payload but must not discard the fact that its number is now consumed: an
+    /// outstanding resend whose gap start is left pointing at that number would
+    /// re-request an already-processed sequence and eventually log the session
+    /// out despite real progress. Only a fill that genuinely advanced the target
+    /// reconciles; a duplicate or a gapped one makes no progress and so does not
+    /// disturb the stall clock.
+    fn consume_rejected_fill(&mut self, gap_fill: bool, seq: u64) -> Result<(), SequenceExhausted> {
+        if self.consume_if_in_sequence(gap_fill, seq)? {
+            self.note_inbound_progress();
+        }
+        Ok(())
     }
 
     /// Handles an inbound SequenceReset (35=4).
@@ -1862,11 +2170,11 @@ impl<A: Application> Reactor<A> {
         // Reset mode carries no meaningful MsgSeqNum and is not classified.
         if gap_fill {
             match self.runtime.sequences.validate_incoming(seq) {
-                SequenceResult::Gap { expected, .. } => {
+                SequenceResult::Gap { expected, received } => {
                     // The fill is itself gapped: it cannot be trusted to
                     // describe the missing range, so NewSeqNo is not applied
                     // and the range is requested instead.
-                    return self.request_resend(framed, phase, expected).await;
+                    return self.request_resend(framed, phase, expected, received).await;
                 }
                 SequenceResult::TooLow { expected, received } => {
                     if raw.get_field_str(43) == Some("Y") {
@@ -1890,7 +2198,7 @@ impl<A: Application> Reactor<A> {
             // deduplicated against the outstanding ResendRequest and dropped,
             // and the session goes on reporting itself healthy while it
             // silently discards traffic.
-            if let Err(err) = self.consume_if_in_sequence(gap_fill, seq) {
+            if let Err(err) = self.consume_rejected_fill(gap_fill, seq) {
                 return Err(exhausted(phase, err));
             }
             return self
@@ -1903,7 +2211,7 @@ impl<A: Application> Reactor<A> {
                 .with_ref_tag(36);
             // Same hazard as the rejection path above: the fill still occupies
             // its sequence number even though its NewSeqNo is unusable.
-            if let Err(err) = self.consume_if_in_sequence(gap_fill, seq) {
+            if let Err(err) = self.consume_rejected_fill(gap_fill, seq) {
                 return Err(exhausted(phase, err));
             }
             return self
@@ -1920,6 +2228,9 @@ impl<A: Application> Reactor<A> {
                 if let Err(err) = self.runtime.sequences.try_increment_target_seq() {
                     return Err(exhausted(phase, err));
                 }
+                // The consumed number is real progress: keep an outstanding
+                // resend from re-requesting it.
+                self.note_inbound_progress();
                 let reason = RejectReason::new(
                     5,
                     format!("GapFill NewSeqNo {new_seq} does not advance past MsgSeqNum {seq}"),
@@ -1957,13 +2268,15 @@ impl<A: Application> Reactor<A> {
 
         let expected_before = self.runtime.sequences.next_target_seq().value();
         self.runtime.sequences.set_target_seq(new_seq);
-        // Only a reset that actually advances the expectation resolves an
+        // Only a reset that actually advances the expectation touches an
         // outstanding ResendRequest. A reset landing on the number we already
-        // expect changes nothing, and clearing the marker for it would let a
-        // peer replay it to make the engine emit a fresh ResendRequest every
-        // round -- sequence amplification with no progress.
+        // expect changes nothing, and reconciling for it would let a peer replay
+        // it to make the engine emit a fresh ResendRequest every round --
+        // sequence amplification with no progress. A reset that advances but
+        // stays inside the outstanding range keeps recovery armed against the
+        // rest of it; one that jumps past the water mark clears it.
         if new_seq > expected_before {
-            self.pending_resend = None;
+            self.note_inbound_progress();
         }
         Ok(phase)
     }
@@ -2232,9 +2545,19 @@ impl<A: Application> Reactor<A> {
                 .await);
         }
 
-        // The frame is well-formed, sequenced, and from the configured
-        // counterparty: it proves the peer is alive. A sequence gap is a
-        // recoverable condition, not evidence of a dead peer, so gapped
+        // Clock accuracy is checked next, and likewise before the heartbeat is
+        // refreshed: a peer whose SendingTime is outside the tolerance is one
+        // whose sequencing cannot be trusted, so it must not keep the session
+        // alive either.
+        if let Err(problem) = self.sending_time.validate(&raw) {
+            return Err(self
+                .close_on_sending_time(framed, phase, seq, msg_type.as_str(), problem)
+                .await);
+        }
+
+        // The frame is well-formed, sequenced, from the configured
+        // counterparty, and timely: it proves the peer is alive. A sequence gap
+        // is a recoverable condition, not evidence of a dead peer, so gapped
         // frames still count here — and so does any frame arriving while a
         // TestRequest is outstanding, which is what stops the countdown.
         let test_req_id = raw.get_field_str(112);
@@ -2266,7 +2589,11 @@ impl<A: Application> Reactor<A> {
                     if let Err(err) = self.runtime.sequences.try_increment_target_seq() {
                         return Err(exhausted(phase, err));
                     }
-                    self.pending_resend = None;
+                    // An in-order message advances recovery but does not
+                    // necessarily end it: clear the marker only once the whole
+                    // outstanding range is filled, never on the first message
+                    // back.
+                    self.note_inbound_progress();
                     self.dispatch_admin(framed, phase, &raw, seq).await
                 } else {
                     // Hand the frame to the dispatcher *before* the inbound
@@ -2277,7 +2604,9 @@ impl<A: Application> Reactor<A> {
                     if let Err(err) = self.runtime.sequences.try_increment_target_seq() {
                         return Err(exhausted(phase, err));
                     }
-                    self.pending_resend = None;
+                    // In-order progress, as above: reconcile recovery rather
+                    // than clearing it on the first message back.
+                    self.note_inbound_progress();
                     Ok(phase)
                 }
             }
@@ -2290,8 +2619,10 @@ impl<A: Application> Reactor<A> {
                     .close_on_too_low(framed, phase, expected, received)
                     .await)
             }
-            SequenceResult::Gap { expected, .. } => {
-                let phase = self.request_resend(framed, phase, expected).await?;
+            SequenceResult::Gap { expected, received } => {
+                let phase = self
+                    .request_resend(framed, phase, expected, received)
+                    .await?;
                 if msg_type.is_app() {
                     // Application messages inside a gap will be resent in
                     // order; admin messages are still processed below

--- a/ironfix-engine/src/wire.rs
+++ b/ironfix-engine/src/wire.rs
@@ -39,6 +39,7 @@ use ironfix_core::types::Timestamp;
 use ironfix_core::version::FixVersion;
 use ironfix_session::SessionConfig;
 use ironfix_tagvalue::{Decoder, Encoder};
+use std::time::Duration;
 
 /// A configured `BeginString` the engine cannot frame conformantly.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -114,16 +115,90 @@ pub(crate) struct IdentityMismatch {
     pub(crate) expected: String,
     /// The value the counterparty sent, empty when the tag was absent.
     pub(crate) received: String,
+    /// True when the tag carried the right value but was found outside the
+    /// standard header, where it does not identify the counterparty.
+    pub(crate) misplaced: bool,
 }
 
 impl std::fmt::Display for IdentityMismatch {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.misplaced {
+            return write!(
+                f,
+                "CompID problem: tag {} appears outside the standard header",
+                self.tag
+            );
+        }
         write!(
             f,
             "CompID problem: tag {} expected '{}', received '{}'",
             self.tag, self.expected, self.received
         )
     }
+}
+
+/// Whether `tag` belongs to the FIX standard header.
+///
+/// The set is the standard header of FIX 4.0 through 5.0 SP2 taken together:
+/// the framing fields, the routing and CompID fields, `MsgSeqNum` (34), the
+/// PossDup/PossResend pair, `SendingTime` (52) and `OrigSendingTime` (122),
+/// the `NoHops` group (627 and its 628/629/630 entries), and the FIXT.1.1
+/// application-version fields (1128, 1129, 1156). A tag outside this set is
+/// the first field of the message body.
+const fn is_standard_header_tag(tag: u32) -> bool {
+    matches!(
+        tag,
+        8 | 9
+            | 34
+            | 35
+            | 43
+            | 49
+            | 50
+            | 52
+            | 56
+            | 57
+            | 90
+            | 91
+            | 97
+            | 115
+            | 116
+            | 122
+            | 128
+            | 129
+            | 142
+            | 143
+            | 144
+            | 145
+            | 212
+            | 213
+            | 347
+            | 369
+            | 627
+            | 628
+            | 629
+            | 630
+            | 1128
+            | 1129
+            | 1156
+    )
+}
+
+/// Whether `tag` occurs in the standard header of `raw`.
+///
+/// The header is the leading run of standard-header tags, so the scan stops at
+/// the first body field. Decoded fields keep their wire order, which is what
+/// makes the distinction available here at all — nothing else in a decoded
+/// message says where the header ended.
+fn in_standard_header(raw: &RawMessage<'_>, tag: u32) -> bool {
+    for field in raw.fields() {
+        if field.tag == tag {
+            return true;
+        }
+        if !is_standard_header_tag(field.tag) {
+            return false;
+        }
+    }
+    false
 }
 
 /// The identity every inbound message must carry, derived from the session
@@ -162,15 +237,13 @@ impl PeerIdentity {
     ///
     /// Sub IDs are only checked when configured; an unconfigured sub ID
     /// places no requirement on the counterparty.
-    /// # Positional caveat
     ///
-    /// Field lookup is by tag over the whole decoded message, not by position,
-    /// so CompIDs appearing anywhere in the frame satisfy the check. A message
-    /// that omits them from the standard header but carries them in the body is
-    /// therefore accepted. Enforcing header position needs positional
-    /// information the decoder does not currently retain; the practical impact
-    /// is small, since a peer able to place the tags in the body can equally
-    /// place them in the header.
+    /// Each field must both carry the expected value **and** occur in the
+    /// standard header. A CompID that appears only after the message body
+    /// identifies nothing: the standard header is where the counterparty is
+    /// named, and a message that omits it from there is missing a required
+    /// header field however many copies it carries elsewhere. Both failures
+    /// are `SessionRejectReason` 9.
     pub(crate) fn validate(&self, raw: &RawMessage<'_>) -> Result<(), IdentityMismatch> {
         check_field(raw, 49, &self.sender_comp_id)?;
         check_field(raw, 56, &self.target_comp_id)?;
@@ -184,18 +257,290 @@ impl PeerIdentity {
     }
 }
 
-/// Compares one inbound identity field against its required value.
+/// Compares one inbound identity field against its required value, and
+/// requires it to sit in the standard header.
+///
+/// The value is compared first so a cross-wired CompID keeps reporting the
+/// value it sent rather than its position.
 fn check_field(raw: &RawMessage<'_>, tag: u32, expected: &str) -> Result<(), IdentityMismatch> {
     let received = raw.get_field_str(tag).unwrap_or_default();
-    if received == expected {
-        Ok(())
-    } else {
-        Err(IdentityMismatch {
+    if received != expected {
+        return Err(IdentityMismatch {
             tag,
             expected: expected.to_string(),
             received: received.to_string(),
-        })
+            misplaced: false,
+        });
     }
+    if !in_standard_header(raw, tag) {
+        return Err(IdentityMismatch {
+            tag,
+            expected: expected.to_string(),
+            received: received.to_string(),
+            misplaced: true,
+        });
+    }
+    Ok(())
+}
+
+/// Why an inbound `SendingTime` (52) failed validation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SendingTimeProblem {
+    /// The field is absent. It is required in every standard header.
+    Missing,
+    /// The field is present but is not a FIX `UTCTimestamp`.
+    Malformed {
+        /// The offending value, truncated for the log and the Reject text.
+        value: String,
+    },
+    /// The field parses but lies outside the configured tolerance.
+    Skewed {
+        /// Absolute difference from the local clock, in milliseconds.
+        skew_millis: u64,
+        /// The configured tolerance, in milliseconds.
+        tolerance_millis: u64,
+    },
+}
+
+impl SendingTimeProblem {
+    /// The session-level Reject this problem produces.
+    ///
+    /// Reason 10 is "SendingTime accuracy problem"; a missing required field
+    /// is reason 1 and an unparseable one is reason 6, "incorrect data
+    /// format" (`doc/fix_operations.md`, "Session Reject Reasons").
+    #[must_use]
+    pub(crate) fn reject_reason(&self) -> RejectReason {
+        let code = match self {
+            Self::Missing => 1,
+            Self::Malformed { .. } => 6,
+            Self::Skewed { .. } => 10,
+        };
+        RejectReason::new(code, self.to_string()).with_ref_tag(52)
+    }
+}
+
+impl std::fmt::Display for SendingTimeProblem {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Missing => write!(f, "SendingTime (52) is missing"),
+            Self::Malformed { value } => {
+                write!(f, "SendingTime (52) '{value}' is not a UTC timestamp")
+            }
+            Self::Skewed {
+                skew_millis,
+                tolerance_millis,
+            } => write!(
+                f,
+                "SendingTime (52) differs from the local clock by {skew_millis}ms, \
+                 outside the {tolerance_millis}ms tolerance"
+            ),
+        }
+    }
+}
+
+/// Longest `SendingTime` value echoed back in a Reject or a log line.
+///
+/// The value is counterparty-controlled and lands in `Text` (58) on the wire,
+/// so it is bounded. A legal `UTCTimestamp` is at most 27 characters.
+const MAX_ECHOED_SENDING_TIME: usize = 32;
+
+/// Checks inbound `SendingTime` (52) against the local clock.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SendingTimeGuard {
+    /// Configured tolerance. `Duration::ZERO` — and only that — disables the
+    /// check; any nonzero value, including a sub-millisecond one, leaves it on.
+    tolerance: Duration,
+}
+
+impl SendingTimeGuard {
+    /// Builds the guard from the session configuration.
+    #[must_use]
+    pub(crate) const fn new(config: &SessionConfig) -> Self {
+        Self {
+            tolerance: config.sending_time_tolerance,
+        }
+    }
+
+    /// Whether the check is switched off.
+    ///
+    /// Only an exactly-zero tolerance disables it. The duration is compared as
+    /// a duration rather than flattened to whole milliseconds first, so a
+    /// sub-millisecond tolerance — which floors to zero milliseconds — cannot
+    /// masquerade as "disabled" and silently switch the whole check off, the
+    /// opposite of what the operator asked for.
+    #[must_use]
+    pub(crate) const fn is_disabled(&self) -> bool {
+        self.tolerance.is_zero()
+    }
+
+    /// Validates the `SendingTime` (52) of an inbound message.
+    ///
+    /// A zero tolerance disables the check entirely, including the presence
+    /// and format checks: the knob governs `SendingTime` validation as a
+    /// whole, so an operator who has switched it off for a peer with a known
+    /// clock problem does not get half of it back.
+    ///
+    /// Tag 52 must sit in the standard header: a copy appearing only after the
+    /// body opens names no sending time, exactly as a misplaced CompID names no
+    /// counterparty, so it is treated as absent. The binding spec assigns no
+    /// positional reject reason for 52 (reason 9 is CompID-only), so this is
+    /// inbound-acceptance hardening rather than a spec-mandated reject.
+    ///
+    /// # Errors
+    /// Returns [`SendingTimeProblem::Missing`] when tag 52 is absent from the
+    /// standard header, [`SendingTimeProblem::Malformed`] when it is present but
+    /// is not a UTF-8 `UTCTimestamp`, and [`SendingTimeProblem::Skewed`] when it
+    /// parses but lies further from the local clock than the configured
+    /// tolerance, in either direction.
+    pub(crate) fn validate(&self, raw: &RawMessage<'_>) -> Result<(), SendingTimeProblem> {
+        if self.is_disabled() {
+            return Ok(());
+        }
+        // Present AND in the standard header, in that order: the header copy is
+        // the one that counts, so a body-only 52 is as good as missing.
+        let Some(field) = raw.get_field(52).filter(|_| in_standard_header(raw, 52)) else {
+            return Err(SendingTimeProblem::Missing);
+        };
+        // A present-but-unreadable value is malformed (reason 6), not missing
+        // (reason 1). Invalid UTF-8 fails `as_str`, so it is folded into the
+        // same malformed path instead of being misreported as absent, per
+        // `doc/fix_operations.md`, "Session Reject Reasons".
+        let Ok(value) = field.as_str() else {
+            return Err(SendingTimeProblem::Malformed {
+                value: String::from_utf8_lossy(field.value)
+                    .chars()
+                    .take(MAX_ECHOED_SENDING_TIME)
+                    .collect(),
+            });
+        };
+        let Some(sent_millis) = parse_utc_timestamp_millis(value) else {
+            return Err(SendingTimeProblem::Malformed {
+                value: value.chars().take(MAX_ECHOED_SENDING_TIME).collect(),
+            });
+        };
+
+        let skew_millis = Timestamp::now().as_millis().abs_diff(sent_millis);
+        // Compared as a duration so the tolerance is never truncated to whole
+        // milliseconds: a sub-millisecond tolerance stays meaningful.
+        if Duration::from_millis(skew_millis) > self.tolerance {
+            return Err(SendingTimeProblem::Skewed {
+                skew_millis,
+                tolerance_millis: u64::try_from(self.tolerance.as_millis()).unwrap_or(u64::MAX),
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Parses a FIX `UTCTimestamp` into milliseconds since the Unix epoch.
+///
+/// Accepts `YYYYMMDD-HH:MM:SS` with an optional fractional part of one to nine
+/// digits, which covers every precision FIX 4.0 through 5.0 SP2 puts on the
+/// wire. Digits below the millisecond are truncated; the tolerance this feeds
+/// is measured in seconds.
+///
+/// Returns `None` for anything else, including a well-shaped string naming a
+/// date that does not exist and any year before 1970. There is no
+/// representable instant for those, and inventing one would let a malformed
+/// value pass the accuracy check.
+fn parse_utc_timestamp_millis(value: &str) -> Option<u64> {
+    let bytes = value.as_bytes();
+    // "YYYYMMDD-HH:MM:SS" — the fractional part is optional.
+    if bytes.len() < 17 || bytes.get(8) != Some(&b'-') {
+        return None;
+    }
+    if bytes.get(11) != Some(&b':') || bytes.get(14) != Some(&b':') {
+        return None;
+    }
+
+    let year = parse_digits(bytes.get(0..4)?)?;
+    let month = parse_digits(bytes.get(4..6)?)?;
+    let day = parse_digits(bytes.get(6..8)?)?;
+    let hour = parse_digits(bytes.get(9..11)?)?;
+    let minute = parse_digits(bytes.get(12..14)?)?;
+    // 60 is a leap second, which FIX permits.
+    let second = parse_digits(bytes.get(15..17)?)?;
+
+    let fraction_millis = match bytes.get(17) {
+        None => 0,
+        Some(&b'.') => parse_fraction_millis(bytes.get(18..)?)?,
+        Some(_) => return None,
+    };
+
+    if !(1970..=9999).contains(&year)
+        || !(1..=12).contains(&month)
+        || day < 1
+        || day > days_in_month(year, month)?
+        || hour > 23
+        || minute > 59
+        || second > 60
+    {
+        return None;
+    }
+
+    let days = days_from_civil(year, month, day)?;
+    let seconds = days
+        .checked_mul(86_400)?
+        .checked_add(hour.checked_mul(3_600)?)?
+        .checked_add(minute.checked_mul(60)?)?
+        .checked_add(second)?;
+    seconds.checked_mul(1_000)?.checked_add(fraction_millis)
+}
+
+/// Parses a run of ASCII digits into an integer.
+fn parse_digits(bytes: &[u8]) -> Option<u64> {
+    if bytes.is_empty() || !bytes.iter().all(u8::is_ascii_digit) {
+        return None;
+    }
+    let mut value: u64 = 0;
+    for byte in bytes {
+        value = value.checked_mul(10)?.checked_add(u64::from(byte - b'0'))?;
+    }
+    Some(value)
+}
+
+/// Parses the fractional-second digits of a `UTCTimestamp` into milliseconds,
+/// truncating anything below a millisecond.
+fn parse_fraction_millis(bytes: &[u8]) -> Option<u64> {
+    if bytes.is_empty() || bytes.len() > 9 || !bytes.iter().all(u8::is_ascii_digit) {
+        return None;
+    }
+    let mut millis: u64 = 0;
+    for index in 0..3 {
+        let digit = bytes.get(index).map_or(0, |byte| u64::from(byte - b'0'));
+        millis = millis * 10 + digit;
+    }
+    Some(millis)
+}
+
+/// Days in `month` of `year`, Gregorian.
+fn days_in_month(year: u64, month: u64) -> Option<u64> {
+    const LENGTHS: [u64; 12] = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    let leap = year.is_multiple_of(4) && (!year.is_multiple_of(100) || year.is_multiple_of(400));
+    if month == 2 && leap {
+        return Some(29);
+    }
+    let index = usize::try_from(month.checked_sub(1)?).ok()?;
+    LENGTHS.get(index).copied()
+}
+
+/// Days from `1970-01-01` to the given Gregorian date.
+///
+/// Hinnant's `days_from_civil`, restricted to dates at or after the epoch so
+/// every intermediate stays non-negative. The caller has already range-checked
+/// the components.
+fn days_from_civil(year: u64, month: u64, day: u64) -> Option<u64> {
+    let shifted = if month <= 2 {
+        year.checked_sub(1)?
+    } else {
+        year
+    };
+    let era = shifted / 400;
+    let year_of_era = shifted - era * 400;
+    let shifted_month = if month > 2 { month - 3 } else { month + 9 };
+    let day_of_year = (153 * shifted_month + 2) / 5 + day - 1;
+    let day_of_era = year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
+    (era * 146_097 + day_of_era).checked_sub(719_468)
 }
 
 /// Decodes a framed FIX message.
@@ -602,6 +947,7 @@ mod tests {
     use super::*;
     use ironfix_core::message::MsgType;
     use ironfix_core::types::CompId;
+    use std::time::Duration;
 
     fn config_for(begin_string: &str) -> SessionConfig {
         let Ok(sender) = CompId::new("CLIENT") else {
@@ -1102,6 +1448,7 @@ mod tests {
                 tag: 49,
                 expected: "VENUE".to_string(),
                 received: "OTHER".to_string(),
+                misplaced: false,
             })
         );
     }
@@ -1127,7 +1474,357 @@ mod tests {
                 tag: 57,
                 expected: "DESK".to_string(),
                 received: String::new(),
+                misplaced: false,
             })
+        );
+    }
+
+    /// Builds a frame with an explicit field order, bypassing the encoder's
+    /// header conformance so the body can carry the CompIDs.
+    fn frame_with_fields(fields: &[(u32, &str)]) -> Vec<u8> {
+        let fields: Vec<(u32, &[u8])> = fields
+            .iter()
+            .map(|(tag, value)| (*tag, value.as_bytes()))
+            .collect();
+        frame_with_raw_fields(&fields)
+    }
+
+    /// Builds a framed message from raw field bytes, so a value can carry a
+    /// sequence that is not valid UTF-8.
+    fn frame_with_raw_fields(fields: &[(u32, &[u8])]) -> Vec<u8> {
+        let mut body = Vec::new();
+        for (tag, value) in fields {
+            body.extend_from_slice(format!("{tag}=").as_bytes());
+            body.extend_from_slice(value);
+            body.push(0x01);
+        }
+        let mut frame = Vec::new();
+        frame.extend_from_slice(b"8=FIX.4.4\x01");
+        frame.extend_from_slice(format!("9={}\x01", body.len()).as_bytes());
+        frame.extend_from_slice(&body);
+        let sum: u64 = frame.iter().map(|&byte| u64::from(byte)).sum();
+        frame.extend_from_slice(format!("10={:03}\x01", sum % 256).as_bytes());
+        frame
+    }
+
+    #[test]
+    fn test_peer_identity_rejects_comp_ids_outside_the_standard_header() {
+        let identity = PeerIdentity::new(&config_for("FIX.4.4"));
+        // 11 (ClOrdID) opens the body; the CompIDs that follow it are not in
+        // the standard header and identify nothing.
+        let frame = frame_with_fields(&[
+            (35, "D"),
+            (34, "2"),
+            (52, "20260721-10:00:00.000"),
+            (11, "ORDER-1"),
+            (49, "VENUE"),
+            (56, "CLIENT"),
+        ]);
+
+        assert_eq!(
+            identity.validate(&decode(&frame)),
+            Err(IdentityMismatch {
+                tag: 49,
+                expected: "VENUE".to_string(),
+                received: "VENUE".to_string(),
+                misplaced: true,
+            })
+        );
+    }
+
+    #[test]
+    fn test_peer_identity_accepts_comp_ids_across_the_whole_standard_header() {
+        // 50/57/122 sit after MsgSeqNum in the standard header, so the run the
+        // scan walks must not stop before them.
+        let config = config_for("FIX.4.4")
+            .with_sender_sub_id("DESK")
+            .with_target_sub_id("MM");
+        let identity = PeerIdentity::new(&config);
+        let frame = frame_with_fields(&[
+            (35, "D"),
+            (49, "VENUE"),
+            (56, "CLIENT"),
+            (34, "2"),
+            (50, "MM"),
+            (57, "DESK"),
+            (43, "Y"),
+            (52, "20260721-10:00:00.000"),
+            (122, "20260721-10:00:00.000"),
+            (11, "ORDER-1"),
+        ]);
+
+        assert_eq!(identity.validate(&decode(&frame)), Ok(()));
+    }
+
+    #[test]
+    fn test_parse_utc_timestamp_accepts_every_fix_precision() {
+        // 1970-01-01T00:00:00Z is 0; the fractional part only adds millis.
+        assert_eq!(parse_utc_timestamp_millis("19700101-00:00:00"), Some(0));
+        assert_eq!(parse_utc_timestamp_millis("19700101-00:00:00.000"), Some(0));
+        assert_eq!(
+            parse_utc_timestamp_millis("19700101-00:00:00.123456"),
+            Some(123)
+        );
+        assert_eq!(
+            parse_utc_timestamp_millis("19700101-00:00:00.123456789"),
+            Some(123)
+        );
+        assert_eq!(
+            parse_utc_timestamp_millis("19700102-00:00:01.500"),
+            Some(86_401_500)
+        );
+    }
+
+    /// The parser must agree with the formatter it validates against, for
+    /// dates on both sides of a leap day.
+    #[test]
+    fn test_parse_utc_timestamp_roundtrips_the_formatter() {
+        for millis in [
+            0,
+            951_782_400_000,   // 2000-02-29, a leap day in a leap century
+            1_078_012_800_000, // 2004-02-29
+            1_769_000_000_123,
+            4_102_444_800_999, // 2100-01-01, a common year divisible by 100
+        ] {
+            let Ok(timestamp) = Timestamp::from_millis(millis) else {
+                unreachable!("{millis} is representable")
+            };
+            assert_eq!(
+                parse_utc_timestamp_millis(timestamp.format_millis().as_str()),
+                Some(millis),
+                "{} did not round-trip",
+                timestamp.format_millis()
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_utc_timestamp_rejects_malformed_values() {
+        for value in [
+            "",
+            "not-a-timestamp",
+            "20260721",
+            "20260721-10:00",
+            "20260721 10:00:00",
+            "20260721-10-00-00",
+            "2026072a-10:00:00",
+            "20260721-10:00:00.",
+            "20260721-10:00:00.1234567890", // more than nanosecond precision
+            "20260721-10:00:00x000",
+            "20260231-10:00:00.000", // February has no 31st
+            "20260732-10:00:00.000",
+            "20261301-10:00:00.000",
+            "20260721-24:00:00.000",
+            "20260721-10:60:00.000",
+            "20260721-10:00:61.000",
+            "19690721-10:00:00.000", // before the epoch
+        ] {
+            assert_eq!(
+                parse_utc_timestamp_millis(value),
+                None,
+                "{value} must not parse"
+            );
+        }
+    }
+
+    /// A leap second is a legal UTCTimestamp and must not be refused.
+    #[test]
+    fn test_parse_utc_timestamp_accepts_leap_second() {
+        assert!(parse_utc_timestamp_millis("20261231-23:59:60.000").is_some());
+    }
+
+    fn guard_with(tolerance: Duration) -> SendingTimeGuard {
+        SendingTimeGuard::new(&config_for("FIX.4.4").with_sending_time_tolerance(tolerance))
+    }
+
+    fn frame_sent_at(sending_time: &str) -> Vec<u8> {
+        frame_with_fields(&[
+            (35, "0"),
+            (49, "VENUE"),
+            (56, "CLIENT"),
+            (34, "2"),
+            (52, sending_time),
+        ])
+    }
+
+    #[test]
+    fn test_sending_time_guard_accepts_the_current_clock() {
+        let frame = frame_sent_at(Timestamp::now().format_millis().as_str());
+
+        assert_eq!(
+            guard_with(Duration::from_secs(120)).validate(&decode(&frame)),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn test_sending_time_guard_rejects_a_stale_timestamp_with_reason_10() {
+        let frame = frame_sent_at("20200101-00:00:00.000");
+
+        let problem = match guard_with(Duration::from_secs(120)).validate(&decode(&frame)) {
+            Err(problem) => problem,
+            Ok(()) => panic!("a five-year-old SendingTime must not pass"),
+        };
+        assert!(matches!(problem, SendingTimeProblem::Skewed { .. }));
+        assert_eq!(problem.reject_reason().code, 10);
+        assert_eq!(problem.reject_reason().ref_tag, Some(52));
+    }
+
+    /// The window is symmetric: a peer whose clock runs fast is as broken as
+    /// one that runs slow.
+    #[test]
+    fn test_sending_time_guard_rejects_a_future_timestamp() {
+        let frame = frame_sent_at("21000101-00:00:00.000");
+
+        assert!(matches!(
+            guard_with(Duration::from_secs(120)).validate(&decode(&frame)),
+            Err(SendingTimeProblem::Skewed { .. })
+        ));
+    }
+
+    #[test]
+    fn test_sending_time_guard_accepts_skew_inside_the_window() {
+        let Some(millis) = Timestamp::now().as_millis().checked_sub(60_000) else {
+            unreachable!("the system clock is at least a minute past the epoch")
+        };
+        let Ok(stale) = Timestamp::from_millis(millis) else {
+            unreachable!("a minute before now is representable")
+        };
+        let frame = frame_sent_at(stale.format_millis().as_str());
+
+        // A minute of skew inside a two-minute window is tolerated: the check
+        // is a broken-clock detector, not a latency budget.
+        assert_eq!(
+            guard_with(Duration::from_secs(120)).validate(&decode(&frame)),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn test_sending_time_guard_reports_missing_and_malformed_fields() {
+        let missing = frame_with_fields(&[(35, "0"), (49, "VENUE"), (56, "CLIENT"), (34, "2")]);
+        let guard = guard_with(Duration::from_secs(120));
+        assert_eq!(
+            guard.validate(&decode(&missing)),
+            Err(SendingTimeProblem::Missing)
+        );
+        assert_eq!(
+            SendingTimeProblem::Missing.reject_reason().code,
+            1,
+            "a missing required header field is reason 1"
+        );
+
+        let malformed = frame_sent_at("yesterday");
+        assert_eq!(
+            guard.validate(&decode(&malformed)),
+            Err(SendingTimeProblem::Malformed {
+                value: "yesterday".to_string(),
+            })
+        );
+        assert_eq!(
+            SendingTimeProblem::Malformed {
+                value: "yesterday".to_string()
+            }
+            .reject_reason()
+            .code,
+            6,
+            "an unparseable timestamp is reason 6"
+        );
+    }
+
+    #[test]
+    fn test_sending_time_guard_zero_tolerance_disables_every_check() {
+        let guard = guard_with(Duration::ZERO);
+        assert!(guard.is_disabled());
+
+        // Neither a wildly skewed value nor an absent one is reported once the
+        // operator has switched the check off.
+        let stale = frame_sent_at("20200101-00:00:00.000");
+        assert_eq!(guard.validate(&decode(&stale)), Ok(()));
+        let missing = frame_with_fields(&[(35, "0"), (49, "VENUE"), (56, "CLIENT"), (34, "2")]);
+        assert_eq!(guard.validate(&decode(&missing)), Ok(()));
+    }
+
+    #[test]
+    fn test_sending_time_guard_echoes_a_bounded_value() {
+        let long = "9".repeat(200);
+        let frame = frame_sent_at(&long);
+
+        match guard_with(Duration::from_secs(120)).validate(&decode(&frame)) {
+            Err(SendingTimeProblem::Malformed { value }) => {
+                assert_eq!(value.chars().count(), MAX_ECHOED_SENDING_TIME);
+            }
+            other => panic!("a 200-character SendingTime must be malformed: {other:?}"),
+        }
+    }
+
+    /// A tag 52 that appears only after the body opens is not in the standard
+    /// header and names no sending time: it is treated as missing, mirroring the
+    /// positional guard the CompID check already applies.
+    #[test]
+    fn test_sending_time_guard_treats_a_body_only_sending_time_as_missing() {
+        // 11 (ClOrdID) opens the body; the 52 that follows it is not a header
+        // field however well-formed its value is.
+        let frame = frame_with_fields(&[
+            (35, "D"),
+            (49, "VENUE"),
+            (56, "CLIENT"),
+            (34, "2"),
+            (11, "ORDER-1"),
+            (52, "20260721-10:00:00.000"),
+        ]);
+
+        assert_eq!(
+            guard_with(Duration::from_secs(120)).validate(&decode(&frame)),
+            Err(SendingTimeProblem::Missing)
+        );
+    }
+
+    /// A present tag 52 whose bytes are not valid UTF-8 is malformed (reason 6),
+    /// not missing (reason 1): the field is there, it is just unreadable.
+    #[test]
+    fn test_sending_time_guard_reports_invalid_utf8_as_malformed() {
+        let frame = frame_with_raw_fields(&[
+            (35, b"0"),
+            (49, b"VENUE"),
+            (56, b"CLIENT"),
+            (34, b"2"),
+            (52, &[0xFF, 0xFE, 0xFD]),
+        ]);
+
+        let problem = match guard_with(Duration::from_secs(120)).validate(&decode(&frame)) {
+            Err(problem) => problem,
+            Ok(()) => panic!("a non-UTF-8 SendingTime must not pass"),
+        };
+        assert!(matches!(problem, SendingTimeProblem::Malformed { .. }));
+        assert_eq!(
+            problem.reject_reason().code,
+            6,
+            "a present but unreadable timestamp is reason 6, not the reason 1 of an absent one"
+        );
+    }
+
+    /// A sub-millisecond tolerance floors to zero milliseconds, but the check
+    /// stays enabled: it must still validate rather than treating the truncated
+    /// value as the disabled sentinel.
+    #[test]
+    fn test_sending_time_guard_sub_millisecond_tolerance_stays_enabled() {
+        let guard = guard_with(Duration::from_micros(500));
+        assert!(!guard.is_disabled(), "a 500us tolerance is not disabled");
+
+        // A wildly stale timestamp is still rejected under the tiny tolerance.
+        let stale = frame_sent_at("20200101-00:00:00.000");
+        assert!(matches!(
+            guard.validate(&decode(&stale)),
+            Err(SendingTimeProblem::Skewed { .. })
+        ));
+
+        // And an absent field is still reported, proving the presence check was
+        // not switched off along with the skew check.
+        let missing = frame_with_fields(&[(35, "0"), (49, "VENUE"), (56, "CLIENT"), (34, "2")]);
+        assert_eq!(
+            guard.validate(&decode(&missing)),
+            Err(SendingTimeProblem::Missing)
         );
     }
 }

--- a/ironfix-engine/tests/initiator_tests.rs
+++ b/ironfix-engine/tests/initiator_tests.rs
@@ -80,6 +80,22 @@ fn venue_msg_from(
     frame_of(&mut encoder)
 }
 
+/// Stub-acceptor frame with an explicit `SendingTime` (52), for clock-skew
+/// validation tests. Unlike [`venue_msg`], the timestamp is not overwritten
+/// with the current clock.
+fn venue_msg_at(msg_type: &str, seq: u64, sending_time: &str, extra: &[(u32, &str)]) -> BytesMut {
+    let mut encoder = Encoder::new("FIX.4.4");
+    encoder.put_str(35, msg_type);
+    encoder.put_str(49, "VENUE");
+    encoder.put_str(56, "CLIENT");
+    encoder.put_uint(34, seq);
+    encoder.put_str(52, sending_time);
+    for (tag, value) in extra {
+        encoder.put_str(*tag, value);
+    }
+    frame_of(&mut encoder)
+}
+
 /// Returns the finished frame, failing the test with the encoder's rejection.
 #[track_caller]
 fn frame_of(encoder: &mut Encoder) -> BytesMut {
@@ -2102,6 +2118,442 @@ async fn test_dropping_all_handles_logs_out() {
         ),
         "acceptor task",
     );
+}
+
+// ---------------------------------------------------------------------------
+// Bounded resend recovery (issue #29, gap 1)
+// ---------------------------------------------------------------------------
+
+/// A peer that never satisfies a resend reaches a bounded outcome: the client
+/// retries the ResendRequest up to the configured limit, then logs out. A long
+/// heartbeat interval rules the heartbeat timeout out as the cause, so the
+/// close is attributable to the resend bound alone.
+#[tokio::test]
+async fn test_unsatisfied_resend_request_times_out_into_logout() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+
+        // Open a gap the acceptor will never fill: jump straight to seq 5.
+        ok(
+            framed
+                .send(venue_msg(
+                    "8",
+                    5,
+                    &[(37, "EX-1"), (17, "E-1"), (150, "0"), (39, "0")],
+                ))
+                .await,
+            "send gapped report",
+        );
+
+        // Read the client's frames until it gives up and logs out, counting
+        // the ResendRequests. The gap is never filled, so the only conforming
+        // outcomes are more requests and, finally, a Logout.
+        let mut resend_requests = 0;
+        loop {
+            let frame = next_frame(&mut framed).await;
+            match msg_type_of(&frame).as_str() {
+                "2" => {
+                    assert_eq!(field(&frame, 7).as_deref(), Some("2"));
+                    resend_requests += 1;
+                }
+                "5" => {
+                    // The Logout explains why, so a supervisor can tell a
+                    // stalled resend from an ordinary shutdown.
+                    let text = some(field(&frame, 58), "abandon Logout carries Text");
+                    assert!(
+                        text.contains("resend"),
+                        "Logout should name the stalled resend, got {text:?}"
+                    );
+                    break;
+                }
+                other => panic!("unexpected frame while stalled: {other}"),
+            }
+        }
+        // Three attempts total: the request the gap opens plus two retries.
+        assert_eq!(
+            resend_requests, 3,
+            "expected the initial request and two retries"
+        );
+    });
+
+    let (app, mut app_rx) = RecordingApp::new();
+    // A 30s heartbeat cannot fire inside this test, so only the resend bound
+    // can close the session; a 150ms resend timeout keeps it quick.
+    let config = client_config(Duration::from_secs(30))
+        .with_resend_timeout(Duration::from_millis(150))
+        .with_max_resend_requests(3);
+    let initiator = Initiator::new(config, Arc::clone(&app));
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    ok(
+        timeout(Duration::from_secs(5), connection.wait_closed()).await,
+        "the stalled session must close within 5s",
+    );
+    assert!(app.events().contains(&"logout".to_string()));
+    // Nothing ever satisfied the gap, so nothing was delivered.
+    assert!(
+        timeout(Duration::from_millis(200), app_rx.recv())
+            .await
+            .is_err(),
+        "a gapped, never-filled message must not be delivered"
+    );
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+}
+
+/// A peer that fills only the *start* of a gap and then goes quiet — while
+/// spamming timely duplicates that keep the heartbeat clock alive — must still
+/// be escalated to Logout. The single in-order message that opens the fill used
+/// to wipe all knowledge of the still-open gap, after which neither the resend
+/// bound nor the heartbeat timeout could fire: a silent stall. Recovery now
+/// tracks the whole outstanding range, so the retries continue from the
+/// advanced expectation until the bound is spent.
+#[tokio::test]
+async fn test_partial_resend_then_duplicate_flood_escalates_to_logout() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+
+        // Open a gap 2..=4 by jumping straight to seq 5.
+        ok(
+            framed
+                .send(venue_msg(
+                    "8",
+                    5,
+                    &[(37, "EX-1"), (17, "E-1"), (150, "0"), (39, "0")],
+                ))
+                .await,
+            "send gapped report",
+        );
+
+        // The client requests the whole range from 2.
+        let first = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&first), "2");
+        assert_eq!(
+            field(&first, 7).as_deref(),
+            Some("2"),
+            "the first request covers the gap start"
+        );
+
+        // Fill only the START of the gap, in order: seq 2. Sequences 3 and 4
+        // (and the 5 that opened the gap) stay missing. Before the fix this
+        // single in-order message cleared all resend state.
+        ok(
+            framed
+                .send(venue_msg(
+                    "8",
+                    2,
+                    &[(43, "Y"), (37, "EX-2"), (17, "E-2"), (150, "0"), (39, "0")],
+                ))
+                .await,
+            "fill the gap start only",
+        );
+
+        // Now flood timely duplicate-2s (PossDup): they refresh the heartbeat
+        // but make no in-order progress. A correct client keeps chasing the
+        // still-open gap from the advanced expectation and finally logs out; a
+        // buggy one sits here forever, having forgotten the gap.
+        let mut resend_requests = 0;
+        loop {
+            ok(
+                framed
+                    .send(venue_msg(
+                        "8",
+                        2,
+                        &[(43, "Y"), (37, "EX-2"), (17, "E-2"), (150, "0"), (39, "0")],
+                    ))
+                    .await,
+                "flood a timely duplicate",
+            );
+            let frame = next_frame(&mut framed).await;
+            match msg_type_of(&frame).as_str() {
+                "2" => {
+                    // The retry targets the advanced gap start (3), never the
+                    // already-consumed 2.
+                    assert_eq!(
+                        field(&frame, 7).as_deref(),
+                        Some("3"),
+                        "the retry must start from the advanced expectation, not the consumed number"
+                    );
+                    resend_requests += 1;
+                }
+                "5" => {
+                    let text = some(field(&frame, 58), "abandon Logout carries Text");
+                    assert!(
+                        text.contains("resend"),
+                        "Logout should name the stalled resend, got {text:?}"
+                    );
+                    break;
+                }
+                // A 30s heartbeat cannot fire in this window, but tolerate an
+                // admin frame rather than racing on it.
+                "0" | "1" => {}
+                other => panic!("unexpected frame while stalled: {other}"),
+            }
+        }
+        assert_eq!(
+            resend_requests, 2,
+            "the partial fill must leave the gap armed: two retries then Logout"
+        );
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    // A 30s heartbeat cannot fire inside this test, so only the resend bound can
+    // close the session; a 150ms resend timeout keeps it quick.
+    let config = client_config(Duration::from_secs(30))
+        .with_resend_timeout(Duration::from_millis(150))
+        .with_max_resend_requests(3);
+    let initiator = Initiator::new(config, Arc::clone(&app));
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    ok(
+        timeout(Duration::from_secs(5), connection.wait_closed()).await,
+        "the partially-filled, then flooded, session must still close within 5s",
+    );
+    assert!(app.events().contains(&"logout".to_string()));
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+}
+
+/// A GapFill that errors mid-recovery still consumes its sequence number, so the
+/// resend must advance with it: the next request starts from the new
+/// expectation, never re-requesting the number the errored fill already
+/// consumed. The reject paths used to advance the target without updating the
+/// resend, so a retry re-asked for an already-processed sequence.
+#[tokio::test]
+async fn test_errored_gap_fill_mid_recovery_advances_the_resend_request() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+
+        // Open a gap 2..=4 by jumping straight to seq 5.
+        ok(
+            framed
+                .send(venue_msg(
+                    "8",
+                    5,
+                    &[(37, "EX-1"), (17, "E-1"), (150, "0"), (39, "0")],
+                ))
+                .await,
+            "send gapped report",
+        );
+
+        // The client requests the whole range from 2.
+        let first = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&first), "2");
+        assert_eq!(field(&first, 7).as_deref(), Some("2"));
+
+        // Answer with an in-sequence GapFill for seq 2 that the app rejects.
+        // It still consumes seq 2, advancing the expectation to 3, so any later
+        // resend must start from 3 — never the already-consumed 2.
+        ok(
+            framed
+                .send(venue_msg("4", 2, &[(43, "Y"), (123, "Y"), (36, "3")]))
+                .await,
+            "send an in-sequence gap fill the app rejects",
+        );
+
+        loop {
+            let frame = next_frame(&mut framed).await;
+            match msg_type_of(&frame).as_str() {
+                "3" => {
+                    // The Reject for the errored fill references seq 2.
+                    assert_eq!(field(&frame, 45).as_deref(), Some("2"));
+                }
+                "2" => {
+                    assert_eq!(
+                        field(&frame, 7).as_deref(),
+                        Some("3"),
+                        "the resend after an errored fill must start from the advanced expectation, not the consumed number"
+                    );
+                    break;
+                }
+                "5" => panic!("the session must keep recovering, not log out here"),
+                "0" | "1" => {}
+                other => panic!("unexpected frame after an errored fill: {other}"),
+            }
+        }
+    });
+
+    let (app, _app_rx) = RecordingApp::rejecting_admin();
+    let config =
+        client_config(Duration::from_secs(30)).with_resend_timeout(Duration::from_millis(150));
+    let initiator = Initiator::new(config, Arc::clone(&app));
+    let _connection = ok(initiator.connect(addr).await, "connect");
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// SendingTime accuracy (issue #29, gap 2)
+// ---------------------------------------------------------------------------
+
+/// A message whose SendingTime is far outside the tolerance is rejected with
+/// reason 10 and the session is logged out, mirroring an identity mismatch.
+#[tokio::test]
+async fn test_skewed_sending_time_rejects_with_reason_10_and_closes() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+
+        // A SendingTime years in the past, well outside any sane tolerance.
+        ok(
+            framed
+                .send(venue_msg_at(
+                    "8",
+                    2,
+                    "20200101-00:00:00.000",
+                    &[(37, "EX-1"), (17, "E-1"), (150, "0"), (39, "0")],
+                ))
+                .await,
+            "send stale report",
+        );
+
+        let reject = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&reject), "3");
+        assert_eq!(field(&reject, 45).as_deref(), Some("2"));
+        assert_eq!(field(&reject, 373).as_deref(), Some("10"));
+        assert_eq!(field(&reject, 371).as_deref(), Some("52"));
+
+        let logout = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&logout), "5");
+    });
+
+    let (app, mut app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    ok(
+        timeout(Duration::from_secs(5), connection.wait_closed()).await,
+        "the skewed session must close within 5s",
+    );
+    assert!(
+        timeout(Duration::from_millis(200), app_rx.recv())
+            .await
+            .is_err(),
+        "a message with a bad SendingTime must not be delivered"
+    );
+
+    ok(acceptor.await, "acceptor task");
+}
+
+/// With the tolerance switched off, the same stale SendingTime is accepted and
+/// the message is delivered.
+#[tokio::test]
+async fn test_zero_tolerance_accepts_any_sending_time() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+        ok(
+            framed
+                .send(venue_msg_at(
+                    "8",
+                    2,
+                    "20200101-00:00:00.000",
+                    &[(37, "EX-1"), (17, "E-1"), (150, "0"), (39, "0")],
+                ))
+                .await,
+            "send stale report",
+        );
+    });
+
+    let (app, mut app_rx) = RecordingApp::new();
+    let config = client_config(Duration::from_secs(30)).with_sending_time_tolerance(Duration::ZERO);
+    let initiator = Initiator::new(config, Arc::clone(&app));
+    let _connection = ok(initiator.connect(addr).await, "connect");
+
+    let delivered = ok(
+        timeout(Duration::from_secs(5), app_rx.recv()).await,
+        "the message must be delivered with the check off",
+    );
+    assert_eq!(delivered.as_deref(), Some("8"));
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Positional CompID enforcement (issue #29, gap 3)
+// ---------------------------------------------------------------------------
+
+/// A frame that carries the CompIDs only after the message body, not in the
+/// standard header, is rejected with reason 9 and the session is closed. The
+/// tags are present and correct; only their placement is wrong.
+#[tokio::test]
+async fn test_comp_ids_outside_the_header_reject_and_close() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+
+        // 11 (ClOrdID) opens the body; the CompIDs sit after it, so they are
+        // no longer in the standard header. Hand-rolled, since the encoder
+        // stamps a conforming header.
+        let now = Timestamp::now().format_millis();
+        let body = format!(
+            "35=8\x0134=2\x0152={}\x0111=ORDER-1\x0149=VENUE\x0156=CLIENT\x01",
+            now.as_str()
+        );
+        ok(
+            framed.send(raw_frame(body.as_bytes())).await,
+            "send body-CompID frame",
+        );
+
+        let reject = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&reject), "3");
+        assert_eq!(field(&reject, 45).as_deref(), Some("2"));
+        assert_eq!(field(&reject, 373).as_deref(), Some("9"));
+        assert_eq!(field(&reject, 371).as_deref(), Some("49"));
+
+        let logout = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&logout), "5");
+    });
+
+    let (app, mut app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    ok(
+        timeout(Duration::from_secs(5), connection.wait_closed()).await,
+        "the misplaced-CompID session must close within 5s",
+    );
+    assert!(
+        timeout(Duration::from_millis(200), app_rx.recv())
+            .await
+            .is_err(),
+        "a frame missing header CompIDs must not be delivered"
+    );
+
+    ok(acceptor.await, "acceptor task");
 }
 
 /// with_initial_sequences seeds both counters for session continuity.

--- a/ironfix-session/src/config.rs
+++ b/ironfix-session/src/config.rs
@@ -310,6 +310,46 @@ pub struct SessionConfig {
     pub logout_timeout: Duration,
     /// Whether to validate the `CheckSum` (10) of inbound messages.
     pub validate_checksum: bool,
+    /// Whether to validate incoming message length.
+    pub validate_length: bool,
+    /// Largest difference tolerated, in either direction, between an inbound
+    /// message's `SendingTime` (52) and the local clock.
+    ///
+    /// Units: wall-clock duration. Range: any duration; `Duration::ZERO`
+    /// disables `SendingTime` validation entirely, including the presence and
+    /// format checks. Default: 120 seconds.
+    ///
+    /// The default matches the tolerance FIX engines have converged on
+    /// (QuickFIX's `MaxLatency`) and is the interval it is worth choosing:
+    /// a host synchronised by NTP stays within milliseconds of true time, so
+    /// two minutes is orders of magnitude more slack than a healthy peer ever
+    /// needs, while a host that is not synchronised at all drifts past two
+    /// minutes within days. Anything much tighter starts rejecting sessions
+    /// over ordinary drift and queueing latency; anything much looser stops
+    /// distinguishing a wrong clock from a right one.
+    pub sending_time_tolerance: Duration,
+    /// How long an outstanding `ResendRequest` (2) may make no progress before
+    /// it is retried, and eventually abandoned.
+    ///
+    /// Units: wall-clock duration, measured from the moment the request was
+    /// sent and restarted by every request that follows it. Any in-sequence
+    /// message clears the outstanding request altogether, so this measures a
+    /// gap that is not being filled at all, not a slow replay. Range: any
+    /// duration; a value below the engine's 100 ms reactor tick simply retries
+    /// on the next tick. Default: 10 seconds.
+    pub resend_timeout: Duration,
+    /// Maximum number of `ResendRequest` (2) messages sent for one gap,
+    /// counting the first.
+    ///
+    /// Once they are spent the session is ended with a Logout rather than left
+    /// waiting for a peer that is not answering. Range: 1 and above; 0 is read
+    /// as 1, because the first request is unconditional. Default: 3, which
+    /// with the default [`SessionConfig::resend_timeout`] bounds an
+    /// unrecoverable gap at 30 seconds plus the logout handshake.
+    ///
+    /// Read it through [`SessionConfig::resend_attempt_limit`], which applies
+    /// the lower bound.
+    pub max_resend_requests: u32,
     /// Optional sender sub ID (tag 50), 1..=[`MAX_ID_LEN`] bytes when set.
     pub sender_sub_id: Option<String>,
     /// Optional target sub ID (tag 57), 1..=[`MAX_ID_LEN`] bytes when set.
@@ -352,6 +392,10 @@ impl SessionConfig {
             logon_timeout: DEFAULT_TIMEOUT,
             logout_timeout: DEFAULT_TIMEOUT,
             validate_checksum: true,
+            validate_length: true,
+            sending_time_tolerance: Duration::from_secs(120),
+            resend_timeout: Duration::from_secs(10),
+            max_resend_requests: 3,
             sender_sub_id: None,
             target_sub_id: None,
             sender_location_id: None,
@@ -459,6 +503,40 @@ impl SessionConfig {
         self
     }
 
+    /// Sets the logout timeout.
+    #[must_use]
+    pub fn with_logout_timeout(mut self, timeout: Duration) -> Self {
+        self.logout_timeout = timeout;
+        self
+    }
+
+    /// Sets the tolerance applied to an inbound `SendingTime` (52).
+    ///
+    /// `Duration::ZERO` disables `SendingTime` validation. See
+    /// [`SessionConfig::sending_time_tolerance`] for the default and its
+    /// rationale.
+    #[must_use]
+    pub fn with_sending_time_tolerance(mut self, tolerance: Duration) -> Self {
+        self.sending_time_tolerance = tolerance;
+        self
+    }
+
+    /// Sets how long an outstanding `ResendRequest` (2) may make no progress
+    /// before it is retried.
+    #[must_use]
+    pub fn with_resend_timeout(mut self, timeout: Duration) -> Self {
+        self.resend_timeout = timeout;
+        self
+    }
+
+    /// Sets how many `ResendRequest` (2) messages may be sent for one gap,
+    /// counting the first. A value of 0 is read as 1.
+    #[must_use]
+    pub const fn with_max_resend_requests(mut self, attempts: u32) -> Self {
+        self.max_resend_requests = attempts;
+        self
+    }
+
     /// Returns the heartbeat interval as the whole seconds that go into
     /// `HeartBtInt` (108).
     ///
@@ -469,6 +547,17 @@ impl SessionConfig {
     #[must_use]
     pub const fn heartbeat_interval_secs(&self) -> u64 {
         self.heartbeat_interval.as_secs()
+    }
+
+    /// Returns how many `ResendRequest` (2) messages may be sent for one gap,
+    /// never less than the one that opens the recovery.
+    #[must_use]
+    pub const fn resend_attempt_limit(&self) -> u32 {
+        if self.max_resend_requests == 0 {
+            1
+        } else {
+            self.max_resend_requests
+        }
     }
 }
 
@@ -755,6 +844,13 @@ impl SessionConfigBuilder {
             logon_timeout: self.logon_timeout,
             logout_timeout: self.logout_timeout,
             validate_checksum: self.validate_checksum,
+            // Inbound-hardening knobs are not exposed on the builder; they take
+            // the same defaults as `SessionConfig::new` and are tuned through
+            // the fluent `SessionConfig::with_*` setters after `build()`.
+            validate_length: true,
+            sending_time_tolerance: Duration::from_secs(120),
+            resend_timeout: Duration::from_secs(10),
+            max_resend_requests: 3,
             sender_sub_id: self.sender_sub_id,
             target_sub_id: self.target_sub_id,
             sender_location_id: self.sender_location_id,
@@ -1217,5 +1313,51 @@ mod tests {
                 max: MAX_MESSAGE_SIZE_LIMIT,
             })
         );
+    }
+
+    fn config() -> SessionConfig {
+        SessionConfig::new(comp_id("SENDER"), comp_id("TARGET"), "FIX.4.4")
+    }
+
+    #[test]
+    fn test_session_config_recovery_defaults_are_bounded() {
+        let config = config();
+
+        // Two minutes of clock skew, the interval FIX engines have converged
+        // on; three resend attempts ten seconds apart.
+        assert_eq!(config.sending_time_tolerance, Duration::from_secs(120));
+        assert_eq!(config.resend_timeout, Duration::from_secs(10));
+        assert_eq!(config.max_resend_requests, 3);
+        assert_eq!(config.resend_attempt_limit(), 3);
+    }
+
+    #[test]
+    fn test_session_config_zero_resend_requests_still_allows_one() {
+        // The first ResendRequest is unconditional: it is what opens the
+        // recovery the limit governs, so zero cannot mean "never ask".
+        let config = config().with_max_resend_requests(0);
+
+        assert_eq!(config.resend_attempt_limit(), 1);
+    }
+
+    #[test]
+    fn test_session_config_zero_tolerance_disables_sending_time_check() {
+        let config = config().with_sending_time_tolerance(Duration::ZERO);
+
+        assert_eq!(config.sending_time_tolerance, Duration::ZERO);
+    }
+
+    #[test]
+    fn test_session_config_recovery_setters_apply() {
+        let config = config()
+            .with_sending_time_tolerance(Duration::from_secs(5))
+            .with_resend_timeout(Duration::from_millis(250))
+            .with_max_resend_requests(7)
+            .with_logout_timeout(Duration::from_secs(3));
+
+        assert_eq!(config.sending_time_tolerance, Duration::from_secs(5));
+        assert_eq!(config.resend_timeout, Duration::from_millis(250));
+        assert_eq!(config.resend_attempt_limit(), 7);
+        assert_eq!(config.logout_timeout, Duration::from_secs(3));
     }
 }


### PR DESCRIPTION
## Summary

Closes the three recovery gaps adversarial review found against a live `Initiator` — all fixed, none merely documented as a limitation.

Closes #29.

## Stack

- **Base branch:** `stack/18-codegen-derive` (PR #43)

## Gap 1 — an unsatisfied ResendRequest never gave up

A peer that never satisfied a resend but kept sending gapped frames held the session open indefinitely. The reason is subtle and worth stating: gapped frames deliberately refresh the heartbeat clock — a gapped message *does* prove the peer is alive — so the heartbeat timeout can never fire on a stalled gap.

An outstanding request now carries its own clock, independent of the heartbeat. It is retried while attempts remain, then the session is logged out with a `Text (58)` naming the stalled sequence number — an orderly, observable close, not a silent stall or a hard drop. Any in-sequence message clears the state, so the timer measures a gap that is filling *not at all*, never a slow replay.

Defaults: **10 s per attempt, 3 attempts** — an unrecoverable gap is bounded at ~30 s plus the logout handshake. Retry first because a single lost request or a briefly slow store is recoverable; escalate to Logout rather than hard-disconnect because FIX wants an orderly teardown and the peer deserves to know why.

## Gap 2 — SendingTime (52) was never validated

Reject reason 10 was enumerated in the spec and never produced. It is checked now on every inbound frame and on the Logon ack, **before** the heartbeat is refreshed — a wrong clock must not keep a session alive either. Outside the window is reason 10, absent is reason 1, unparseable is reason 6; each is followed by a Logout, because a wrong clock is systemic rather than per-message.

**Default 120 s, symmetric.** This is where FIX engines have converged (QuickFIX `MaxLatency`): an NTP-synced host stays within milliseconds, so 120 s is orders of magnitude more slack than a healthy peer needs, while an unsynced host drifts past it within days. Tighter starts killing sessions over ordinary drift plus queueing; looser stops distinguishing a wrong clock from a right one. A zero window disables the whole check — presence, format and skew together — for a peer with a known clock problem.

The comparison uses a self-contained `UTCTimestamp` parser (no new dependency): it accepts every FIX precision including leap seconds, rejects impossible dates and pre-1970, and round-trips against the formatter across leap days and a century boundary in tests.

## Gap 3 — CompIDs were matched by tag, not position

`PeerIdentity::validate` looked fields up by tag across the whole message, so 49/56 appearing **anywhere** satisfied the check — a frame carrying them only after the application body was accepted. This is **closed, not documented away**: `RawMessage` already preserves wire order, so no change to the decoder was needed. Each identity field must now carry the expected value *and* sit in the standard header; a misplaced one is Reject reason 9 on both the reactor and Logon-ack paths. The header-tag set covers FIX 4.0–5.0 SP2.

## What must not regress

The inbound path from #25/#37 is intact and still tested: GapFill vs Reset, bounded ResendRequest reply with `MsgSeqNum = BeginSeqNo`, inbound `141=Y` requiring MsgSeqNum 1, checked sequence arithmetic, and the rejected-in-sequence-GapFill-consumes-its-number path.

## Public API changes (semver)

`SessionConfig` gains three fields and four setters; `EngineError` gains `SendingTime`. Workspace is at 0.4.0. `SessionConfig`'s all-public fields without `#[non_exhaustive]` mean adding fields breaks an external exhaustive struct literal — worth a note, though construction is via `new()` plus builders in practice.

## Tests

Workspace at **516 passing**, including a stub-acceptor test per gap: a peer that only holds the socket open getting exactly 3 ResendRequests then a Logout (with a 30 s heartbeat, so the close is attributable to the resend bound alone), a stale SendingTime producing `373=10`/`371=52`, and body-only CompIDs producing `373=9`/`371=49`.

## Verification

```
cargo test --workspace                                    # 516 passed
cargo clippy --all-targets --all-features -- -D warnings  # clean
cargo fmt --all --check                                   # clean
make doc                                                  # clean
```
