### PR TITLE
fix: three conformance-edge fixes (Closes #48, #49, #50)

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -77,7 +77,7 @@ jobs:
               echo "$version client exited with $client_rc"
               exit 1
             fi
-            if ! grep -q "Logon OK" "client-${version}.log"; then
+            if ! grep -q "logon accepted" "client-${version}.log"; then
               echo "$version client never completed logon"
               exit 1
             fi
@@ -125,7 +125,7 @@ jobs:
           echo "--- server ---"; cat server-fast.log
           echo "--- client ---"; cat client-fast.log
 
-          if ! grep -q "Received:" client-fast.log; then
+          if ! grep -q "market data" client-fast.log; then
             echo "FAST client never decoded a market data message"
             exit 1
           fi

--- a/Docker/fast.Dockerfile
+++ b/Docker/fast.Dockerfile
@@ -27,11 +27,12 @@ COPY . .
 
 # Cache mounts carry the registry and the build directory across builds. They
 # are not part of the image, so the binary is copied out inside the same RUN.
-# `--locked` fails the build rather than silently resolving a different
-# dependency set than Cargo.lock records.
+# Cargo.lock is not committed (it is git-ignored for this workspace), so the
+# build resolves dependencies fresh rather than passing `--locked` against a
+# lock file the build context does not carry.
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/app/target \
-    cargo build --release --locked --example fast_server -p ironfix-example \
+    cargo build --release --example fast_server -p ironfix-example \
     && cp target/release/examples/fast_server /fast_server
 
 # Runtime stage

--- a/Docker/fix40.Dockerfile
+++ b/Docker/fix40.Dockerfile
@@ -27,11 +27,12 @@ COPY . .
 
 # Cache mounts carry the registry and the build directory across builds. They
 # are not part of the image, so the binary is copied out inside the same RUN.
-# `--locked` fails the build rather than silently resolving a different
-# dependency set than Cargo.lock records.
+# Cargo.lock is not committed (it is git-ignored for this workspace), so the
+# build resolves dependencies fresh rather than passing `--locked` against a
+# lock file the build context does not carry.
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/app/target \
-    cargo build --release --locked --example fix40_server -p ironfix-example \
+    cargo build --release --example fix40_server -p ironfix-example \
     && cp target/release/examples/fix40_server /fix40_server
 
 # Runtime stage

--- a/Docker/fix41.Dockerfile
+++ b/Docker/fix41.Dockerfile
@@ -27,11 +27,12 @@ COPY . .
 
 # Cache mounts carry the registry and the build directory across builds. They
 # are not part of the image, so the binary is copied out inside the same RUN.
-# `--locked` fails the build rather than silently resolving a different
-# dependency set than Cargo.lock records.
+# Cargo.lock is not committed (it is git-ignored for this workspace), so the
+# build resolves dependencies fresh rather than passing `--locked` against a
+# lock file the build context does not carry.
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/app/target \
-    cargo build --release --locked --example fix41_server -p ironfix-example \
+    cargo build --release --example fix41_server -p ironfix-example \
     && cp target/release/examples/fix41_server /fix41_server
 
 # Runtime stage

--- a/Docker/fix42.Dockerfile
+++ b/Docker/fix42.Dockerfile
@@ -27,11 +27,12 @@ COPY . .
 
 # Cache mounts carry the registry and the build directory across builds. They
 # are not part of the image, so the binary is copied out inside the same RUN.
-# `--locked` fails the build rather than silently resolving a different
-# dependency set than Cargo.lock records.
+# Cargo.lock is not committed (it is git-ignored for this workspace), so the
+# build resolves dependencies fresh rather than passing `--locked` against a
+# lock file the build context does not carry.
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/app/target \
-    cargo build --release --locked --example fix42_server -p ironfix-example \
+    cargo build --release --example fix42_server -p ironfix-example \
     && cp target/release/examples/fix42_server /fix42_server
 
 # Runtime stage

--- a/Docker/fix43.Dockerfile
+++ b/Docker/fix43.Dockerfile
@@ -27,11 +27,12 @@ COPY . .
 
 # Cache mounts carry the registry and the build directory across builds. They
 # are not part of the image, so the binary is copied out inside the same RUN.
-# `--locked` fails the build rather than silently resolving a different
-# dependency set than Cargo.lock records.
+# Cargo.lock is not committed (it is git-ignored for this workspace), so the
+# build resolves dependencies fresh rather than passing `--locked` against a
+# lock file the build context does not carry.
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/app/target \
-    cargo build --release --locked --example fix43_server -p ironfix-example \
+    cargo build --release --example fix43_server -p ironfix-example \
     && cp target/release/examples/fix43_server /fix43_server
 
 # Runtime stage

--- a/Docker/fix44.Dockerfile
+++ b/Docker/fix44.Dockerfile
@@ -27,11 +27,12 @@ COPY . .
 
 # Cache mounts carry the registry and the build directory across builds. They
 # are not part of the image, so the binary is copied out inside the same RUN.
-# `--locked` fails the build rather than silently resolving a different
-# dependency set than Cargo.lock records.
+# Cargo.lock is not committed (it is git-ignored for this workspace), so the
+# build resolves dependencies fresh rather than passing `--locked` against a
+# lock file the build context does not carry.
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/app/target \
-    cargo build --release --locked --example fix44_server -p ironfix-example \
+    cargo build --release --example fix44_server -p ironfix-example \
     && cp target/release/examples/fix44_server /fix44_server
 
 # Runtime stage

--- a/Docker/fix50.Dockerfile
+++ b/Docker/fix50.Dockerfile
@@ -27,11 +27,12 @@ COPY . .
 
 # Cache mounts carry the registry and the build directory across builds. They
 # are not part of the image, so the binary is copied out inside the same RUN.
-# `--locked` fails the build rather than silently resolving a different
-# dependency set than Cargo.lock records.
+# Cargo.lock is not committed (it is git-ignored for this workspace), so the
+# build resolves dependencies fresh rather than passing `--locked` against a
+# lock file the build context does not carry.
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/app/target \
-    cargo build --release --locked --example fix50_server -p ironfix-example \
+    cargo build --release --example fix50_server -p ironfix-example \
     && cp target/release/examples/fix50_server /fix50_server
 
 # Runtime stage

--- a/Docker/fix50sp1.Dockerfile
+++ b/Docker/fix50sp1.Dockerfile
@@ -27,11 +27,12 @@ COPY . .
 
 # Cache mounts carry the registry and the build directory across builds. They
 # are not part of the image, so the binary is copied out inside the same RUN.
-# `--locked` fails the build rather than silently resolving a different
-# dependency set than Cargo.lock records.
+# Cargo.lock is not committed (it is git-ignored for this workspace), so the
+# build resolves dependencies fresh rather than passing `--locked` against a
+# lock file the build context does not carry.
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/app/target \
-    cargo build --release --locked --example fix50sp1_server -p ironfix-example \
+    cargo build --release --example fix50sp1_server -p ironfix-example \
     && cp target/release/examples/fix50sp1_server /fix50sp1_server
 
 # Runtime stage

--- a/Docker/fix50sp2.Dockerfile
+++ b/Docker/fix50sp2.Dockerfile
@@ -27,11 +27,12 @@ COPY . .
 
 # Cache mounts carry the registry and the build directory across builds. They
 # are not part of the image, so the binary is copied out inside the same RUN.
-# `--locked` fails the build rather than silently resolving a different
-# dependency set than Cargo.lock records.
+# Cargo.lock is not committed (it is git-ignored for this workspace), so the
+# build resolves dependencies fresh rather than passing `--locked` against a
+# lock file the build context does not carry.
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/app/target \
-    cargo build --release --locked --example fix50sp2_server -p ironfix-example \
+    cargo build --release --example fix50sp2_server -p ironfix-example \
     && cp target/release/examples/fix50sp2_server /fix50sp2_server
 
 # Runtime stage

--- a/ironfix-codegen/src/generator.rs
+++ b/ironfix-codegen/src/generator.rs
@@ -45,9 +45,9 @@
 //!
 //! # What it does not contain
 //!
-//! The generated structs are **data definitions only**: no
-//! [`FixMessage`](ironfix_core::message::FixMessage) implementations, no
-//! encode/decode. Deriving those is `ironfix-derive`'s job, and the two are not
+//! The generated structs are **data definitions only**: no `FixMessage`
+//! implementations, no encode/decode. Deriving those is `ironfix-derive`'s job,
+//! and the two are not
 //! wired together — nothing in this workspace consumes either.
 //!
 //! # Fidelity limits, stated rather than hidden

--- a/ironfix-core/src/field.rs
+++ b/ironfix-core/src/field.rs
@@ -21,18 +21,27 @@ use std::str::FromStr;
 
 /// The lowest tag number FIX reserves for user-defined fields.
 ///
-/// FIX reserves 5000-9999 for user-defined fields, so 4999 is the highest
-/// standard tag and 5000 the first user-defined one.
+/// FIX reserves 5000-9999 for bilateral user-defined fields, so 4999 is the
+/// highest standard tag below the range and 5000 the first user-defined one.
 pub const USER_DEFINED_TAG_MIN: u32 = 5000;
+
+/// The highest tag number in the FIX user-defined range.
+///
+/// The user-defined range is exactly 5000-9999. Tags at or above 10000 —
+/// including the Extension Pack tags assigned at 40000+ — are *not*
+/// user-defined; they are assigned by the specification, and the loaded
+/// dictionary (not this type) is what says what an individual high tag means.
+pub const USER_DEFINED_TAG_MAX: u32 = 9999;
 
 /// FIX field tag number.
 ///
 /// Tags are positive integers that identify fields within a FIX message.
-/// Standard tags are defined in the FIX specification (1-4999), while FIX
-/// reserves 5000-9999 for user-defined fields. Tags at or above
-/// [`USER_DEFINED_TAG_MIN`] are treated as user-defined; venues do assign
-/// beyond 9999 in practice, and a dictionary — not this type — is what says
-/// whether a given tag is known.
+/// Standard tags are defined in the FIX specification (1-4999), FIX reserves
+/// the bilateral user-defined range 5000-9999, and the specification also
+/// assigns tags above 9999 (the Extension Pack range at 40000+). Only
+/// [`USER_DEFINED_TAG_MIN`]..=[`USER_DEFINED_TAG_MAX`] is user-defined; every
+/// other value, high ones included, is standard or unassigned, and a
+/// dictionary — not this type — is what says whether a given tag is known.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[repr(transparent)]
 #[serde(transparent)]
@@ -77,18 +86,28 @@ impl FieldTag {
         self.0 >= 1
     }
 
-    /// Returns true if this is a standard FIX tag (1-4999).
+    /// Returns true if this is a standard FIX tag below the user-defined range
+    /// (1-4999).
+    ///
+    /// This does not cover assigned tags above 9999 (the Extension Pack range
+    /// at 40000+): those are standard too, but the dictionary — not this
+    /// predicate — classifies an individual high tag.
     #[inline]
     #[must_use]
     pub const fn is_standard(self) -> bool {
         self.0 >= 1 && self.0 < USER_DEFINED_TAG_MIN
     }
 
-    /// Returns true if this is a user-defined tag (5000+).
+    /// Returns true if this is a user-defined tag, i.e. in the bilateral range
+    /// [`USER_DEFINED_TAG_MIN`]..=[`USER_DEFINED_TAG_MAX`] (5000-9999).
+    ///
+    /// A tag at or above 10000 — including an assigned Extension Pack tag at
+    /// 40000+ — is deliberately *not* user-defined: it is assigned by the FIX
+    /// specification, not agreed bilaterally.
     #[inline]
     #[must_use]
     pub const fn is_user_defined(self) -> bool {
-        self.0 >= USER_DEFINED_TAG_MIN
+        self.0 >= USER_DEFINED_TAG_MIN && self.0 <= USER_DEFINED_TAG_MAX
     }
 }
 
@@ -423,6 +442,35 @@ mod tests {
         assert!(!tag.is_standard());
         assert!(tag.is_user_defined());
         assert_eq!(tag.value(), USER_DEFINED_TAG_MIN);
+    }
+
+    #[test]
+    fn test_field_tag_boundary_9999_is_user_defined() {
+        let tag = ok(FieldTag::try_new(9999), "9999 is a legal tag");
+        assert!(!tag.is_standard());
+        assert!(tag.is_user_defined());
+        assert_eq!(tag.value(), USER_DEFINED_TAG_MAX);
+    }
+
+    #[test]
+    fn test_field_tag_boundary_10000_is_not_user_defined() {
+        // The bilateral user-defined range ends at 9999; 10000 is outside it.
+        let tag = ok(FieldTag::try_new(10000), "10000 is a legal tag");
+        assert!(!tag.is_user_defined());
+        assert!(!tag.is_standard());
+    }
+
+    #[test]
+    fn test_field_tag_assigned_extension_pack_is_not_user_defined() {
+        // Extension Pack tags assigned at 40000+ are standard, not user-defined:
+        // the earlier `>= 5000` predicate misclassified them.
+        for tag_num in [40000, 40001] {
+            let tag = ok(FieldTag::try_new(tag_num), "assigned high tag is legal");
+            assert!(
+                !tag.is_user_defined(),
+                "assigned tag {tag_num} must not be user-defined"
+            );
+        }
     }
 
     #[test]

--- a/ironfix-core/src/field.rs
+++ b/ironfix-core/src/field.rs
@@ -19,29 +19,42 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
 
-/// The lowest tag number FIX reserves for user-defined fields.
+/// The lowest tag number in the original FIX bilateral user-defined range.
 ///
 /// FIX reserves 5000-9999 for bilateral user-defined fields, so 4999 is the
 /// highest standard tag below the range and 5000 the first user-defined one.
 pub const USER_DEFINED_TAG_MIN: u32 = 5000;
 
-/// The highest tag number in the FIX user-defined range.
+/// The highest tag number in the original FIX bilateral user-defined range.
 ///
-/// The user-defined range is exactly 5000-9999. Tags at or above 10000 —
-/// including the Extension Pack tags assigned at 40000+ — are *not*
-/// user-defined; they are assigned by the specification, and the loaded
-/// dictionary (not this type) is what says what an individual high tag means.
+/// The first user-defined range is 5000-9999. Tags 10000-19999 are reserved
+/// for internal use within a single firm and are not the bilateral range.
 pub const USER_DEFINED_TAG_MAX: u32 = 9999;
+
+/// The lowest tag number in the extended FIX bilateral user-defined range.
+///
+/// The Global Technical Committee approved 20000-39999 as a second bilateral
+/// user-defined range in December 2009, once the 5000-9999 range filled up;
+/// tags here are used bilaterally and do not need to be registered.
+pub const USER_DEFINED_EXT_TAG_MIN: u32 = 20000;
+
+/// The highest tag number in the extended FIX bilateral user-defined range.
+///
+/// The extended user-defined range is 20000-39999. Tags at or above 40000 are
+/// reserved (GTC / internal use), not user-defined; the loaded dictionary, not
+/// this type, is what says what an individual high tag means.
+pub const USER_DEFINED_EXT_TAG_MAX: u32 = 39999;
 
 /// FIX field tag number.
 ///
 /// Tags are positive integers that identify fields within a FIX message.
-/// Standard tags are defined in the FIX specification (1-4999), FIX reserves
-/// the bilateral user-defined range 5000-9999, and the specification also
-/// assigns tags above 9999 (the Extension Pack range at 40000+). Only
-/// [`USER_DEFINED_TAG_MIN`]..=[`USER_DEFINED_TAG_MAX`] is user-defined; every
-/// other value, high ones included, is standard or unassigned, and a
-/// dictionary — not this type — is what says whether a given tag is known.
+/// Standard tags are defined in the FIX specification (1-4999). FIX reserves
+/// **two** disjoint bilateral user-defined ranges: 5000-9999, and 20000-39999
+/// (approved by the GTC in December 2009 once the first filled up). Tags
+/// 10000-19999 are internal-use, and tags at or above 40000 are reserved, so
+/// neither is user-defined. Only the two user-defined ranges classify as such
+/// here; a dictionary — not this type — is what says whether a given tag is
+/// known.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[repr(transparent)]
 #[serde(transparent)]
@@ -89,8 +102,7 @@ impl FieldTag {
     /// Returns true if this is a standard FIX tag below the user-defined range
     /// (1-4999).
     ///
-    /// This does not cover assigned tags above 9999 (the Extension Pack range
-    /// at 40000+): those are standard too, but the dictionary — not this
+    /// This does not cover assigned tags above 9999: the dictionary — not this
     /// predicate — classifies an individual high tag.
     #[inline]
     #[must_use]
@@ -98,16 +110,18 @@ impl FieldTag {
         self.0 >= 1 && self.0 < USER_DEFINED_TAG_MIN
     }
 
-    /// Returns true if this is a user-defined tag, i.e. in the bilateral range
-    /// [`USER_DEFINED_TAG_MIN`]..=[`USER_DEFINED_TAG_MAX`] (5000-9999).
+    /// Returns true if this is a bilateral user-defined tag.
     ///
-    /// A tag at or above 10000 — including an assigned Extension Pack tag at
-    /// 40000+ — is deliberately *not* user-defined: it is assigned by the FIX
-    /// specification, not agreed bilaterally.
+    /// FIX defines **two** disjoint user-defined ranges:
+    /// [`USER_DEFINED_TAG_MIN`]..=[`USER_DEFINED_TAG_MAX`] (5000-9999) and
+    /// [`USER_DEFINED_EXT_TAG_MIN`]..=[`USER_DEFINED_EXT_TAG_MAX`]
+    /// (20000-39999). A tag in the 10000-19999 internal-use range, or at or
+    /// above 40000, is deliberately *not* user-defined.
     #[inline]
     #[must_use]
     pub const fn is_user_defined(self) -> bool {
-        self.0 >= USER_DEFINED_TAG_MIN && self.0 <= USER_DEFINED_TAG_MAX
+        (self.0 >= USER_DEFINED_TAG_MIN && self.0 <= USER_DEFINED_TAG_MAX)
+            || (self.0 >= USER_DEFINED_EXT_TAG_MIN && self.0 <= USER_DEFINED_EXT_TAG_MAX)
     }
 }
 
@@ -454,21 +468,46 @@ mod tests {
 
     #[test]
     fn test_field_tag_boundary_10000_is_not_user_defined() {
-        // The bilateral user-defined range ends at 9999; 10000 is outside it.
+        // 10000-19999 is internal-use, between the two bilateral ranges.
         let tag = ok(FieldTag::try_new(10000), "10000 is a legal tag");
         assert!(!tag.is_user_defined());
         assert!(!tag.is_standard());
     }
 
     #[test]
-    fn test_field_tag_assigned_extension_pack_is_not_user_defined() {
-        // Extension Pack tags assigned at 40000+ are standard, not user-defined:
-        // the earlier `>= 5000` predicate misclassified them.
-        for tag_num in [40000, 40001] {
-            let tag = ok(FieldTag::try_new(tag_num), "assigned high tag is legal");
+    fn test_field_tag_extended_user_defined_range_boundaries() {
+        // The GTC approved 20000-39999 as a second bilateral user-defined range
+        // in 2009; the earlier `<= 9999` bound regressed all of it to false.
+        // 19999 is still internal-use; 40000+ is reserved.
+        let cases = [
+            (19999u32, false),
+            (20000, true),
+            (USER_DEFINED_EXT_TAG_MIN, true),
+            (30000, true),
+            (39999, true),
+            (USER_DEFINED_EXT_TAG_MAX, true),
+            (40000, false),
+        ];
+        for (tag_num, expected) in cases {
+            let tag = ok(FieldTag::try_new(tag_num), "high tag is legal");
+            assert_eq!(
+                tag.is_user_defined(),
+                expected,
+                "is_user_defined({tag_num}) should be {expected}"
+            );
+            assert!(!tag.is_standard(), "{tag_num} is not a standard low tag");
+        }
+    }
+
+    #[test]
+    fn test_field_tag_reserved_high_range_is_not_user_defined() {
+        // Tags at or above 40000 are reserved (GTC / internal use), not
+        // user-defined; the original `>= 5000` predicate misclassified them.
+        for tag_num in [40000, 40001, 49999, 50000] {
+            let tag = ok(FieldTag::try_new(tag_num), "reserved high tag is legal");
             assert!(
                 !tag.is_user_defined(),
-                "assigned tag {tag_num} must not be user-defined"
+                "reserved tag {tag_num} must not be user-defined"
             );
         }
     }

--- a/ironfix-core/src/lib.rs
+++ b/ironfix-core/src/lib.rs
@@ -38,7 +38,9 @@ pub use error::{
     CompIdError, DecodeError, EncodeError, FixError, InvalidFieldTag, InvalidSide, MsgTypeError,
     Result, SessionError, StoreError, TimestampError, UnknownFixVersion,
 };
-pub use field::{FieldRef, FieldTag, FieldValue, FixField, USER_DEFINED_TAG_MIN};
+pub use field::{
+    FieldRef, FieldTag, FieldValue, FixField, USER_DEFINED_TAG_MAX, USER_DEFINED_TAG_MIN,
+};
 pub use message::{CustomMsgType, FixMessage, MSG_TYPE_MAX_LEN, MsgType, OwnedMessage, RawMessage};
 pub use types::{COMP_ID_MAX_LEN, CompId, SeqNum, Side, Timestamp};
 pub use version::FixVersion;

--- a/ironfix-core/src/lib.rs
+++ b/ironfix-core/src/lib.rs
@@ -39,7 +39,8 @@ pub use error::{
     Result, SessionError, StoreError, TimestampError, UnknownFixVersion,
 };
 pub use field::{
-    FieldRef, FieldTag, FieldValue, FixField, USER_DEFINED_TAG_MAX, USER_DEFINED_TAG_MIN,
+    FieldRef, FieldTag, FieldValue, FixField, USER_DEFINED_EXT_TAG_MAX, USER_DEFINED_EXT_TAG_MIN,
+    USER_DEFINED_TAG_MAX, USER_DEFINED_TAG_MIN,
 };
 pub use message::{CustomMsgType, FixMessage, MSG_TYPE_MAX_LEN, MsgType, OwnedMessage, RawMessage};
 pub use types::{COMP_ID_MAX_LEN, CompId, SeqNum, Side, Timestamp};

--- a/ironfix-derive/src/lib.rs
+++ b/ironfix-derive/src/lib.rs
@@ -11,8 +11,8 @@
 //! This crate derives the two `ironfix-core` traits that give a Rust struct a
 //! FIX wire form:
 //!
-//! - `#[derive(FixMessage)]` implements [`ironfix_core::message::FixMessage`]
-//! - `#[derive(FixField)]` implements [`ironfix_core::field::FixField`]
+//! - `#[derive(FixMessage)]` implements `ironfix_core::message::FixMessage`
+//! - `#[derive(FixField)]` implements `ironfix_core::field::FixField`
 //!
 //! Both expansions name every type, trait, and enum variant by absolute path
 //! (`::ironfix_core::…`, `::core::…`, `::std::…`), so a derived type compiles
@@ -25,8 +25,7 @@
 //!   is a compile error naming what is missing. A MsgType is never assumed to
 //!   be `0` (Heartbeat) and a tag is never assumed to be `0`.
 //! - **Nothing panics.** The generated bodies return
-//!   [`DecodeError`](ironfix_core::error::DecodeError) /
-//!   [`EncodeError`](ironfix_core::error::EncodeError); there is no `unwrap`,
+//!   `DecodeError` / `EncodeError`; there is no `unwrap`,
 //!   no indexing, and no `todo!()` in the expansion.
 //!
 //! ## `#[derive(FixMessage)]`
@@ -54,7 +53,7 @@
 //!   `MSG_TYPE`, so decoding an `ExecutionReport` as a `NewOrderSingle` is a
 //!   typed error rather than a half-populated struct. A field typed `Option<T>`
 //!   is optional; any other type is required and its absence is
-//!   [`DecodeError::MissingRequiredField`](ironfix_core::error::DecodeError::MissingRequiredField).
+//!   `DecodeError::MissingRequiredField`.
 //! - `encode` appends `tag=value<SOH>` for each field **in declaration order**
 //!   and writes nothing else: no BeginString (8), no BodyLength (9), no
 //!   MsgType (35), no CheckSum (10). It produces the *body* fields, matching
@@ -104,7 +103,7 @@
 //!   encoding/decoding is not implemented.
 //! - **No `Length`/`Data` pairing.** A `Vec<u8>` field is written raw; if its
 //!   bytes contain SOH, `encode` fails with
-//!   [`EncodeError::InvalidFieldValue`](ironfix_core::error::EncodeError::InvalidFieldValue)
+//!   `EncodeError::InvalidFieldValue`
 //!   rather than emitting a frame that cannot be parsed back. Emitting the
 //!   paired `Length` field is the caller's job.
 //! - **No `skip`.** Every field of a derived `FixMessage` must map to a tag.
@@ -133,7 +132,7 @@ const SOH: u8 = 0x01;
 /// a message type that can never match into a compile error.
 const MSG_TYPE_MAX_LEN: usize = 8;
 
-/// Derives [`ironfix_core::message::FixMessage`] for a struct with named
+/// Derives `ironfix_core::message::FixMessage` for a struct with named
 /// fields.
 ///
 /// # Attributes
@@ -169,7 +168,7 @@ pub fn derive_fix_message(input: TokenStream) -> TokenStream {
         .into()
 }
 
-/// Derives [`ironfix_core::field::FixField`] for a single-field struct.
+/// Derives `ironfix_core::field::FixField` for a single-field struct.
 ///
 /// # Attributes
 ///

--- a/ironfix-engine/src/reactor.rs
+++ b/ironfix-engine/src/reactor.rs
@@ -1653,11 +1653,16 @@ impl<A: Application> Reactor<A> {
         };
         let msg_type = raw.msg_type().clone();
 
-        let Some(seq) = raw.get_field_str(34).and_then(|s| s.parse::<u64>().ok()) else {
+        // Positional read: MsgSeqNum (34) must be in the standard header, the
+        // same contract the CompID/SendingTime paths enforce. A 34 that appears
+        // only after the body is treated as missing rather than smuggled in as
+        // the session sequence number. Both Initiator and Acceptor share this
+        // reactor, so this closes the gap for in-session traffic on both.
+        let Some(seq) = wire::header_seq_num(&raw) else {
             tracing::warn!(
                 session = %self.session_id,
                 msg_type = %msg_type,
-                "dropping message without valid MsgSeqNum (34)"
+                "dropping message without a valid header MsgSeqNum (34)"
             );
             return Ok(phase);
         };

--- a/ironfix-engine/tests/initiator_tests.rs
+++ b/ironfix-engine/tests/initiator_tests.rs
@@ -2063,6 +2063,57 @@ async fn test_frame_without_msg_seq_num_is_dropped() {
     assert_eq!(connection.next_target_seq(), 3);
 }
 
+/// A frame whose MsgSeqNum (34) appears only after the body is dropped as a
+/// missing header field on the shared in-session reactor path, the same
+/// positional contract the CompID and SendingTime checks already enforce.
+/// Initiator and Acceptor share this reactor, so this covers both.
+#[tokio::test]
+async fn test_frame_with_body_only_msg_seq_num_is_dropped() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_logon(listener).await;
+
+        // 11 (ClOrdID) opens the body, so the 34 that follows it is not the
+        // standard-header MsgSeqNum. Built by hand: the encoder refuses a frame
+        // whose header field order is not standard, which is exactly the shape
+        // under test.
+        let ts = Timestamp::now().format_millis();
+        let body = format!(
+            "35=0\x0149=VENUE\x0156=CLIENT\x0152={}\x0111=ORDER-1\x0134=1\x01",
+            ts.as_str()
+        );
+        ok(
+            framed.send(raw_frame(body.as_bytes())).await,
+            "send frame with a body-only MsgSeqNum",
+        );
+
+        // The dropped frame consumed no sequence number, so 2 is still next: a
+        // valid TestRequest at 2 is answered, proving sequence state is intact.
+        ok(
+            framed.send(venue_msg("1", 2, &[(112, "PING-1")])).await,
+            "send test request",
+        );
+        let reply = next_frame(&mut framed).await;
+        assert_eq!(msg_type_of(&reply), "0");
+        assert_eq!(field(&reply, 112).as_deref(), Some("PING-1"));
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+    let connection = ok(initiator.connect(addr).await, "connect");
+
+    ok(
+        ok(
+            timeout(Duration::from_secs(5), acceptor).await,
+            "acceptor done within 5s",
+        ),
+        "acceptor task",
+    );
+    // The body-only-34 frame was dropped; 2 was consumed by the TestRequest.
+    assert_eq!(connection.next_target_seq(), 3);
+}
+
 /// A Logout that is never acknowledged closes the session at the logout
 /// deadline.
 #[tokio::test]

--- a/ironfix-example/examples/fix44_server.rs
+++ b/ironfix-example/examples/fix44_server.rs
@@ -68,8 +68,15 @@ impl ServerApp {
     }
 
     /// Publishes the outbound handle for the established session.
+    ///
+    /// Uses `send_replace`, not `send`: the initial receiver is dropped in
+    /// `new`, so when `set_connection` wins the race against `from_app`'s
+    /// `subscribe`, a plain `send` would have no receivers, discard the value,
+    /// and leave every later subscriber seeing `None` forever. `send_replace`
+    /// stores the handle unconditionally, so a task that subscribes afterwards
+    /// still observes it.
     fn set_connection(&self, connection: Connection) {
-        let _ = self.connection.send(Some(connection));
+        let _ = self.connection.send_replace(Some(connection));
     }
 
     /// A receiver a spawned task can await the connection handle on.

--- a/ironfix-fast/src/decoder.rs
+++ b/ironfix-fast/src/decoder.rs
@@ -216,6 +216,48 @@ impl FastDecoder {
         Ok(result)
     }
 
+    /// Decodes a stop-bit unsigned integer into a `u128`.
+    ///
+    /// Identical to [`FastDecoder::decode_uint`] but accumulates in `u128`, so
+    /// it can hold the biased `2^64` a nullable unsigned uses to denote
+    /// `u64::MAX`. The same [`MAX_INT_ENCODED_LEN`] ceiling bounds the read, so
+    /// a hostile over-long encoding is [`FastError::IntegerOverflow`] rather
+    /// than an unbounded loop.
+    ///
+    /// # Errors
+    /// [`FastError::UnexpectedEof`] if the input ends mid-value, or
+    /// [`FastError::IntegerOverflow`] if the encoding exceeds
+    /// [`MAX_INT_ENCODED_LEN`] bytes.
+    fn decode_uint_u128(data: &[u8], offset: &mut usize) -> Result<u128, FastError> {
+        /// Value of one payload byte position.
+        const RADIX: u128 = 1 << PAYLOAD_BITS;
+
+        let mut result: u128 = 0;
+        let mut consumed: usize = 0;
+
+        loop {
+            if consumed == MAX_INT_ENCODED_LEN {
+                return Err(FastError::IntegerOverflow);
+            }
+            let byte = read_byte(data, offset)?;
+            consumed += 1;
+
+            // `checked_mul` rejects any value that would lose significant bits.
+            // The product's low seven bits are zero, so the `|` below cannot
+            // carry and is exact.
+            result = result
+                .checked_mul(RADIX)
+                .ok_or(FastError::IntegerOverflow)?
+                | u128::from(byte & PAYLOAD_MASK);
+
+            if byte & STOP_BIT != 0 {
+                break;
+            }
+        }
+
+        Ok(result)
+    }
+
     /// Decodes a nullable unsigned integer.
     ///
     /// FAST represents a nullable unsigned integer with a bias of one: a lone
@@ -225,20 +267,25 @@ impl FastDecoder {
     /// the two must agree, so the bias lives here rather than in every caller,
     /// which is where an off-by-one reappears.
     ///
-    /// The representable domain is therefore `0..=u64::MAX - 1`.
+    /// The representable domain is the full `0..=u64::MAX`: `u64::MAX` biases to
+    /// `2^64`, which does not fit `u64`, so the biased value is decoded through
+    /// `u128` and only the debiased result is narrowed back to `u64`.
     ///
     /// # Errors
     /// Returns [`FastError::UnexpectedEof`] if the input ends mid-value, or
-    /// [`FastError::IntegerOverflow`] if the encoded value exceeds the
-    /// representable domain.
+    /// [`FastError::IntegerOverflow`] if the debiased value exceeds `u64::MAX`
+    /// (a hostile over-long encoding) — never a panic and never an unbounded
+    /// read.
     pub fn decode_nullable_uint(data: &[u8], offset: &mut usize) -> Result<Option<u64>, FastError> {
-        let raw = Self::decode_uint(data, offset)?;
-        match raw {
+        let biased = Self::decode_uint_u128(data, offset)?;
+        match biased {
             0 => Ok(None),
-            biased => biased
-                .checked_sub(1)
+            // `biased >= 1` here, so the subtraction cannot underflow; the value
+            // may still exceed `u64::MAX` for an over-long encoding, which the
+            // narrowing rejects.
+            biased => u64::try_from(biased - 1)
                 .map(Some)
-                .ok_or(FastError::IntegerOverflow),
+                .map_err(|_| FastError::IntegerOverflow),
         }
     }
 
@@ -837,6 +884,9 @@ mod tests {
             Some(127),
             Some(128),
             Some(u64::MAX - 1),
+            // u64::MAX biases to 2^64, decoded through u128: the domain now
+            // covers the full unsigned range, not 0..=u64::MAX-1.
+            Some(u64::MAX),
         ] {
             let mut encoder = crate::FastEncoder::new();
             assert!(encoder.encode_nullable_uint(value).is_ok());
@@ -861,10 +911,15 @@ mod tests {
     }
 
     #[test]
-    fn test_encode_nullable_uint_rejects_the_value_outside_its_domain() {
-        let mut encoder = crate::FastEncoder::new();
+    fn test_decode_nullable_uint_over_long_encoding_is_bounded_overflow() {
+        // The full u64 range now decodes, so the remaining hostile case is an
+        // encoding longer than MAX_INT_ENCODED_LEN bytes. A ten-byte run with
+        // no stop bit exhausts the ceiling on the next read: a bounded
+        // IntegerOverflow, never an unbounded loop or a panic.
+        let hostile = [0x00u8; MAX_INT_ENCODED_LEN];
+        let mut offset = 0;
         assert_eq!(
-            encoder.encode_nullable_uint(Some(u64::MAX)),
+            FastDecoder::decode_nullable_uint(&hostile, &mut offset),
             Err(FastError::IntegerOverflow)
         );
     }

--- a/ironfix-fast/src/decoder.rs
+++ b/ironfix-fast/src/decoder.rs
@@ -928,6 +928,34 @@ mod tests {
     }
 
     #[test]
+    fn test_decode_nullable_uint_boundary_from_external_fixtures() {
+        // Hand-built stop-bit fixtures, independent of the encoder, that pin the
+        // u128 narrowing branch directly: a properly stopped biased value that
+        // does fit u64 after debiasing, and the first one that does not.
+        //
+        // Biased 2^64 (10 stop-bit bytes, MSB first, stop bit on the last):
+        // decodes to 2^64, debiases to u64::MAX. This is the accepted boundary.
+        let biased_two_pow_64 = [0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80];
+        let mut offset = 0;
+        assert_eq!(
+            FastDecoder::decode_nullable_uint(&biased_two_pow_64, &mut offset),
+            Ok(Some(u64::MAX))
+        );
+        assert_eq!(offset, biased_two_pow_64.len());
+
+        // Biased 2^64 + 1: a valid, fully-stopped ten-byte encoding whose
+        // debiased value is 2^64, one past u64::MAX. This exercises the
+        // `u64::try_from` narrowing failure, not the byte-count ceiling.
+        let biased_two_pow_64_plus_one =
+            [0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x81];
+        let mut offset = 0;
+        assert_eq!(
+            FastDecoder::decode_nullable_uint(&biased_two_pow_64_plus_one, &mut offset),
+            Err(FastError::IntegerOverflow)
+        );
+    }
+
+    #[test]
     fn test_decode_ascii() {
         let data = [b'H', b'i', b'!' | 0x80]; // "Hi!"
         let mut offset = 0;

--- a/ironfix-fast/src/decoder.rs
+++ b/ironfix-fast/src/decoder.rs
@@ -280,12 +280,15 @@ impl FastDecoder {
         let biased = Self::decode_uint_u128(data, offset)?;
         match biased {
             0 => Ok(None),
-            // `biased >= 1` here, so the subtraction cannot underflow; the value
-            // may still exceed `u64::MAX` for an over-long encoding, which the
-            // narrowing rejects.
-            biased => u64::try_from(biased - 1)
+            // `checked_sub` keeps the decode path free of bare arithmetic even
+            // though the `0` arm above already guarantees `biased >= 1`; the
+            // debiased value may still exceed `u64::MAX` for an over-long
+            // encoding, which the narrowing rejects as `IntegerOverflow`.
+            biased => biased
+                .checked_sub(1)
+                .and_then(|value| u64::try_from(value).ok())
                 .map(Some)
-                .map_err(|_| FastError::IntegerOverflow),
+                .ok_or(FastError::IntegerOverflow),
         }
     }
 

--- a/ironfix-fast/src/encoder.rs
+++ b/ironfix-fast/src/encoder.rs
@@ -176,24 +176,49 @@ impl FastEncoder {
         self.buffer.extend_from_slice(value);
     }
 
+    /// Encodes a `u128` using stop-bit encoding.
+    ///
+    /// Identical to [`FastEncoder::encode_uint`] but takes a `u128`, so it can
+    /// emit the biased `2^64` a nullable unsigned uses to denote `u64::MAX`.
+    /// `2^64` occupies ten payload bytes, within [`MAX_INT_ENCODED_LEN`].
+    fn encode_uint_u128(&mut self, value: u128) {
+        let mut bytes = IntScratch::new();
+        let mut remaining = value;
+
+        loop {
+            bytes.push((remaining & u128::from(PAYLOAD_MASK)) as u8);
+            remaining >>= PAYLOAD_BITS;
+
+            if remaining == 0 {
+                break;
+            }
+        }
+
+        Self::flush_stop_bit_encoded(&mut self.buffer, &mut bytes);
+    }
+
     /// Encodes a nullable unsigned integer.
     ///
     /// A nullable unsigned integer is encoded with a bias of one so that the
-    /// single stop byte `0x80` is reserved for `None`. The representable
-    /// domain is therefore `0..=u64::MAX - 1`: `Some(u64::MAX)` has no
-    /// encoding and is rejected rather than silently biased into the `None`
-    /// representation.
+    /// single stop byte `0x80` is reserved for `None`. The full `0..=u64::MAX`
+    /// domain is representable: `Some(u64::MAX)` biases to `2^64`, which does
+    /// not fit `u64`, so the biased value is widened to `u128` and emitted in
+    /// ten stop-bit bytes — the same frame
+    /// [`FastDecoder::decode_nullable_uint`](crate::FastDecoder::decode_nullable_uint)
+    /// reads back.
     ///
     /// # Arguments
     /// * `value` - The optional value to encode
     ///
     /// # Errors
-    /// Returns [`FastError::IntegerOverflow`] for `Some(u64::MAX)`.
+    /// Never returns an error; the `Result` is kept for API stability and to
+    /// match the fallible signed and byte-vector encoders.
     pub fn encode_nullable_uint(&mut self, value: Option<u64>) -> Result<(), FastError> {
         match value {
             Some(v) => {
-                let biased = v.checked_add(1).ok_or(FastError::IntegerOverflow)?;
-                self.encode_uint(biased);
+                // The biased value is at most `2^64`, which fits `u128`, not `u64`.
+                let biased = u128::from(v) + 1;
+                self.encode_uint_u128(biased);
             }
             None => self.buffer.push(STOP_BIT),
         }
@@ -553,17 +578,13 @@ mod tests {
     }
 
     #[test]
-    fn test_encode_nullable_uint_max_is_integer_overflow() {
+    fn test_encode_nullable_uint_max_is_representable() {
+        // u64::MAX biases to 2^64, which does not fit u64; it now encodes
+        // through u128 in ten stop-bit bytes instead of being rejected as
+        // IntegerOverflow. The round-trip is pinned in the decoder tests.
         let mut encoder = FastEncoder::new();
-        assert_eq!(
-            encoder.encode_nullable_uint(Some(u64::MAX)),
-            Err(FastError::IntegerOverflow),
-            "u64::MAX is outside the 0..=u64::MAX-1 nullable domain"
-        );
-        assert!(
-            encoder.is_empty(),
-            "an overflowing value must not be biased into the NULL representation"
-        );
+        assert_eq!(encoder.encode_nullable_uint(Some(u64::MAX)), Ok(()));
+        assert_eq!(encoder.len(), MAX_INT_ENCODED_LEN);
     }
 
     #[test]

--- a/ironfix-fast/src/lib.rs
+++ b/ironfix-fast/src/lib.rs
@@ -59,9 +59,11 @@
 //!
 //! The encoders are the mirror image: they only ever emit encodings the
 //! decoders accept. Values that have no legal FAST representation — a
-//! non-ASCII string, a string that begins with a NUL and continues, or
-//! `Some(u64::MAX)` in a nullable unsigned field — are refused with a typed
-//! error rather than written to the wire in a corrupt form.
+//! non-ASCII string, or a string that begins with a NUL and continues — are
+//! refused with a typed error rather than written to the wire in a corrupt
+//! form. The nullable unsigned codec covers the full `0..=u64::MAX` domain:
+//! `Some(u64::MAX)` biases to 2^64 and round-trips through a `u128` path
+//! rather than being rejected.
 
 pub mod decoder;
 pub mod encoder;


### PR DESCRIPTION
## Summary

Three small, independently-verified conformance edges from the 2026-07-22 review
round, bundled into one PR because they touch disjoint crates and share no
interface.

Closes #48
Closes #49
Closes #50

No breaking API change: one additive `pub const`, two new private helpers, and a
private-module fix. The workspace stays at unreleased `0.4.0`.

Two drive-by CI repairs ride along, both pre-existing breakage that earlier
`--admin` merges bypassed and this (first non-admin) PR surfaced:

- **`docs` job:** `cargo doc -D warnings` (stricter than the local `make doc`
  clippy gate) flagged broken intra-doc links in `ironfix-derive` and
  `ironfix-codegen` — both link into `ironfix_core`, which neither crate depends
  on directly. Demoted to plain code spans so `cargo doc --workspace` passes.
- **`smoke` job (stale asserts):** `examples.yml` grepped client logs for
  `Logon OK` / `Received:`, but #45 rewrote the example log messages to
  `logon accepted` / `market data`. The two greps now match the examples' actual
  output.
- **`smoke` job (real bug):** the Acceptor-based `fix44_server` (#47) never
  delivered its `ExecutionReport` reply — it published the `Connection` over a
  `watch` whose initial receiver is dropped, and `send` silently discards the
  value when it wins the race against `from_app`'s `subscribe` (the common case),
  so the client timed out with "no reply within 10s". `send_replace` stores the
  handle unconditionally. Verified by running the fix44 pair 4/4.
- **`build` (Docker) jobs:** the example image builds passed `cargo build
  --locked`, but `Cargo.lock` is git-ignored and excluded from the build context,
  so `--locked` had no lock file to honour — the images built only while the GHA
  cache held a compatible lock, which the `0.4.0` bumps invalidated. `--locked`
  is dropped so the images resolve dependencies fresh.

## #49 — `ironfix-core`: bound `is_user_defined` to 5000–9999

`FieldTag::is_user_defined` returned `true` for any tag `>= 5000`, so an assigned
high tag (40000+) was misclassified as user-defined. FIX defines **two disjoint
bilateral user-defined ranges**: **5000–9999**, and **20000–39999** (approved by
the GTC in December 2009 once the first filled up). Tags 10000–19999 are
internal-use and tags at or above 40000 are reserved, so neither is user-defined.

- Adds `USER_DEFINED_TAG_MAX` (9999) plus `USER_DEFINED_EXT_TAG_MIN` (20000) /
  `USER_DEFINED_EXT_TAG_MAX` (39999), and makes the predicate the union of both
  ranges.
- Boundary tests: 4999→false, 5000→true, 9999→true, 10000→false, 19999→false,
  20000→true, 39999→true, 40000→false.

## #48 — `ironfix-fast`: nullable unsigned codec now represents `u64::MAX`

**Part 1 (implemented).** The nullable unsigned codec biases by one, so
`Some(u64::MAX)` biased to `2^64`, which the `u64` encoder rejected as
`IntegerOverflow` and the `u64` decoder could not represent — the domain was
`0..=u64::MAX-1`. The biased value now travels through `u128` on both sides
(private `encode_uint_u128` / `decode_uint_u128`), so `Some(u64::MAX)`
round-trips while the plain `u64` `encode_uint`/`decode_uint` API is unchanged.
Values that fit `u64` encode to byte-identical frames as before — only the
previously-unrepresentable `Some(u64::MAX)` is new. The `MAX_INT_ENCODED_LEN`
ceiling still bounds the decode, so a hostile over-long encoding is a typed
`IntegerOverflow`, never a panic or an unbounded read.

**Part 2 (already done).** The issue's second finding — `DictionaryValue`
cross-variant accessors returning `None` — was already resolved on `main` (by
#40): `as_i64`/`as_u64` cross-read with exact-cast guards, and existing tests
pin it (`Int(42).as_u64() == Some(42)`, `UInt(42).as_i64() == Some(42)`, plus the
negative/out-of-range guards). No change was needed; the decision is test-pinned.

## #50 — `ironfix-engine`: read MsgSeqNum(34) positionally in the shared reactor

The shared in-session reactor read `MsgSeqNum(34)` with a whole-message
`get_field_str`, so a `34` placed only after the body read as present instead of
a missing header field. It now uses `wire::header_seq_num`, the same positional
guard the Acceptor handshake and the CompID/SendingTime paths use, so a body-only
`34` is treated as missing. Both `Initiator` and `Acceptor` share this reactor,
so the gap closes for in-session traffic on both. New test
`test_frame_with_body_only_msg_seq_num_is_dropped` drives a body-only-`34` frame
and asserts it is dropped without disturbing sequence state.

The spec (`doc/fix_operations.md`) assigns no positional reject reason for tag 34,
so this is inbound-acceptance hardening (silent drop, no sequence advance), not a
conformance break.

## Public API changes (semver)

- `ironfix-core`: **adds** `USER_DEFINED_TAG_MAX`, `USER_DEFINED_EXT_TAG_MIN`,
  `USER_DEFINED_EXT_TAG_MAX` (all `pub const`, minor). No removed or renamed
  public item.
- `ironfix-fast`: behaviour change only (nullable now accepts `u64::MAX`); the two
  new helpers are private.
- `ironfix-engine`: `reactor.rs` is a private module; no public surface change.

## Tests

```
cargo test --workspace                                    # all pass
cargo clippy --all-targets --all-features -- -D warnings  # clean
cargo fmt --all --check                                   # clean
cargo build --release --workspace                         # clean
make doc                                                  # clean (clippy -W missing-docs)
```

New coverage: core tag-range boundaries; `Some(u64::MAX)` round-trip and a bounded
over-long-encoding `IntegerOverflow`; and the body-only-`34` reactor drop.
No performance claim is made — the repo has no criterion baseline.

## Review

`architect`, `codec-expert` and `protocol-reviewer` all signed off. Two review
notes were applied: the crate root now re-exports `USER_DEFINED_TAG_MAX`
symmetrically with `USER_DEFINED_TAG_MIN`, and the nullable debias uses
`checked_sub`. Two adjacent same-class gaps found in review are out of scope here
and tracked as follow-ups:

- **#51** — the nullable **signed** codec has the same `i64::MAX` domain gap #48
  fixes for unsigned.
- **#52** — the Initiator's Logon-**ack** MsgSeqNum is the one remaining
  non-positional tag-34 read (the shared reactor and the Acceptor handshake both
  enforce the standard-header contract after #50).
