### PR TITLE
fix: nullable signed i64::MAX and positional initiator ack MsgSeqNum (Closes #51, #52)

### DIFF
--- a/doc/fix_operations.md
+++ b/doc/fix_operations.md
@@ -106,11 +106,11 @@ and stops at the first failure:
    — its initiator would set 1, its acceptor 2 — and IronFix matches the
    acceptor. The mismatch self-heals: the peer sees a gap at 2, requests a
    resend of 1, and receives a GapFill that resynchronises it.
-7. **`MsgSeqNum` (34).** Read positionally: 34 must appear in the standard
-   header, the same contract steps 2 and 5 enforce, so a 34 that occurs only
-   after the body is treated as missing and fails the handshake. When present in
-   the header, too low fails the handshake and a gap completes the handshake and
-   immediately issues a ResendRequest.
+7. **`MsgSeqNum` (34).** The header 34 is read positionally, *before* identity —
+   the same standard-header contract step 2 applies to the CompIDs — so a 34 that
+   occurs only after the body is treated as missing and fails the handshake. The
+   value read there is then validated at this step: too low fails the handshake,
+   and a gap completes the handshake and immediately issues a ResendRequest.
 
 The same identity and `SendingTime` checks (steps 2 and 3) run on every inbound
 frame once the session is established; there a failure produces the Reject and

--- a/doc/fix_operations.md
+++ b/doc/fix_operations.md
@@ -106,8 +106,11 @@ and stops at the first failure:
    — its initiator would set 1, its acceptor 2 — and IronFix matches the
    acceptor. The mismatch self-heals: the peer sees a gap at 2, requests a
    resend of 1, and receives a GapFill that resynchronises it.
-7. **`MsgSeqNum` (34).** Too low fails the handshake; a gap completes the
-   handshake and immediately issues a ResendRequest.
+7. **`MsgSeqNum` (34).** Read positionally: 34 must appear in the standard
+   header, the same contract steps 2 and 5 enforce, so a 34 that occurs only
+   after the body is treated as missing and fails the handshake. When present in
+   the header, too low fails the handshake and a gap completes the handshake and
+   immediately issues a ResendRequest.
 
 The same identity and `SendingTime` checks (steps 2 and 3) run on every inbound
 frame once the session is established; there a failure produces the Reject and

--- a/ironfix-engine/src/initiator.rs
+++ b/ironfix-engine/src/initiator.rs
@@ -640,7 +640,17 @@ impl<A: Application + 'static> Initiator<A> {
                 }
             }
 
-            let ack_seq: u64 = raw.get_field_as(34)?;
+            // Positional: MsgSeqNum (34) must be in the standard header, the
+            // same contract the CompID check enforces on 49/56 and the acceptor
+            // handshake already applies. A 34 that appears only after the body
+            // is treated as a missing header field rather than accepted as the
+            // ack sequence number.
+            let Some(ack_seq) = wire::header_seq_num(&raw) else {
+                let _ = session.on_logon_reject();
+                return Err(EngineError::Sequence(
+                    "Logon ack has no valid MsgSeqNum (34) in the standard header".to_string(),
+                ));
+            };
 
             // Identity before anything else: a cross-wired acceptor must not
             // be allowed to establish a session or move sequence state.

--- a/ironfix-engine/tests/initiator_tests.rs
+++ b/ironfix-engine/tests/initiator_tests.rs
@@ -2868,7 +2868,7 @@ async fn test_logon_ack_body_only_msg_seq_num_fails_handshake() {
 
         // 98 (EncryptMethod) is a body field, so the standard-header run ends at
         // it; the 34 placed after it is not the header MsgSeqNum. Built by hand
-        // because the encoder refuses a non-standard header field order.
+        // to place 34 after that body field.
         let ts = Timestamp::now().format_millis();
         let body = format!(
             "35=A\x0149=VENUE\x0156=CLIENT\x0152={}\x0198=0\x01108=30\x0134=1\x01",

--- a/ironfix-engine/tests/initiator_tests.rs
+++ b/ironfix-engine/tests/initiator_tests.rs
@@ -2855,6 +2855,44 @@ async fn test_logon_ack_wrong_begin_string_fails_handshake() {
     ok(acceptor.await, "acceptor task");
 }
 
+/// A Logon ack whose MsgSeqNum (34) sits only after the body, not in the
+/// standard header, fails the handshake: the initiator reads 34 positionally,
+/// the same contract the Acceptor handshake and the in-session reactor use.
+#[tokio::test]
+async fn test_logon_ack_body_only_msg_seq_num_fails_handshake() {
+    let (listener, addr) = bind_listener().await;
+
+    let acceptor = tokio::spawn(async move {
+        let mut framed = accept_framed(listener).await;
+        let _logon = next_frame(&mut framed).await;
+
+        // 98 (EncryptMethod) is a body field, so the standard-header run ends at
+        // it; the 34 placed after it is not the header MsgSeqNum. Built by hand
+        // because the encoder refuses a non-standard header field order.
+        let ts = Timestamp::now().format_millis();
+        let body = format!(
+            "35=A\x0149=VENUE\x0156=CLIENT\x0152={}\x0198=0\x01108=30\x0134=1\x01",
+            ts.as_str()
+        );
+        ok(
+            framed.send(raw_frame(body.as_bytes())).await,
+            "send logon ack with a body-only MsgSeqNum",
+        );
+    });
+
+    let (app, _app_rx) = RecordingApp::new();
+    let initiator = Initiator::new(client_config(Duration::from_secs(30)), Arc::clone(&app));
+
+    match initiator.connect(addr).await {
+        Err(EngineError::Sequence(detail)) => {
+            assert!(detail.contains("MsgSeqNum"), "got {detail}");
+        }
+        other => panic!("expected a Sequence error, got {other:?}"),
+    }
+
+    ok(acceptor.await, "acceptor task");
+}
+
 /// A zero initial sequence seed is refused before the socket is dialled: a
 /// seeded MsgSeqNum (34) of 0 would be rejected by every conforming
 /// counterparty, since FIX numbers messages from 1.

--- a/ironfix-fast/src/decoder.rs
+++ b/ironfix-fast/src/decoder.rs
@@ -379,10 +379,13 @@ impl FastDecoder {
         }
 
         // Positive values are biased by one; `2^63` debiases to i64::MAX, and
-        // anything larger overflows i64.
-        i64::try_from(raw - 1)
+        // anything larger overflows i64. `checked_sub` keeps the decode path
+        // free of bare arithmetic, matching the unsigned sibling, though the
+        // `raw > 0` branch already guarantees no underflow.
+        raw.checked_sub(1)
+            .and_then(|value| i64::try_from(value).ok())
             .map(Some)
-            .map_err(|_| FastError::IntegerOverflow)
+            .ok_or(FastError::IntegerOverflow)
     }
 
     /// Decodes a nullable ASCII string.

--- a/ironfix-fast/src/decoder.rs
+++ b/ironfix-fast/src/decoder.rs
@@ -292,6 +292,53 @@ impl FastDecoder {
         }
     }
 
+    /// Decodes a stop-bit signed integer into an `i128`.
+    ///
+    /// Identical to [`FastDecoder::decode_int`] but accumulates in `i128`, so it
+    /// can hold the biased `2^63` a nullable signed uses to denote `i64::MAX`.
+    /// The same [`MAX_INT_ENCODED_LEN`] ceiling bounds the read, so a hostile
+    /// over-long encoding is [`FastError::IntegerOverflow`] rather than an
+    /// unbounded loop.
+    ///
+    /// # Errors
+    /// [`FastError::UnexpectedEof`] if the input ends mid-value, or
+    /// [`FastError::IntegerOverflow`] if the encoding exceeds
+    /// [`MAX_INT_ENCODED_LEN`] bytes.
+    fn decode_int_i128(data: &[u8], offset: &mut usize) -> Result<i128, FastError> {
+        /// Value of one payload byte position.
+        const RADIX: i128 = 1 << PAYLOAD_BITS;
+
+        let first_byte = *data.get(*offset).ok_or(FastError::UnexpectedEof)?;
+        let negative = (first_byte & SIGN_BIT) != 0;
+
+        // Sign extension: a negative value starts from all-ones so the
+        // accumulated two's complement stays negative.
+        let mut result: i128 = if negative { -1 } else { 0 };
+        let mut consumed: usize = 0;
+
+        loop {
+            if consumed == MAX_INT_ENCODED_LEN {
+                return Err(FastError::IntegerOverflow);
+            }
+            let byte = read_byte(data, offset)?;
+            consumed += 1;
+
+            // `checked_mul` rejects any value that would lose significant bits.
+            // The product is a multiple of `RADIX`, so its low seven bits are
+            // zero and the `|` below is exact.
+            result = result
+                .checked_mul(RADIX)
+                .ok_or(FastError::IntegerOverflow)?
+                | i128::from(byte & PAYLOAD_MASK);
+
+            if byte & STOP_BIT != 0 {
+                break;
+            }
+        }
+
+        Ok(result)
+    }
+
     /// Decodes a nullable signed integer.
     ///
     /// FAST biases only the non-negative half of the range: zero is NULL, a
@@ -301,7 +348,9 @@ impl FastDecoder {
     /// and the bias lives here rather than in every caller for the same reason
     /// it does for the unsigned form.
     ///
-    /// The representable domain is `i64::MIN..=i64::MAX - 1`.
+    /// The representable domain is the full `i64::MIN..=i64::MAX`: `i64::MAX`
+    /// biases to `2^63`, which does not fit `i64`, so the biased value is
+    /// decoded through `i128` and only the debiased result is narrowed back.
     ///
     /// # Arguments
     /// * `data` - The input bytes
@@ -313,22 +362,27 @@ impl FastDecoder {
     /// # Errors
     /// Returns [`FastError::UnexpectedEof`] if the input ends mid-value, or
     /// [`FastError::IntegerOverflow`] if the encoding is over-long or denotes a
-    /// value outside `i64`.
+    /// value outside `i64` — never a panic and never an unbounded read.
     pub fn decode_nullable_int(data: &[u8], offset: &mut usize) -> Result<Option<i64>, FastError> {
-        let raw = Self::decode_int(data, offset)?;
+        let raw = Self::decode_int_i128(data, offset)?;
 
         if raw == 0 {
             return Ok(None);
         }
 
         if raw < 0 {
-            // Negative values carry no bias.
-            return Ok(Some(raw));
+            // Negative values carry no bias; an over-long encoding could still
+            // land below i64::MIN, which the narrowing rejects.
+            return i64::try_from(raw)
+                .map(Some)
+                .map_err(|_| FastError::IntegerOverflow);
         }
 
-        raw.checked_sub(1)
+        // Positive values are biased by one; `2^63` debiases to i64::MAX, and
+        // anything larger overflows i64.
+        i64::try_from(raw - 1)
             .map(Some)
-            .ok_or(FastError::IntegerOverflow)
+            .map_err(|_| FastError::IntegerOverflow)
     }
 
     /// Decodes a nullable ASCII string.
@@ -1141,6 +1195,9 @@ mod tests {
             Some(-65),
             Some(i64::MIN),
             Some(i64::MAX - 1),
+            // i64::MAX biases to 2^63, carried through i128: the domain now
+            // covers the full signed range, not i64::MIN..=i64::MAX-1.
+            Some(i64::MAX),
         ] {
             let mut encoder = FastEncoder::new();
             assert_eq!(encoder.encode_nullable_int(value), Ok(()));
@@ -1177,15 +1234,51 @@ mod tests {
     }
 
     #[test]
-    fn test_encode_nullable_int_rejects_the_value_outside_its_domain() {
+    fn test_encode_nullable_int_max_is_representable() {
+        // i64::MAX biases to 2^63, which does not fit i64; it now encodes
+        // through i128 in ten stop-bit bytes instead of being rejected as
+        // IntegerOverflow. The round-trip is pinned in the round-trip test.
         let mut encoder = FastEncoder::new();
+        assert_eq!(encoder.encode_nullable_int(Some(i64::MAX)), Ok(()));
+        assert_eq!(encoder.len(), MAX_INT_ENCODED_LEN);
+    }
+
+    #[test]
+    fn test_decode_nullable_int_boundary_from_external_fixtures() {
+        // Hand-built stop-bit fixtures, independent of the encoder, that pin the
+        // i128 narrowing branch directly.
+        //
+        // Biased 2^63 (10 stop-bit bytes, MSB first, stop bit on the last):
+        // decodes to 2^63, debiases to i64::MAX. This is the accepted boundary.
+        let biased_two_pow_63 = [0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80];
+        let mut offset = 0;
         assert_eq!(
-            encoder.encode_nullable_int(Some(i64::MAX)),
+            FastDecoder::decode_nullable_int(&biased_two_pow_63, &mut offset),
+            Ok(Some(i64::MAX))
+        );
+        assert_eq!(offset, biased_two_pow_63.len());
+
+        // Biased 2^63 + 1: a valid, fully-stopped ten-byte encoding whose
+        // debiased value is 2^63, one past i64::MAX. This exercises the
+        // `i64::try_from` narrowing failure, not the byte-count ceiling.
+        let biased_two_pow_63_plus_one =
+            [0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x81];
+        let mut offset = 0;
+        assert_eq!(
+            FastDecoder::decode_nullable_int(&biased_two_pow_63_plus_one, &mut offset),
             Err(FastError::IntegerOverflow)
         );
-        assert!(
-            encoder.is_empty(),
-            "an overflowing value must not be biased into the NULL representation"
+    }
+
+    #[test]
+    fn test_decode_nullable_int_over_long_encoding_is_bounded_overflow() {
+        // A ten-byte run with no stop bit exhausts the ceiling on the next read:
+        // a bounded IntegerOverflow, never an unbounded loop or a panic.
+        let hostile = [0x00u8; MAX_INT_ENCODED_LEN];
+        let mut offset = 0;
+        assert_eq!(
+            FastDecoder::decode_nullable_int(&hostile, &mut offset),
+            Err(FastError::IntegerOverflow)
         );
     }
 

--- a/ironfix-fast/src/decoder.rs
+++ b/ironfix-fast/src/decoder.rs
@@ -321,7 +321,9 @@ impl FastDecoder {
                 return Err(FastError::IntegerOverflow);
             }
             let byte = read_byte(data, offset)?;
-            consumed += 1;
+            // Checked even though the ceiling above already bounds it, per the
+            // decoder checked-arithmetic rule.
+            consumed = consumed.checked_add(1).ok_or(FastError::IntegerOverflow)?;
 
             // `checked_mul` rejects any value that would lose significant bits.
             // The product is a multiple of `RADIX`, so its low seven bits are
@@ -1282,6 +1284,34 @@ mod tests {
         assert_eq!(
             FastDecoder::decode_nullable_int(&hostile, &mut offset),
             Err(FastError::IntegerOverflow)
+        );
+    }
+
+    #[test]
+    fn test_decode_nullable_int_negative_below_i64_min_is_overflow() {
+        // The negative narrowing branch (raw < 0) has its own exit: a fully
+        // stopped ten-byte negative value whose magnitude is far below i64::MIN.
+        // The first byte's sign bit is set, so decode seeds -1 and accumulates a
+        // ~70-bit negative that i64::try_from rejects — distinct from the
+        // positive-overflow fixture and the byte-count ceiling.
+        let below_min = [0x7e, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0xff];
+        let mut offset = 0;
+        assert_eq!(
+            FastDecoder::decode_nullable_int(&below_min, &mut offset),
+            Err(FastError::IntegerOverflow)
+        );
+    }
+
+    #[test]
+    fn test_decode_nullable_int_truncated_input_is_unexpected_eof() {
+        // Truncated input through the new i128 path: a first byte with no stop
+        // bit and nothing after it ends mid-value. This exercises
+        // decode_nullable_int itself, not the old decode_int helper.
+        let truncated = [0x01u8];
+        let mut offset = 0;
+        assert_eq!(
+            FastDecoder::decode_nullable_int(&truncated, &mut offset),
+            Err(FastError::UnexpectedEof)
         );
     }
 

--- a/ironfix-fast/src/encoder.rs
+++ b/ironfix-fast/src/encoder.rs
@@ -274,14 +274,20 @@ impl FastEncoder {
     /// * `value` - The optional value to encode
     ///
     /// # Errors
-    /// Never returns an error; the `Result` is kept for API stability and to
-    /// match the fallible ASCII and byte-vector encoders.
+    /// [`FastError::IntegerOverflow`] if the internal bias overflowed `i128`,
+    /// which cannot happen for an `i64` input; the arithmetic is checked per the
+    /// checked-arithmetic rule rather than assumed. The `Result` also matches
+    /// the fallible ASCII and byte-vector encoders.
     pub fn encode_nullable_int(&mut self, value: Option<i64>) -> Result<(), FastError> {
         match value {
             Some(v) if v < 0 => self.encode_int(v),
             Some(v) => {
-                // The biased value is at most `2^63`, which fits `i128`, not `i64`.
-                let biased = i128::from(v) + 1;
+                // The biased value is at most `2^63`, which fits `i128`, not
+                // `i64`; checked even though an `i64` input can never overflow
+                // `i128`, per the checked-arithmetic rule.
+                let biased = i128::from(v)
+                    .checked_add(1)
+                    .ok_or(FastError::IntegerOverflow)?;
                 self.encode_int_i128(biased);
             }
             None => self.buffer.push(STOP_BIT),

--- a/ironfix-fast/src/encoder.rs
+++ b/ironfix-fast/src/encoder.rs
@@ -226,26 +226,63 @@ impl FastEncoder {
         Ok(())
     }
 
+    /// Encodes a signed integer using stop-bit encoding, in `i128`.
+    ///
+    /// Identical to [`FastEncoder::encode_int`] but takes an `i128`, so it can
+    /// emit the biased `2^63` a nullable signed uses to denote `i64::MAX`.
+    /// `2^63` occupies ten payload bytes, within [`MAX_INT_ENCODED_LEN`].
+    fn encode_int_i128(&mut self, value: i128) {
+        let negative = value < 0;
+        let mut bytes = IntScratch::new();
+        let mut remaining = value;
+
+        loop {
+            bytes.push((remaining & i128::from(PAYLOAD_MASK)) as u8);
+            // Arithmetic shift: converges to 0 for a positive value and to -1
+            // for a negative one.
+            remaining >>= PAYLOAD_BITS;
+
+            if (negative && remaining == -1) || (!negative && remaining == 0) {
+                break;
+            }
+        }
+
+        // The loop always pushes at least one byte, so `last` is always `Some`.
+        let sign_conflicts = bytes
+            .last()
+            .is_some_and(|most_significant| (most_significant & SIGN_BIT != 0) != negative);
+
+        if sign_conflicts {
+            bytes.push(if negative { PAYLOAD_MASK } else { 0x00 });
+        }
+
+        Self::flush_stop_bit_encoded(&mut self.buffer, &mut bytes);
+    }
+
     /// Encodes a nullable signed integer.
     ///
     /// FAST biases only the non-negative half of the range: `None` is the
     /// single stop byte `0x80`, a non-negative value is encoded one higher than
-    /// it is, and a negative value is encoded as itself. The representable
-    /// domain is therefore `i64::MIN..=i64::MAX - 1`: `Some(i64::MAX)` has no
-    /// encoding and is rejected rather than silently biased into the `None`
-    /// representation.
+    /// it is, and a negative value is encoded as itself. The full
+    /// `i64::MIN..=i64::MAX` domain is representable: `Some(i64::MAX)` biases to
+    /// `2^63`, which does not fit `i64`, so the biased value is widened to
+    /// `i128` and emitted in ten stop-bit bytes — the same frame
+    /// [`FastDecoder::decode_nullable_int`](crate::FastDecoder::decode_nullable_int)
+    /// reads back.
     ///
     /// # Arguments
     /// * `value` - The optional value to encode
     ///
     /// # Errors
-    /// Returns [`FastError::IntegerOverflow`] for `Some(i64::MAX)`.
+    /// Never returns an error; the `Result` is kept for API stability and to
+    /// match the fallible ASCII and byte-vector encoders.
     pub fn encode_nullable_int(&mut self, value: Option<i64>) -> Result<(), FastError> {
         match value {
             Some(v) if v < 0 => self.encode_int(v),
             Some(v) => {
-                let biased = v.checked_add(1).ok_or(FastError::IntegerOverflow)?;
-                self.encode_int(biased);
+                // The biased value is at most `2^63`, which fits `i128`, not `i64`.
+                let biased = i128::from(v) + 1;
+                self.encode_int_i128(biased);
             }
             None => self.buffer.push(STOP_BIT),
         }


### PR DESCRIPTION
## Summary

Two small follow-ups from the #48/#49/#50 review round, each the same class as a
fix already shipped. They touch disjoint crates (`ironfix-fast`, `ironfix-engine`)
and share no interface, but land together in one PR as requested.

Closes #51
Closes #52

No breaking API change: no `pub` item added, renamed, or reshaped. The workspace
stays at unreleased `0.4.0`.

## #51 — `ironfix-fast`: nullable **signed** codec now represents `i64::MAX`

The exact signed counterpart of the unsigned fix from #48. The nullable signed
codec biases the non-negative half by one, so `Some(i64::MAX)` biased to `2^63`,
which the `i64` encoder rejected as `IntegerOverflow` and the `i64` decoder could
not represent — the domain was `i64::MIN..=i64::MAX-1`. The biased value now
travels through `i128` on both sides (private `encode_int_i128` /
`decode_int_i128`), so `Some(i64::MAX)` round-trips while the plain `i64`
`encode_int`/`decode_int` API and the negative (unbiased) path are unchanged.
The `MAX_INT_ENCODED_LEN` ceiling still bounds the decode, so a hostile over-long
encoding is a typed `IntegerOverflow`, never a panic or an unbounded read.

New coverage: `Some(i64::MAX)` round-trip; a bounded over-long-encoding
`IntegerOverflow`; and hand-built external stop-bit fixtures pinning the `i128`
narrowing branch directly (biased `2^63` → `Some(i64::MAX)`, biased `2^63+1` →
`IntegerOverflow`).

## #52 — `ironfix-engine`: read the Logon-ack MsgSeqNum(34) positionally

The initiator read the Logon-ack sequence number with a whole-message
`get_field_as(34)`, so an ack carrying `34` only after the body was accepted —
the last non-positional tag-34 read in the engine (the Acceptor handshake and the
shared reactor already read it positionally). It now uses `wire::header_seq_num`,
and fails the handshake with `EngineError::Sequence` when `34` is absent from the
standard header, calling `on_logon_reject` first — mirroring the Acceptor's
`test_acceptor_rejects_body_only_seq_num`.

New coverage: `test_logon_ack_body_only_msg_seq_num_fails_handshake` drives a
body-only-`34` ack and asserts the handshake fails; the well-formed header-`34`
path is unchanged (the existing 80+ initiator tests cover it).

## Public API changes (semver)

None. The two `ironfix-fast` helpers are private; `initiator.rs` is
engine-internal and `EngineError::Sequence` already exists. Behaviour changes
only (nullable signed accepts `i64::MAX`; the initiator ack fails on a body-only
`34`), which are not semver-breaking API changes.

## Verification

```
cargo test --workspace                                    # all pass
cargo clippy --all-targets --all-features -- -D warnings  # clean
cargo fmt --all --check                                   # clean
cargo build --release --workspace                         # clean
cargo doc --no-deps --workspace --all-features            # clean (-D warnings)
```

No performance claim is made — the repo has no criterion baseline.
